### PR TITLE
feat(cli): add env_logger to CLI

### DIFF
--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -44,6 +44,8 @@ sha3 = { package = "sha3_ce", version = "=0.10.6" }
 
 gpu_prover = { workspace = true, optional = true }
 
+env_logger = "0.11"
+
 [features]
 
 # If include verifiers is disabled, the compilation is a lot faster, but some commands (verify, verify-all) are not available.

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -245,6 +245,11 @@ fn fetch_final_input_json(input: &InputConfig) -> Result<Option<String>, reqwest
 }
 
 fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format_timestamp_millis()
+        .format_module_path(false)
+        .format_target(false)
+        .init();
     let cli = Cli::parse();
     match &cli.command {
         Commands::Prove {


### PR DESCRIPTION
## What ❔

This PR enables logging using `env_logger` in CLI.
Among other things, log level can be changed using the `RUST_LOG` environment variable. See `env_logger` documentation for more configuration options.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted.