### PR TITLE
feat(zksmith): add env_logger to zksmith

### DIFF
--- a/tools/zksmith/Cargo.toml
+++ b/tools/zksmith/Cargo.toml
@@ -20,6 +20,7 @@ cli = { path = "../cli" }
 warp = "0.3"
 tokio = { version = "1", features = ["full"] }
 futures = "0.3.31"
+env_logger = "0.11"
 
 [features]
 # if enabled - allow GPU for proving.

--- a/tools/zksmith/src/main.rs
+++ b/tools/zksmith/src/main.rs
@@ -295,6 +295,7 @@ struct RpcResponse {
 #[tokio::main(flavor = "multi_thread", worker_threads = 10)]
 async fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .target(env_logger::Target::Stdout)
         .format_timestamp_millis()
         .format_module_path(false)
         .format_target(false)

--- a/tools/zksmith/src/main.rs
+++ b/tools/zksmith/src/main.rs
@@ -294,6 +294,12 @@ struct RpcResponse {
 //#[tokio::main]
 #[tokio::main(flavor = "multi_thread", worker_threads = 10)]
 async fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format_timestamp_millis()
+        .format_module_path(false)
+        .format_target(false)
+        .init();
+
     let index_html = include_str!("index.html");
 
     let cli = Cli::parse();


### PR DESCRIPTION
## What ❔

Adds `env_logger` to `zksmith` with default logging level set to Info.

## Why ❔

We want to see the log output from gpu_prover.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.