### PR TITLE
chore: Set required cmake to 3.28

### DIFF
--- a/gpu_prover/native/CMakeLists.txt
+++ b/gpu_prover/native/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.30)
-# Cmake must be at least 3.30 - the earlier one didn't pass cuda_standard properly.
+cmake_minimum_required(VERSION 3.28)
+# Cmake must be at least 3.28 - the earlier one didn't pass cuda_standard properly.
 project(gpu_prover_native)
 enable_language(CUDA)
 if ((NOT DEFINED CMAKE_CUDA_ARCHITECTURES) OR (CMAKE_CUDA_ARCHITECTURES STREQUAL ""))


### PR DESCRIPTION

## What ❔

* Seems that cmake 3.28 is enough - and it is used by 12.6.0-devel-ubuntu24.04.

## Why ❔

* originally we had cmake 3.24 (but it didn't pass c++20 flags correctly)
* I've manually updated our ubuntu 22 - to install cmake 3.30 - and everything worked
* but it seems that it is working fine on ubuntu 24 - with cmake 3.28 - so let's set this as minimum version.
