### PR TITLE
chore: lower RAM size from 1GB in places where 4GB was used

### DIFF
--- a/circuit_defs/opcode_tests/src/lib.rs
+++ b/circuit_defs/opcode_tests/src/lib.rs
@@ -264,7 +264,7 @@ pub fn test_single_opcode(
         let delegation_factories =
             setups::delegation_factories_for_machine::<IMStandardIsaConfig, Global>();
 
-        let ram_tracer = RamTracingData::new_for_ram_size_and_rom_bound(1 << 32, MAX_ROM);
+        let ram_tracer = RamTracingData::new_for_ram_size_and_rom_bound(1 << 30, MAX_ROM); // use 1 GB RAM
         let delegation_tracer = DelegationTracingData {
             all_per_type_logs: HashMap::new(),
             delegation_witness_factories: delegation_factories,

--- a/circuit_defs/trace_and_split/src/lib.rs
+++ b/circuit_defs/trace_and_split/src/lib.rs
@@ -60,7 +60,7 @@ pub fn run_till_end_for_gpu_for_machine_config<
     assert!(trace_size.is_power_of_two());
     let rom_address_space_bound = 1usize << (16 + ROM_ADDRESS_SPACE_SECOND_WORD_BITS);
 
-    let mut memory = VectorMemoryImplWithRom::new_for_byte_size(1 << 32, rom_address_space_bound); // use full RAM
+    let mut memory = VectorMemoryImplWithRom::new_for_byte_size(1 << 30, rom_address_space_bound); // use 1 GB RAM
     for (idx, insn) in binary.iter().enumerate() {
         memory.populate(ENTRY_POINT + idx as u32 * 4, *insn);
     }
@@ -72,7 +72,7 @@ pub fn run_till_end_for_gpu_for_machine_config<
     let mut state = RiscV32StateForUnrolledProver::<C>::initial(ENTRY_POINT);
 
     let bookkeeping_aux_data =
-        RamTracingData::<true>::new_for_ram_size_and_rom_bound(1 << 32, rom_address_space_bound);
+        RamTracingData::<true>::new_for_ram_size_and_rom_bound(1 << 30, rom_address_space_bound); // use 1 GB RAM
     let delegation_tracer = DelegationTracingData {
         all_per_type_logs: HashMap::new(),
         delegation_witness_factories: delegation_factories,
@@ -254,7 +254,7 @@ pub fn run_till_end_for_machine_config_without_tracing<
     assert!(trace_size.is_power_of_two());
     let rom_address_space_bound = 1usize << (16 + ROM_ADDRESS_SPACE_SECOND_WORD_BITS);
 
-    let mut memory = VectorMemoryImplWithRom::new_for_byte_size(1 << 32, rom_address_space_bound); // use full RAM
+    let mut memory = VectorMemoryImplWithRom::new_for_byte_size(1 << 30, rom_address_space_bound); // use 1 GB RAM
     for (idx, insn) in binary.iter().enumerate() {
         memory.populate(ENTRY_POINT + idx as u32 * 4, *insn);
     }

--- a/prover/src/witness_evaluator/ext_calls_with_gpu_tracers.rs
+++ b/prover/src/witness_evaluator/ext_calls_with_gpu_tracers.rs
@@ -76,9 +76,9 @@ where
     assert!(compiled_machine.witness_layout.width_3_lookups.len() * trace_len <= capacity);
 
     let mut memory = VectorMemoryImplWithRom::new_for_byte_size(
-        1 << 32,
+        1 << 30,
         1 << (16 + ROM_ADDRESS_SPACE_SECOND_WORD_BITS),
-    ); // use full RAM
+    ); // use 1 GB RAM
     for (idx, insn) in binary.iter().enumerate() {
         memory.populate(ENTRY_POINT + idx as u32 * 4, *insn);
     }
@@ -376,7 +376,7 @@ pub fn dev_run_for_num_cycles_under_convention_ext_with_gpu_tracers<
     let mut state = RiscV32StateForUnrolledProver::<C>::initial(initial_pc);
 
     let bookkeeping_aux_data =
-        RamTracingData::<true>::new_for_ram_size_and_rom_bound(1 << 32, rom_address_space_bound);
+        RamTracingData::<true>::new_for_ram_size_and_rom_bound(1 << 30, rom_address_space_bound); // use 1 GB RAM
     let delegation_tracer = DelegationTracingData {
         all_per_type_logs: HashMap::new(),
         delegation_witness_factories: delegation_factories,

--- a/risc_v_simulator/src/runner/mod.rs
+++ b/risc_v_simulator/src/runner/mod.rs
@@ -56,7 +56,7 @@ pub fn run_simple_with_entry_point_and_non_determimism_source_for_config<
     let memory_tracer = ();
     let mmu = NoMMU { sapt: 0 };
 
-    let mut memory = VectorMemoryImpl::new_for_byte_size(1 << 32); // use full RAM
+    let mut memory = VectorMemoryImpl::new_for_byte_size(1 << 30); // use 1 GB RAM
     memory.load_image(config.entry_point, read_bin(&config.bin_path).into_iter());
 
     let mut sim = Simulator::new(
@@ -83,7 +83,7 @@ pub fn run_simple_for_num_cycles<S: NonDeterminismCSRSource<VectorMemoryImpl>, C
     let mut memory_tracer = ();
     let mut mmu = NoMMU { sapt: 0 };
 
-    let mut memory = VectorMemoryImpl::new_for_byte_size(1 << 32); // use full RAM
+    let mut memory = VectorMemoryImpl::new_for_byte_size(1 << 30); // use 1 GB RAM
     memory.load_image(entry_point, binary.iter().copied());
 
     let mut previous_pc = entry_point;
@@ -119,7 +119,7 @@ pub fn run_simple_for_num_cycles<S: NonDeterminismCSRSource<VectorMemoryImpl>, C
 //     let memory_tracer = ();
 //     let mmu = NoMMU { sapt: 0 };
 
-//     let mut memory = VectorMemoryImpl::new_for_byte_size(1 << 32); // use full RAM
+//     let mut memory = VectorMemoryImpl::new_for_byte_size(1 << 30); // use 1 GB RAM
 //     memory.load_image(config.entry_point, read_bin(&config.bin_path).into_iter());
 
 //     let mut sim = Simulator::new(
@@ -148,7 +148,7 @@ pub fn run_simulator_with_traces_for_config<C: MachineConfig>(
     let mmu = NoMMU { sapt: state.sapt };
     let non_determinism_source = QuasiUARTSource::default();
 
-    let mut memory = VectorMemoryImpl::new_for_byte_size(1 << 32); // use full RAM
+    let mut memory = VectorMemoryImpl::new_for_byte_size(1 << 30); // use 1 GB RAM
     memory.load_image(config.entry_point, read_bin(&config.bin_path).into_iter());
 
     let cycles = config.cycles;


### PR DESCRIPTION
## What ❔

This PR lowers the RAM size for the simulation to 1GB where 4GB was used before.

## Why ❔

#23 changed the memory layout and heap size making it possible to run the simulation with 1GB of RAM instead of 4GB.
Tracing a simulation with 4GB of RAM required 12GB of CPU RAM just for tracking the memory state, this change lowers this to 3GB, making running multiple simulation in parallel more feasible.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.