### PR TITLE
fix(gpu_prover): Avoid race condition in memory commitments

### DIFF
--- a/gpu_prover/src/execution/gpu_worker.rs
+++ b/gpu_prover/src/execution/gpu_worker.rs
@@ -10,7 +10,7 @@ use crate::prover::setup::SetupPrecomputations;
 use crate::prover::tracing_data::{TracingDataHost, TracingDataTransfer};
 use crate::witness::trace_main::get_aux_arguments_boundary_values;
 use crossbeam_channel::{Receiver, Sender};
-use era_cudart::device::{device_synchronize, get_device_properties};
+use era_cudart::device::get_device_properties;
 use fft::GoodAllocator;
 use field::Mersenne31Field;
 use log::{debug, error, info, trace};

--- a/gpu_prover/src/execution/gpu_worker.rs
+++ b/gpu_prover/src/execution/gpu_worker.rs
@@ -27,6 +27,8 @@ use std::process::exit;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use era_cudart::device::device_synchronize;
+
 type BF = Mersenne31Field;
 
 const NUM_QUERIES: usize = 53;
@@ -247,6 +249,7 @@ fn gpu_worker<C: ProverContext>(
                         log_tree_cap_size,
                         &context,
                     )?;
+                    context.get_exec_stream().synchronize()?;
                     JobType::MemoryCommitment(job)
                 }
                 GpuWorkRequest::Proof(request) => {

--- a/gpu_prover/src/execution/gpu_worker.rs
+++ b/gpu_prover/src/execution/gpu_worker.rs
@@ -10,7 +10,7 @@ use crate::prover::setup::SetupPrecomputations;
 use crate::prover::tracing_data::{TracingDataHost, TracingDataTransfer};
 use crate::witness::trace_main::get_aux_arguments_boundary_values;
 use crossbeam_channel::{Receiver, Sender};
-use era_cudart::device::get_device_properties;
+use era_cudart::device::{device_synchronize, get_device_properties};
 use fft::GoodAllocator;
 use field::Mersenne31Field;
 use log::{debug, error, info, trace};
@@ -26,8 +26,6 @@ use std::mem;
 use std::process::exit;
 use std::rc::Rc;
 use std::sync::Arc;
-
-use era_cudart::device::device_synchronize;
 
 type BF = Mersenne31Field;
 


### PR DESCRIPTION
## What ❔

I encountered a race condition in the first pass memory commitments. It manifested more often for faster GPUs and larger proofs. @robik75 had a hunch, and after some sync-bisecting the present diff appears to be enough to avoid the problem, even on H100 for full blocks of ethereum transactions simulated in the ZKsync OS memory model (~hundreds of millions of riscv cycles).

## Why ❔

Avoid the race condition. (Ideally we should be able to fix it without syncing, but this can be a followup.)

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.