### PR TITLE
fix(gpu_prover): Ensure deterministic ordering of delegation data

### DIFF
--- a/gpu_prover/src/execution/prover.rs
+++ b/gpu_prover/src/execution/prover.rs
@@ -659,14 +659,29 @@ impl<K: Clone + Debug + Eq + Hash> ExecutionProver<'_, K> {
             .sorted_by_key(|(index, _)| *index)
             .map(|(_, caps)| caps)
             .collect_vec();
-        let delegation_memory_commitments = delegation_memory_commitments
-            .into_iter()
-            .map(|(id, caps)| (id as u32, caps))
+        let mut delegation_memory_commitment_keys =
+            delegation_memory_commitments.keys().copied().collect_vec();
+        delegation_memory_commitment_keys.sort_unstable();
+        let delegation_memory_commitments = delegation_memory_commitment_keys
+            .iter()
+            .map(|id| {
+                let proofs = delegation_memory_commitments.remove(id).unwrap();
+                (*id as u32, proofs)
+            })
             .collect_vec();
         let main_proofs = main_proofs
             .into_iter()
             .sorted_by_key(|(index, _)| *index)
             .map(|(_, proof)| proof)
+            .collect_vec();
+        let mut delegation_proof_keys = delegation_proofs.keys().copied().collect_vec();
+        delegation_proof_keys.sort_unstable();
+        let delegation_proofs = delegation_proof_keys
+            .iter()
+            .map(|id| {
+                let proofs = delegation_proofs.remove(id).unwrap();
+                (*id as u32, proofs)
+            })
             .collect_vec();
         let delegation_proofs = delegation_proofs
             .into_iter()


### PR DESCRIPTION
## What ❔

Ensures deterministic ordering of delegation data when unpacking it from HashMaps.

## Why ❔

In current code, some delegation data is unpacked directly from HashMaps, so the order is nondeterministic. However, other parts of the code expect it to be ordered by delegation type (id). For big proofs (e.g. Ethereum-block-equivalent) that use multiple delegation types, I sometimes saw [this assert](https://github.com/matter-labs/zksync-airbender/blob/main/circuit_defs/trace_and_split/src/lib.rs#L542) fire, indicating the wrong order. With these diffs, I no longer see the assert fire.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.