### PR TITLE
fix(gpu_prover): add disable delegation caching option and enable it

### DIFF
--- a/gpu_prover/src/execution/gpu_worker.rs
+++ b/gpu_prover/src/execution/gpu_worker.rs
@@ -159,10 +159,10 @@ fn gpu_worker<C: ProverContext>(
                     let setup = if let Some(holder) = &current_setup
                         && Arc::ptr_eq(&holder.trace, &precomputations.setup)
                     {
-                        trace!(
-                            "BATCH[{batch_id}] GPU_WORKER[{device_id}] proof request reusing setup for circuit {:?}",
-                            request.circuit_type,
-                        );
+                        match request.circuit_type {
+                            CircuitType::Main(main) => trace!("BATCH[{batch_id}] GPU_WORKER[{device_id}] reusing setup for main circuit {main:?}"),
+                            CircuitType::Delegation(delegation) => trace!("BATCH[{batch_id}] GPU_WORKER[{device_id}] reusing setup for delegation circuit {delegation:?}"),
+                        }
                         holder.setup.clone()
                     } else {
                         let lde_factor = precomputations.lde_precomputations.lde_factor;
@@ -178,10 +178,10 @@ fn gpu_worker<C: ProverContext>(
                             log_tree_cap_size,
                             &context,
                         )?;
-                        trace!(
-                            "BATCH[{batch_id}] GPU_WORKER[{device_id}] transferring setup for circuit {:?}",
-                            request.circuit_type,
-                        );
+                        match request.circuit_type {
+                            CircuitType::Main(main) => trace!("BATCH[{batch_id}] GPU_WORKER[{device_id}] transferring setup for main circuit {main:?}"),
+                            CircuitType::Delegation(delegation) => trace!("BATCH[{batch_id}] GPU_WORKER[{device_id}] transferring setup for delegation circuit {delegation:?}"),
+                        }
                         setup.schedule_transfer(precomputations.setup.clone(), &context)?;
                         let setup = Rc::new(RefCell::new(setup));
                         current_setup = Some(SetupHolder {
@@ -313,8 +313,8 @@ fn gpu_worker<C: ProverContext>(
         let result = if let Some((request, job)) = job {
             match request {
                 GpuWorkRequest::MemoryCommitment(request) => {
-                    let batch_id = request.batch_id;
                     let MemoryCommitmentRequest {
+                        batch_id,
                         circuit_type,
                         circuit_sequence,
                         tracing_data,
@@ -324,17 +324,17 @@ fn gpu_worker<C: ProverContext>(
                         JobType::MemoryCommitment(job) => job.finish()?,
                         JobType::Proof(_) => unreachable!(),
                     };
-                    match request.circuit_type {
+                    match circuit_type {
                         CircuitType::Main(main) => debug!(
                             "BATCH[{batch_id}] GPU_WORKER[{device_id}] produced memory commitment for main circuit {:?} chunk {} in {:.3} ms",
                             main,
-                            request.circuit_sequence,
+                            circuit_sequence,
                             commitment_time_ms
                         ),
                         CircuitType::Delegation(delegation) => debug!(
                             "BATCH[{batch_id}] GPU_WORKER[{device_id}] produced memory commitment for delegation circuit {:?} chunk {} in {:.3} ms",
                             delegation,
-                            request.circuit_sequence,
+                            circuit_sequence,
                             commitment_time_ms
                         ),
                     }
@@ -348,8 +348,8 @@ fn gpu_worker<C: ProverContext>(
                     Some(WorkerResult::MemoryCommitment(result))
                 }
                 GpuWorkRequest::Proof(request) => {
-                    let batch_id = request.batch_id;
                     let ProofRequest {
+                        batch_id,
                         circuit_type,
                         circuit_sequence,
                         tracing_data,
@@ -359,17 +359,17 @@ fn gpu_worker<C: ProverContext>(
                         JobType::MemoryCommitment(_) => unreachable!(),
                         JobType::Proof(job) => job.finish()?,
                     };
-                    match request.circuit_type {
+                    match circuit_type {
                         CircuitType::Main(main) => debug!(
                             "BATCH[{batch_id}] GPU_WORKER[{device_id}] produced proof for main circuit {:?} chunk {} in {:.3} ms",
                             main,
-                            request.circuit_sequence,
+                            circuit_sequence,
                             proof_time_ms,
                         ),
                         CircuitType::Delegation(delegation) => debug!(
                             "BATCH[{batch_id}] GPU_WORKER[{device_id}] produced proof for delegation circuit {:?} chunk {} in {:.3} ms",
                             delegation,
-                            request.circuit_sequence,
+                            circuit_sequence,
                             proof_time_ms,
                         ),
                     }

--- a/gpu_prover/src/execution/tracer.rs
+++ b/gpu_prover/src/execution/tracer.rs
@@ -197,7 +197,7 @@ impl<A: GoodAllocator> CycleTracingData<A> {
 
 pub struct DelegationCounter {
     pub num_requests: usize,
-    pub counter: usize,
+    pub count: usize,
 }
 
 pub enum DelegationTracingType<A: GoodAllocator> {
@@ -581,8 +581,8 @@ impl<
 
             let should_replace = match current_tracer {
                 DelegationTracingType::Counter(counter) => {
-                    counter.counter += 1;
-                    counter.counter == counter.num_requests
+                    counter.count += 1;
+                    counter.count == counter.num_requests
                 }
                 DelegationTracingType::Witness(witness) => {
                     debug_assert_eq!(witness.base_register_index, base_register);

--- a/gpu_prover/src/witness/trace_delegation.rs
+++ b/gpu_prover/src/witness/trace_delegation.rs
@@ -94,11 +94,29 @@ impl<A: GoodAllocator> From<DelegationWitness<A>> for DelegationTraceHost<A> {
             num_indirect_writes_per_delegation: value.num_indirect_writes_per_delegation,
             base_register_index: value.base_register_index,
             delegation_type: value.delegation_type,
-            indirect_accesses_properties: value.indirect_accesses_properties.clone(),
+            indirect_accesses_properties: value.indirect_accesses_properties,
             write_timestamp: Arc::new(value.write_timestamp),
             register_accesses: Arc::new(value.register_accesses),
             indirect_reads: Arc::new(value.indirect_reads),
             indirect_writes: Arc::new(value.indirect_writes),
+        }
+    }
+}
+
+impl<A: GoodAllocator> Into<DelegationWitness<A>> for DelegationTraceHost<A> {
+    fn into(self) -> DelegationWitness<A> {
+        DelegationWitness {
+            num_requests: self.num_requests,
+            num_register_accesses_per_delegation: self.num_register_accesses_per_delegation,
+            num_indirect_reads_per_delegation: self.num_indirect_reads_per_delegation,
+            num_indirect_writes_per_delegation: self.num_indirect_writes_per_delegation,
+            base_register_index: self.base_register_index,
+            delegation_type: self.delegation_type,
+            indirect_accesses_properties: self.indirect_accesses_properties,
+            write_timestamp: Arc::into_inner(self.write_timestamp).unwrap(),
+            register_accesses: Arc::into_inner(self.register_accesses).unwrap(),
+            indirect_reads: Arc::into_inner(self.indirect_reads).unwrap(),
+            indirect_writes: Arc::into_inner(self.indirect_writes).unwrap(),
         }
     }
 }


### PR DESCRIPTION
## What ❔

This PR adds a disable delegation caching option and enables it.

## Why ❔

There is an underlying race condition causing trace corruption when delegation caching is enabled and multiple GPUs are used but so far the cause us unclear. For now disabling delegation trace caching seems to suppress it.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.