### PR TITLE
feat: Adding reproducible builds for verifiers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,7 +18,7 @@ tools/verifier/target
 !poseidon2
 !prover
 !risc_v_simulator
-!risc_v_common
+!riscv_common
 !trace_holder
 !transcript
 !verifier

--- a/.github/workflows/check-verifiers.yml
+++ b/.github/workflows/check-verifiers.yml
@@ -1,0 +1,32 @@
+name: Check verifiers
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  packages: read
+  actions: read
+
+jobs:
+  check_verifiers:
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3
+
+      - name: Build fresh verifiers
+        run: |
+          tools/reproduce/reproduce.sh
+
+      - name: Fail if any files were modified
+        run: |
+          git status --porcelain
+          git diff --name-only
+          if [ -n "$(git diff --name-only)" ]; then
+            echo "❌ The following files were modified. Did you run tools/reproduce/reproduce.sh ?:"
+            git diff --name-only
+            exit 1
+          fi

--- a/tools/reproduce/Dockerfile
+++ b/tools/reproduce/Dockerfile
@@ -4,7 +4,9 @@ FROM debian:bullseye-slim as builder
 RUN apt-get update && apt-get install -y \
     curl \
     build-essential \
-    git
+    git \
+    libssl-dev \
+    pkg-config
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2025-05-24
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/tools/reproduce/Dockerfile
+++ b/tools/reproduce/Dockerfile
@@ -1,0 +1,23 @@
+# Use a specific version of Rust for reproducibility
+FROM debian:bullseye-slim as builder
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    build-essential \
+    git
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2025-05-24
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN rustup target add riscv32i-unknown-none-elf
+RUN cargo install cargo-binutils
+RUN rustup component add llvm-tools-preview
+
+
+
+# RUN git clone  --depth 1 -b mmzk_0608_reproduce  https://github.com/matter-labs/zksync-airbender.git
+COPY . zksync-airbender
+
+WORKDIR zksync-airbender/tools/verifier
+
+RUN ./build.sh

--- a/tools/reproduce/README.md
+++ b/tools/reproduce/README.md
@@ -1,0 +1,12 @@
+# Building reproducible verifiers
+
+This docker script allows building reproducible verifiers.
+
+Simply run:
+
+```shell
+./tools/reproduce/reproduce.sh
+```
+
+
+from the main directory.

--- a/tools/reproduce/reproduce.sh
+++ b/tools/reproduce/reproduce.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Make sure to run from the main zksync-airbender directory.
+
+# create a fresh docker
+docker build -t airbender-verifiers  -f tools/reproduce/Dockerfile .
+
+docker create --name verifiers airbender-verifiers
+
+FILES=(
+    base_layer.bin
+    recursion_layer.bin
+    final_recursion_layer.bin
+    base_layer_with_output.bin
+    recursion_layer_with_output.bin
+    final_recursion_layer_with_output.bin
+    universal.bin
+    universal_no_delegation.bin
+    verifier_test.bin
+    universal.reduced.vk.json
+    universal_no_delegation.final.vk.json
+    recursion_layer.reduced.vk.json
+    recursion_layer_no_delegation.final.vk.json
+    final_recursion_layer.final.vk.json
+)
+
+for FILE in "${FILES[@]}"; do
+    docker cp verifiers:/zksync-airbender/tools/verifier/$FILE tools/verifier/
+done
+
+
+docker rm verifiers

--- a/tools/verifier/rust-toolchain.toml
+++ b/tools/verifier/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2025-05-24"


### PR DESCRIPTION
## What ❔

* shell script + Docker + CI - to create reproducible verifier binaries.

## Why ❔

* to make sure that we have the same hashes for verification keys.
