### PR TITLE
feat(gpu_prover): custom GPU allocator

### DIFF
--- a/circuit_defs/prover_examples/src/gpu.rs
+++ b/circuit_defs/prover_examples/src/gpu.rs
@@ -4,11 +4,12 @@ use cs::utils::split_timestamp;
 pub use gpu_prover::allocator::host::ConcurrentStaticHostAllocator;
 use gpu_prover::circuit_type::{CircuitType, DelegationCircuitType, MainCircuitType};
 use gpu_prover::cudart::result::CudaResult;
+use gpu_prover::prover::context::HostAllocator;
 use gpu_prover::witness::trace_delegation::DelegationTraceHost;
 use gpu_prover::witness::trace_main::{MainTraceHost, ShuffleRamSetupAndTeardownHost};
 use gpu_prover::{
     prover::{
-        context::{MemPoolProverContext, ProverContext, ProverContextConfig},
+        context::{ProverContext, ProverContextConfig},
         memory::commit_memory,
         setup::SetupPrecomputations,
         tracing_data::{TracingDataHost, TracingDataTransfer},
@@ -46,35 +47,34 @@ use trace_and_split::{
 use crate::{NUM_QUERIES, POW_BITS};
 
 pub fn initialize_host_allocator_if_needed() {
-    if !MemPoolProverContext::is_host_allocator_initialized() {
+    if !ProverContext::is_host_allocator_initialized() {
         // allocate 8 x 1 GB ((1 << 8) << 22) of pinned host memory with 4 MB (1 << 22) chunking
-        MemPoolProverContext::initialize_host_allocator(8, 1 << 8, 22).unwrap();
+        ProverContext::initialize_host_allocator(8, 1 << 8, 22).unwrap();
     }
 }
 
-pub fn create_default_prover_context<'a>() -> MemPoolProverContext<'a> {
+pub fn create_default_prover_context<'a>() -> ProverContext {
     initialize_host_allocator_if_needed();
     let mut prover_context_config = ProverContextConfig::default();
     prover_context_config.allocation_block_log_size = 22;
 
-    let prover_context = MemPoolProverContext::new(&prover_context_config).unwrap();
+    let prover_context = ProverContext::new(&prover_context_config).unwrap();
     prover_context
 }
 
 pub fn gpu_prove_image_execution_for_machine_with_gpu_tracers<
     ND: NonDeterminismCSRSource<VectorMemoryImplWithRom>,
     C: MachineConfig,
-    P: ProverContext,
 >(
     num_instances_upper_bound: usize,
     bytecode: &[u32],
     non_determinism: ND,
-    risc_v_circuit_precomputations: &MainCircuitPrecomputations<C, Global, P::HostAllocator>,
+    risc_v_circuit_precomputations: &MainCircuitPrecomputations<C, Global, HostAllocator>,
     delegation_circuits_precomputations: &[(
         u32,
-        DelegationCircuitPrecomputations<Global, P::HostAllocator>,
+        DelegationCircuitPrecomputations<Global, HostAllocator>,
     )],
-    prover_context: &P,
+    prover_context: &ProverContext,
     worker: &Worker,
 ) -> CudaResult<(Vec<Proof>, Vec<(u32, Vec<Proof>)>, Vec<FinalRegisterValue>)> {
     let cycles_per_circuit = setups::num_cycles_for_machine::<C>();
@@ -100,7 +100,7 @@ pub fn gpu_prove_image_execution_for_machine_with_gpu_tracers<
         inits_and_teardowns,
         delegation_circuits_witness,
         final_register_values,
-    ) = trace_execution_for_gpu::<ND, C, P::HostAllocator>(
+    ) = trace_execution_for_gpu::<ND, C, HostAllocator>(
         max_cycles_to_run,
         bytecode,
         non_determinism,
@@ -229,10 +229,8 @@ pub fn gpu_prove_image_execution_for_machine_with_gpu_tracers<
 
     let mut gpu_setup_main = {
         let setup_row_major = &risc_v_circuit_precomputations.setup.ldes[0].trace;
-        let mut setup_evaluations = Vec::with_capacity_in(
-            setup_row_major.as_slice().len(),
-            P::HostAllocator::default(),
-        );
+        let mut setup_evaluations =
+            Vec::with_capacity_in(setup_row_major.as_slice().len(), HostAllocator::default());
         unsafe { setup_evaluations.set_len(setup_row_major.as_slice().len()) };
         transpose::transpose(
             setup_row_major.as_slice(),
@@ -349,10 +347,8 @@ pub fn gpu_prove_image_execution_for_machine_with_gpu_tracers<
             let log_tree_cap_size =
                 OPTIMAL_FOLDING_PROPERTIES[log_domain_size as usize].total_caps_size_log2 as u32;
             let setup_row_major = &prec.setup.ldes[0].trace;
-            let mut setup_evaluations = Vec::with_capacity_in(
-                setup_row_major.as_slice().len(),
-                P::HostAllocator::default(),
-            );
+            let mut setup_evaluations =
+                Vec::with_capacity_in(setup_row_major.as_slice().len(), HostAllocator::default());
             unsafe { setup_evaluations.set_len(setup_row_major.as_slice().len()) };
             transpose::transpose(
                 setup_row_major.as_slice(),

--- a/gpu_prover/src/allocator/allocation_data.rs
+++ b/gpu_prover/src/allocator/allocation_data.rs
@@ -5,18 +5,28 @@ use std::ptr::NonNull;
 pub(crate) struct StaticAllocationData<T> {
     pub ptr: NonNull<T>,
     pub len: usize,
+    pub alloc_len: usize,
     _owns_t: PhantomData<T>,
 }
 
 impl<T> StaticAllocationData<T> {
-    pub fn new(ptr: NonNull<T>, len: usize) -> Self {
+    pub fn new(ptr: NonNull<T>, len: usize, alloc_len: usize) -> Self {
         Self {
             ptr,
             len,
+            alloc_len,
             _owns_t: PhantomData,
         }
     }
 }
+
+impl<T> Clone for StaticAllocationData<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for StaticAllocationData<T> {}
 
 unsafe impl<T> Send for StaticAllocationData<T> where Vec<T>: Send {}
 

--- a/gpu_prover/src/allocator/tracker.rs
+++ b/gpu_prover/src/allocator/tracker.rs
@@ -3,14 +3,23 @@ use std::alloc::AllocError;
 use std::collections::{BTreeMap, BTreeSet, Bound};
 use std::ptr::NonNull;
 
-pub struct StaticAllocationsTracker {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AllocationPlacement {
+    BestFit,
+    Bottom,
+    Top,
+}
+
+pub struct AllocationsTracker {
     ptrs: Vec<NonNull<u8>>,
     lens: Vec<usize>,
     free_len_by_ptr: BTreeMap<NonNull<u8>, usize>,
     free_ptrs_by_len: BTreeMap<usize, BTreeSet<NonNull<u8>>>,
+    used_mem_current: usize,
+    used_mem_peak: usize,
 }
 
-impl StaticAllocationsTracker {
+impl AllocationsTracker {
     pub fn new(ptrs_and_lens: &[(NonNull<u8>, usize)]) -> Self {
         let len = ptrs_and_lens.len();
         let mut ptrs = Vec::with_capacity(len);
@@ -20,7 +29,10 @@ impl StaticAllocationsTracker {
         for &(ptr, len) in ptrs_and_lens.iter().sorted() {
             ptrs.push(ptr);
             lens.push(len);
-            free_len_by_ptr.insert(ptr, len);
+            assert!(
+                free_len_by_ptr.insert(ptr, len).is_none(),
+                "duplicate pointer"
+            );
             let ptrs = free_ptrs_by_len.entry(len).or_insert_with(BTreeSet::new);
             ptrs.insert(ptr);
         }
@@ -29,73 +41,150 @@ impl StaticAllocationsTracker {
             lens,
             free_len_by_ptr,
             free_ptrs_by_len,
+            used_mem_current: 0,
+            used_mem_peak: 0,
         }
     }
 
-    pub fn alloc(&mut self, len: usize) -> Result<NonNull<u8>, AllocError> {
+    fn insert_remainder(
+        &mut self,
+        free_ptr: NonNull<u8>,
+        free_len: usize,
+        len: usize,
+        placement: AllocationPlacement,
+    ) -> NonNull<u8> {
+        assert!(free_len > len);
+        let free_len = free_len - len;
+        let (ptr, free_ptr) = unsafe {
+            match placement {
+                AllocationPlacement::Top => (free_ptr.add(free_len), free_ptr),
+                _ => (free_ptr, free_ptr.add(len)),
+            }
+        };
+        assert!(self.free_len_by_ptr.insert(free_ptr, free_len).is_none());
+        assert!(self
+            .free_ptrs_by_len
+            .entry(free_len)
+            .or_default()
+            .insert(free_ptr));
+        ptr
+    }
+
+    fn alloc_best_fit(&mut self, len: usize) -> Result<NonNull<u8>, AllocError> {
         let mut cursor = self.free_ptrs_by_len.lower_bound_mut(Bound::Included(&len));
         if let Some((&free_len, free_ptrs)) = cursor.peek_next() {
-            let ptr = free_ptrs.pop_first().unwrap();
+            let free_ptr = free_ptrs.pop_first().unwrap();
             if free_ptrs.is_empty() {
                 cursor.remove_next();
             }
-            self.free_len_by_ptr.remove(&ptr);
+            assert_eq!(self.free_len_by_ptr.remove(&free_ptr).unwrap(), free_len);
             if free_len > len {
-                let new_free_len = free_len - len;
-                let new_free_ptr = unsafe { ptr.add(len) };
-                self.free_len_by_ptr.insert(new_free_ptr, new_free_len);
-                self.free_ptrs_by_len
-                    .entry(new_free_len)
-                    .or_default()
-                    .insert(new_free_ptr);
+                self.insert_remainder(free_ptr, free_len, len, AllocationPlacement::BestFit);
             }
-            Ok(ptr)
+            Ok(free_ptr)
         } else {
             Err(AllocError)
         }
     }
 
-    pub fn free(&mut self, mut ptr: NonNull<u8>, mut len: usize) {
-        unsafe {
-            let (self_ptr, self_len) = match self.ptrs.binary_search(&ptr) {
-                Ok(idx) => (self.ptrs[idx], self.lens[idx]),
-                Err(0) => panic!("out of bounds free"),
-                Err(idx) => {
-                    let idx = idx - 1;
-                    (self.ptrs[idx], self.lens[idx])
-                }
-            };
-            let offset = ptr.offset_from(self_ptr);
-            if offset < 0 || (offset as usize + len) > self_len {
-                panic!("out of bounds free");
+    fn find_free_ptr_by_len<'a>(
+        mut iter: impl Iterator<Item = (&'a NonNull<u8>, &'a usize)>,
+        len: usize,
+    ) -> Option<NonNull<u8>> {
+        iter.find_map(|(&ptr, &l)| if l >= len { Some(ptr) } else { None })
+    }
+
+    fn alloc_at_free_ptr(
+        &mut self,
+        free_ptr: Option<NonNull<u8>>,
+        len: usize,
+        placement: AllocationPlacement,
+    ) -> Result<NonNull<u8>, AllocError> {
+        if let Some(free_ptr) = free_ptr {
+            let free_len = self.free_len_by_ptr.remove(&free_ptr).unwrap();
+            assert!(free_len >= len);
+            let ptrs = self.free_ptrs_by_len.get_mut(&free_len).unwrap();
+            assert!(ptrs.remove(&free_ptr));
+            if ptrs.is_empty() {
+                assert!(self.free_ptrs_by_len.remove(&free_len).unwrap().is_empty());
             }
+            Ok(if free_len == len {
+                free_ptr
+            } else {
+                self.insert_remainder(free_ptr, free_len, len, placement)
+            })
+        } else {
+            Err(AllocError)
+        }
+    }
+
+    fn alloc_bottom(&mut self, len: usize) -> Result<NonNull<u8>, AllocError> {
+        let iter = self.free_len_by_ptr.iter();
+        let free_ptr = Self::find_free_ptr_by_len(iter, len);
+        self.alloc_at_free_ptr(free_ptr, len, AllocationPlacement::Bottom)
+    }
+
+    fn alloc_top(&mut self, len: usize) -> Result<NonNull<u8>, AllocError> {
+        let free_ptr = Self::find_free_ptr_by_len(self.free_len_by_ptr.iter().rev(), len);
+        self.alloc_at_free_ptr(free_ptr, len, AllocationPlacement::Top)
+    }
+
+    pub fn alloc(
+        &mut self,
+        len: usize,
+        placement: AllocationPlacement,
+    ) -> Result<NonNull<u8>, AllocError> {
+        let result = match placement {
+            AllocationPlacement::BestFit => self.alloc_best_fit(len),
+            AllocationPlacement::Bottom => self.alloc_bottom(len),
+            AllocationPlacement::Top => self.alloc_top(len),
+        };
+        if result.is_ok() {
+            self.used_mem_current += len;
+            self.used_mem_peak = self.used_mem_peak.max(self.used_mem_current);
+        };
+        result
+    }
+
+    pub fn free(&mut self, mut ptr: NonNull<u8>, mut len: usize) {
+        assert_ne!(len, 0, "attempt to free zero-length allocation");
+        self.used_mem_current -= len;
+        unsafe {
+            let idx = match self.ptrs.binary_search(&ptr) {
+                Ok(idx) => idx,
+                Err(0) => panic!("out of bounds free"),
+                Err(idx) => idx - 1,
+            };
+            let self_ptr = self.ptrs[idx];
+            let self_len = self.lens[idx];
+            let offset = ptr.offset_from(self_ptr);
+            assert!(
+                offset >= 0 && (offset as usize + len) <= self_len,
+                "out of bounds free"
+            );
             let mut cursor = self.free_len_by_ptr.lower_bound_mut(Bound::Included(&ptr));
             if let Some((&next_ptr, &mut next_len)) = cursor.peek_next() {
-                let offset = next_ptr.offset_from(ptr) as usize;
-                if offset < len {
-                    panic!("double free");
-                }
-                if offset == len && ptr.add(len) != self_ptr.add(self_len) {
+                let offset = next_ptr.offset_from(ptr);
+                assert!(offset >= len as isize, "double free");
+                if offset as usize == len && ptr.add(len) != self_ptr.add(self_len) {
                     cursor.remove_next();
                     let ptrs = self.free_ptrs_by_len.get_mut(&next_len).unwrap();
-                    ptrs.remove(&next_ptr);
+                    assert!(ptrs.remove(&next_ptr));
                     if ptrs.is_empty() {
-                        self.free_ptrs_by_len.remove(&next_len);
+                        assert!(self.free_ptrs_by_len.remove(&next_len).unwrap().is_empty());
                     }
                     len += next_len;
                 }
             }
             if let Some((&prev_ptr, &mut prev_len)) = cursor.peek_prev() {
-                let offset = ptr.offset_from(prev_ptr) as usize;
-                if offset < prev_len {
-                    panic!("double free");
-                }
-                if offset == prev_len && ptr != self_ptr {
+                let offset = ptr.offset_from(prev_ptr);
+                assert!(offset >= prev_len as isize, "double free");
+                if offset as usize == prev_len && ptr != self_ptr {
                     cursor.remove_prev();
                     let ptrs = self.free_ptrs_by_len.get_mut(&prev_len).unwrap();
-                    ptrs.remove(&prev_ptr);
+                    assert!(ptrs.remove(&prev_ptr));
                     if ptrs.is_empty() {
-                        self.free_ptrs_by_len.remove(&prev_len);
+                        assert!(self.free_ptrs_by_len.remove(&prev_len).unwrap().is_empty());
                     }
                     ptr = prev_ptr;
                     len += prev_len;
@@ -105,6 +194,18 @@ impl StaticAllocationsTracker {
         self.free_len_by_ptr.insert(ptr, len);
         self.free_ptrs_by_len.entry(len).or_default().insert(ptr);
     }
+
+    pub fn get_used_mem_current(&self) -> usize {
+        self.used_mem_current
+    }
+
+    pub fn get_used_mem_peak(&self) -> usize {
+        self.used_mem_peak
+    }
+
+    pub fn reset_used_mem_peak(&mut self) {
+        self.used_mem_peak = self.used_mem_current;
+    }
 }
 
-unsafe impl Send for StaticAllocationsTracker {}
+unsafe impl Send for AllocationsTracker {}

--- a/gpu_prover/src/barycentric.rs
+++ b/gpu_prover/src/barycentric.rs
@@ -327,7 +327,7 @@ pub fn batch_barycentric_eval(
 mod tests {
     use super::*;
 
-    use crate::context::Context;
+    use crate::device_context::DeviceContext;
     use crate::device_structures::DeviceMatrix;
     use crate::field::{BaseField, Ext2Field, Ext4Field};
 
@@ -555,7 +555,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_barycentric_for_delegation_circuit() {
-        let ctx = Context::create(12).unwrap();
+        let ctx = DeviceContext::create(12).unwrap();
         run_basic_delegation_test_impl(
             Some(Box::new(comparison_hook)),
             Some(Box::new(comparison_hook)),

--- a/gpu_prover/src/device_context.rs
+++ b/gpu_prover/src/device_context.rs
@@ -167,7 +167,7 @@ fn generate_powers_dev<F: Field>(
     memory_copy(powers_dev, &powers_host)
 }
 
-pub struct Context {
+pub struct DeviceContext {
     pub powers_of_w_fine: DeviceAllocation<Ext2Field>,
     pub powers_of_w_coarser: DeviceAllocation<Ext2Field>,
     pub powers_of_w_coarsest: DeviceAllocation<Ext2Field>,
@@ -177,7 +177,7 @@ pub struct Context {
     pub powers_of_w_inv_coarse_bitrev_for_ntt: DeviceAllocation<Ext2Field>,
 }
 
-impl Context {
+impl DeviceContext {
     pub fn create(powers_of_w_coarsest_log_count: u32) -> CudaResult<Self> {
         assert!(powers_of_w_coarsest_log_count <= OMEGA_LOG_ORDER);
         let length_fine = 1usize << FINEST_LOG_COUNT;

--- a/gpu_prover/src/execution/gpu_manager.rs
+++ b/gpu_prover/src/execution/gpu_manager.rs
@@ -2,7 +2,7 @@ use super::gpu_worker::{get_gpu_worker_func, GpuWorkRequest};
 use super::messages::WorkerResult;
 use crate::cudart::device::get_device_count;
 use crate::cudart::result::CudaResult;
-use crate::prover::context::{ProverContext, ProverContextConfig};
+use crate::prover::context::{HostAllocator, ProverContextConfig};
 use crossbeam_channel::internal::SelectHandle;
 use crossbeam_channel::{bounded, unbounded, Receiver, Select, Sender};
 use crossbeam_utils::sync::WaitGroup;
@@ -21,19 +21,19 @@ pub struct GpuWorkBatch<A: GoodAllocator, B: GoodAllocator = Global> {
     pub sender: Sender<WorkerResult<A>>,
 }
 
-pub struct GpuManager<C: ProverContext, A: GoodAllocator + 'static = Global> {
+pub struct GpuManager<A: GoodAllocator + 'static = Global> {
     wait_group: Option<WaitGroup>,
-    batches_sender: Option<Sender<GpuWorkBatch<C::HostAllocator, A>>>,
+    batches_sender: Option<Sender<GpuWorkBatch<HostAllocator, A>>>,
 }
 
-impl<C: ProverContext, A: GoodAllocator + 'static> GpuManager<C, A> {
+impl<A: GoodAllocator + 'static> GpuManager<A> {
     pub fn new() -> Self {
         let (batches_sender, batches_receiver) = unbounded();
         trace!("GPU_MANAGER spawning");
         let wait_group = WaitGroup::new();
         let wait_group_clone = wait_group.clone();
         thread::spawn(move || {
-            let result = scope(|s| gpu_manager::<C>(batches_receiver, s)).unwrap();
+            let result = scope(|s| gpu_manager(batches_receiver, s)).unwrap();
             if let Err(e) = result {
                 error!("GPU_MANAGER encountered an error: {e}");
                 exit(1);
@@ -46,12 +46,12 @@ impl<C: ProverContext, A: GoodAllocator + 'static> GpuManager<C, A> {
         }
     }
 
-    pub fn send_batch(&self, batch: GpuWorkBatch<C::HostAllocator, A>) {
+    pub fn send_batch(&self, batch: GpuWorkBatch<HostAllocator, A>) {
         self.batches_sender.as_ref().unwrap().send(batch).unwrap()
     }
 }
 
-impl<C: ProverContext, A: GoodAllocator + 'static> Drop for GpuManager<C, A> {
+impl<A: GoodAllocator + 'static> Drop for GpuManager<A> {
     fn drop(&mut self) {
         drop(self.batches_sender.take().unwrap());
         trace!("GPU_MANAGER waiting for all workers to finish");
@@ -59,8 +59,8 @@ impl<C: ProverContext, A: GoodAllocator + 'static> Drop for GpuManager<C, A> {
         trace!("GPU_MANAGER all workers finished");
     }
 }
-fn gpu_manager<C: ProverContext>(
-    batches_receiver: Receiver<GpuWorkBatch<C::HostAllocator, impl GoodAllocator + 'static>>,
+fn gpu_manager(
+    batches_receiver: Receiver<GpuWorkBatch<HostAllocator, impl GoodAllocator + 'static>>,
     scope: &Scope,
 ) -> CudaResult<()> {
     let device_count = get_device_count()? as usize;
@@ -80,7 +80,7 @@ fn gpu_manager<C: ProverContext>(
         worker_senders.push(request_sender);
         worker_receivers.push(result_receiver);
         worker_queues.push(VecDeque::from([None, None]));
-        let gpu_worker_func = get_gpu_worker_func::<C>(
+        let gpu_worker_func = get_gpu_worker_func(
             device_id,
             prover_context_config,
             worker_initialized_sender.clone(),

--- a/gpu_prover/src/lib.rs
+++ b/gpu_prover/src/lib.rs
@@ -14,7 +14,7 @@ pub mod allocator;
 pub mod barycentric;
 pub mod blake2s;
 pub mod circuit_type;
-pub mod context;
+pub mod device_context;
 pub mod device_structures;
 pub mod execution;
 pub mod field;

--- a/gpu_prover/src/ntt/mod.rs
+++ b/gpu_prover/src/ntt/mod.rs
@@ -13,7 +13,7 @@ use era_cudart::result::{CudaResult, CudaResultWrap};
 use era_cudart::slice::DeviceSlice;
 use era_cudart::stream::{CudaStream, CudaStreamWaitEventFlags};
 
-use crate::context::OMEGA_LOG_ORDER;
+use crate::device_context::OMEGA_LOG_ORDER;
 use crate::device_structures::{
     DeviceMatrixChunk, DeviceMatrixChunkImpl, DeviceMatrixChunkMut, DeviceMatrixChunkMutImpl,
     MutPtrAndStride, PtrAndStride,

--- a/gpu_prover/src/ntt/tests.rs
+++ b/gpu_prover/src/ntt/tests.rs
@@ -14,7 +14,7 @@ use rand::Rng;
 use serial_test::serial;
 use worker::Worker;
 
-use crate::context::Context;
+use crate::device_context::DeviceContext;
 use crate::device_structures::{DeviceMatrixChunk, DeviceMatrixChunkImpl, DeviceMatrixChunkMut};
 use crate::field::{BaseField, Ext2Field};
 use crate::ntt::utils::REAL_COLS_PER_BLOCK;
@@ -65,7 +65,7 @@ fn run_natural_evals_to_bitrev_Z(
     num_bf_cols: usize,
     evals_are: EvalsAre,
 ) {
-    let ctx = Context::create(12).unwrap();
+    let ctx = DeviceContext::create(12).unwrap();
     let n_max = 1 << (log_n_range.end - 1);
     assert_eq!(num_bf_cols % 2, 0);
     let num_Z_cols = num_bf_cols / 2;
@@ -259,7 +259,7 @@ fn run_natural_evals_to_bitrev_Z(
 }
 
 fn run_bitrev_Z_to_natural_trace_coset_evals(log_n_range: Range<usize>, num_bf_cols: usize) {
-    let ctx = Context::create(12).unwrap();
+    let ctx = DeviceContext::create(12).unwrap();
     let n_max = 1 << (log_n_range.end - 1);
     // let num_Z_cols = (num_bf_cols + 1) / 2;
     assert_eq!(num_bf_cols % 2, 0);
@@ -469,7 +469,7 @@ fn run_bitrev_Z_to_natural_trace_coset_evals(log_n_range: Range<usize>, num_bf_c
 }
 
 fn run_bitrev_Z_to_natural_composition_main_evals(log_n_range: Range<usize>, num_bf_cols: usize) {
-    let ctx = Context::create(12).unwrap();
+    let ctx = DeviceContext::create(12).unwrap();
     let n_max = 1 << (log_n_range.end - 1);
     // let num_Z_cols = (num_bf_cols + 1) / 2;
     assert_eq!(num_bf_cols % 2, 0);
@@ -612,7 +612,7 @@ fn run_bitrev_Z_to_natural_composition_main_evals(log_n_range: Range<usize>, num
 }
 
 fn run_natural_main_evals_to_natural_coset_evals(log_n_range: Range<usize>, num_bf_cols: usize) {
-    let ctx = Context::create(12).unwrap();
+    let ctx = DeviceContext::create(12).unwrap();
     let device_properties = DeviceProperties::new().unwrap();
     let n_max = 1 << (log_n_range.end - 1);
     // let num_Z_cols = (num_bf_cols + 1) / 2;

--- a/gpu_prover/src/ops_complex.rs
+++ b/gpu_prover/src/ops_complex.rs
@@ -10,7 +10,7 @@ use era_cudart::{
 };
 
 use crate::blake2s::Digest;
-use crate::context::CIRCLE_GROUP_LOG_ORDER;
+use crate::device_context::CIRCLE_GROUP_LOG_ORDER;
 use crate::device_structures::{
     DeviceMatrixChunkImpl, DeviceMatrixChunkMutImpl, MutPtrAndStride, PtrAndStride,
 };
@@ -478,7 +478,7 @@ mod tests {
     use serial_test::serial;
     use worker::Worker;
 
-    use crate::context::Context;
+    use crate::device_context::DeviceContext;
     use crate::device_structures::{DeviceMatrix, DeviceMatrixMut};
 
     use super::*;
@@ -754,7 +754,7 @@ mod tests {
         const LOG_N: u32 = 16;
         const N: usize = 1 << LOG_N;
         const ROOT_OFFSET: usize = N;
-        let context = Context::create(12).unwrap();
+        let context = DeviceContext::create(12).unwrap();
         let worker = Worker::new_with_num_threads(1);
         let roots = precompute_twiddles_for_fft::<E2, Global, true>(N * 4, &worker);
         let mut rng = rng();

--- a/gpu_prover/src/prover/context.rs
+++ b/gpu_prover/src/prover/context.rs
@@ -1,21 +1,16 @@
+use crate::allocator::device::{
+    NonConcurrentStaticDeviceAllocation, NonConcurrentStaticDeviceAllocator,
+    StaticDeviceAllocationBackend,
+};
 use crate::allocator::host::ConcurrentStaticHostAllocator;
-use crate::context::Context;
+use crate::allocator::tracker::AllocationPlacement;
+use crate::device_context::DeviceContext;
 use era_cudart::device::{device_get_attribute, get_device, set_device};
 use era_cudart::memory::{memory_get_info, CudaHostAllocFlags, HostAllocation};
-use era_cudart::memory_pools::{
-    AttributeHandler, CudaMemPoolAttributeU64, CudaOwnedMemPool, DevicePoolAllocation,
-};
 use era_cudart::result::CudaResult;
-use era_cudart::slice::{CudaSliceMut, DeviceSlice};
 use era_cudart::stream::CudaStream;
 use era_cudart_sys::{CudaDeviceAttr, CudaError};
-use fft::GoodAllocator;
-use field::Mersenne31Field;
 use log::error;
-use std::marker::PhantomData;
-use std::ops::DerefMut;
-
-static DEFAULT_STREAM: CudaStream = CudaStream::DEFAULT;
 
 pub struct DeviceProperties {
     pub l2_cache_size_bytes: usize,
@@ -48,72 +43,33 @@ impl Default for ProverContextConfig {
         Self {
             powers_of_w_coarse_log_count: 12,
             allocation_block_log_size: 22,
-            device_slack_blocks: 1,
+            device_slack_blocks: 32,
         }
     }
 }
 
-pub trait ProverContext {
-    type HostAllocator: GoodAllocator + 'static;
-    type Allocation<T: Sync>: DerefMut<Target = DeviceSlice<T>> + CudaSliceMut<T> + Sync;
-    fn is_host_allocator_initialized() -> bool;
-    fn initialize_host_allocator(
-        host_allocations_count: usize,
-        blocks_per_allocation_count: usize,
-        block_log_size: u32,
-    ) -> CudaResult<()>;
-    fn new(config: &ProverContextConfig) -> CudaResult<Self>
-    where
-        Self: Sized;
-    fn get_device_id(&self) -> i32;
-    fn switch_to_device(&self) -> CudaResult<()>;
-    fn get_exec_stream(&self) -> &CudaStream;
-    fn get_aux_stream(&self) -> &CudaStream;
-    fn get_h2d_stream(&self) -> &CudaStream;
-    fn alloc<T: Sync>(&self, size: usize) -> CudaResult<Self::Allocation<T>>;
-    fn free<T: Sync>(&self, allocation: Self::Allocation<T>) -> CudaResult<()>;
-    fn get_mem_size(&self) -> usize;
-    fn get_used_mem_current(&self) -> CudaResult<usize>;
-    fn get_used_mem_high(&self) -> CudaResult<usize>;
-    fn get_reserved_mem_current(&self) -> CudaResult<usize>;
-    fn get_reserved_mem_high(&self) -> CudaResult<usize>;
-    fn reset_used_mem_high(&self) -> CudaResult<()>;
-    fn get_device_properties(&self) -> &DeviceProperties;
-
-    #[cfg(feature = "log_gpu_mem_usage")]
-    fn log_mem_pool_stats(&self, location: &str) -> CudaResult<()> {
-        let used_mem_current = self.get_used_mem_current()?;
-        let used_mem_high = self.get_used_mem_high()?;
-        log::debug!(
-            "GPU memory usage {location} current/high: {}/{} GB",
-            used_mem_current as f64 / ((1 << 30) as f64),
-            used_mem_high as f64 / ((1 << 30) as f64),
-        );
-        Ok(())
-    }
-}
-
-pub struct MemPoolProverContext<'a> {
-    _inner: Context,
+pub struct ProverContext {
+    _device_context: DeviceContext,
+    pub(crate) device_allocator: NonConcurrentStaticDeviceAllocator,
     pub(crate) exec_stream: CudaStream,
     pub(crate) aux_stream: CudaStream,
     pub(crate) h2d_stream: CudaStream,
-    pub(crate) mem_pool: CudaOwnedMemPool,
     pub(crate) mem_size: usize,
     pub(crate) device_id: i32,
     pub(crate) device_properties: DeviceProperties,
-    _phantom: PhantomData<&'a ()>,
+    pub(crate) reversed_allocation_placement: bool,
 }
 
-impl<'a> ProverContext for MemPoolProverContext<'a> {
-    type HostAllocator = ConcurrentStaticHostAllocator;
-    type Allocation<T: Sync> = DevicePoolAllocation<'a, T>;
+pub type HostAllocator = ConcurrentStaticHostAllocator;
 
-    fn is_host_allocator_initialized() -> bool {
+pub type DeviceAllocation<T> = NonConcurrentStaticDeviceAllocation<T>;
+
+impl ProverContext {
+    pub fn is_host_allocator_initialized() -> bool {
         ConcurrentStaticHostAllocator::is_initialized_global()
     }
 
-    fn initialize_host_allocator(
+    pub fn initialize_host_allocator(
         host_allocations_count: usize,
         blocks_per_allocation_count: usize,
         block_log_size: u32,
@@ -134,142 +90,135 @@ impl<'a> ProverContext for MemPoolProverContext<'a> {
         Ok(())
     }
 
-    fn new(config: &ProverContextConfig) -> CudaResult<Self> {
+    pub fn new(config: &ProverContextConfig) -> CudaResult<Self> {
         assert!(ConcurrentStaticHostAllocator::is_initialized_global());
-        let inner = Context::create(config.powers_of_w_coarse_log_count)?;
+        let device_context = DeviceContext::create(config.powers_of_w_coarse_log_count)?;
         let exec_stream = CudaStream::create()?;
         let aux_stream = CudaStream::create()?;
         let h2d_stream = CudaStream::create()?;
         let device_id = get_device()?;
-        let mem_pool = CudaOwnedMemPool::create_for_device(device_id)?;
-        mem_pool.set_attribute(CudaMemPoolAttributeU64::AttrReleaseThreshold, u64::MAX)?;
         let (free, _) = memory_get_info()?;
         let mut size = (free >> config.allocation_block_log_size) - config.device_slack_blocks;
-        loop {
-            match DevicePoolAllocation::<Mersenne31Field>::alloc_from_pool_async(
+        let allocation = loop {
+            let result = era_cudart::memory::DeviceAllocation::<u8>::alloc(
                 size << config.allocation_block_log_size,
-                &mem_pool,
-                &DEFAULT_STREAM,
-            ) {
-                Ok(dummy) => {
-                    dummy.free_async(&DEFAULT_STREAM)?;
-                    break;
-                }
+            );
+            match result {
+                Ok(allocation) => break allocation,
                 Err(CudaError::ErrorMemoryAllocation) => {
                     let last_error = era_cudart::error::get_last_error();
                     if last_error != CudaError::ErrorMemoryAllocation {
                         return Err(last_error);
                     }
                     size -= 1;
+                    continue;
                 }
                 Err(e) => return Err(e),
-            }
-            if let Ok(dummy) = DevicePoolAllocation::<u8>::alloc_from_pool_async(
-                size << config.allocation_block_log_size,
-                &mem_pool,
-                &DEFAULT_STREAM,
-            ) {
-                dummy.free_async(&DEFAULT_STREAM)?;
-                break;
-            } else {
-                size -= 1;
-            }
-        }
+            };
+        };
+        let device_allocator = NonConcurrentStaticDeviceAllocator::new(
+            [StaticDeviceAllocationBackend::DeviceAllocation(allocation)],
+            config.allocation_block_log_size,
+        );
         let mem_size = size << config.allocation_block_log_size;
-        mem_pool.set_attribute(CudaMemPoolAttributeU64::AttrUsedMemHigh, 0)?;
-        DEFAULT_STREAM.synchronize()?;
         let device_properties = DeviceProperties::new()?;
         let context = Self {
-            _inner: inner,
+            _device_context: device_context,
+            device_allocator,
             exec_stream,
             aux_stream,
             h2d_stream,
-            mem_pool,
             mem_size,
             device_id,
             device_properties,
-            _phantom: PhantomData,
+            reversed_allocation_placement: false,
         };
         Ok(context)
     }
 
-    fn get_device_id(&self) -> i32 {
+    pub fn get_device_id(&self) -> i32 {
         self.device_id
     }
 
-    fn switch_to_device(&self) -> CudaResult<()> {
+    pub fn switch_to_device(&self) -> CudaResult<()> {
         set_device(self.device_id)
     }
 
-    fn get_exec_stream(&self) -> &CudaStream {
+    pub fn get_exec_stream(&self) -> &CudaStream {
         &self.exec_stream
     }
 
-    fn get_aux_stream(&self) -> &CudaStream {
+    pub fn get_aux_stream(&self) -> &CudaStream {
         &self.aux_stream
     }
 
-    fn get_h2d_stream(&self) -> &CudaStream {
+    pub fn get_h2d_stream(&self) -> &CudaStream {
         &self.h2d_stream
     }
 
-    fn alloc<T: Sync>(&self, size: usize) -> CudaResult<Self::Allocation<T>> {
+    pub fn alloc<T>(
+        &self,
+        size: usize,
+        placement: AllocationPlacement,
+    ) -> CudaResult<DeviceAllocation<T>> {
         assert_ne!(size, 0);
-        let result = DevicePoolAllocation::<T>::alloc_from_pool_async(
-            size,
-            &self.mem_pool,
-            &self.exec_stream,
-        );
-        let result: CudaResult<Self::Allocation<T>> = unsafe { std::mem::transmute(result) };
+        let placement = if self.reversed_allocation_placement {
+            match placement {
+                AllocationPlacement::BestFit => AllocationPlacement::BestFit,
+                AllocationPlacement::Bottom => AllocationPlacement::Top,
+                AllocationPlacement::Top => AllocationPlacement::Bottom,
+            }
+        } else {
+            placement
+        };
+        let result = self.device_allocator.alloc(size, placement);
         if result.is_err() {
             error!(
-                "failed to allocate {} bytes from GPU memory pool of device ID {}, currently allocated {} bytes",
+                "failed to allocate {} bytes from GPU memory allocator of device ID {}, currently allocated {} bytes",
                 size * size_of::<T>(),
                 self.device_id,
-                self.get_used_mem_current()?
+                self.get_used_mem_current()
             );
         }
         result
     }
 
-    fn free<T: Sync>(&self, allocation: Self::Allocation<T>) -> CudaResult<()> {
-        allocation.free_async(&self.exec_stream)
-    }
-
-    fn get_mem_size(&self) -> usize {
+    pub fn get_mem_size(&self) -> usize {
         self.mem_size
     }
 
-    fn get_used_mem_current(&self) -> CudaResult<usize> {
-        self.mem_pool
-            .get_attribute(CudaMemPoolAttributeU64::AttrUsedMemCurrent)
-            .map(|x| x as usize)
+    pub fn get_used_mem_current(&self) -> usize {
+        self.device_allocator.get_used_mem_current()
     }
 
-    fn get_used_mem_high(&self) -> CudaResult<usize> {
-        self.mem_pool
-            .get_attribute(CudaMemPoolAttributeU64::AttrUsedMemHigh)
-            .map(|x| x as usize)
+    pub fn get_used_mem_peak(&self) -> usize {
+        self.device_allocator.get_used_mem_peak()
     }
 
-    fn get_reserved_mem_current(&self) -> CudaResult<usize> {
-        self.mem_pool
-            .get_attribute(CudaMemPoolAttributeU64::AttrReservedMemCurrent)
-            .map(|x| x as usize)
+    pub fn reset_used_mem_peak(&self) {
+        self.device_allocator.reset_used_mem_peak();
     }
 
-    fn get_reserved_mem_high(&self) -> CudaResult<usize> {
-        self.mem_pool
-            .get_attribute(CudaMemPoolAttributeU64::AttrReservedMemHigh)
-            .map(|x| x as usize)
+    #[cfg(feature = "log_gpu_mem_usage")]
+    pub fn log_gpu_mem_usage(&self, location: &str) {
+        let used_mem_current = self.get_used_mem_current();
+        let used_mem_peak = self.get_used_mem_peak();
+        log::debug!(
+            "GPU memory usage {location} current/peak: {}/{} GB",
+            used_mem_current as f64 / ((1 << 30) as f64),
+            used_mem_peak as f64 / ((1 << 30) as f64),
+        );
     }
 
-    fn reset_used_mem_high(&self) -> CudaResult<()> {
-        self.mem_pool
-            .set_attribute(CudaMemPoolAttributeU64::AttrUsedMemHigh, 0)
-    }
-
-    fn get_device_properties(&self) -> &DeviceProperties {
+    pub fn get_device_properties(&self) -> &DeviceProperties {
         &self.device_properties
+    }
+
+    pub fn is_reversed_allocation_placement(&self) -> bool {
+        self.reversed_allocation_placement
+    }
+
+    pub fn set_reversed_allocation_placement(&mut self, reversed: bool) {
+        self.reversed_allocation_placement = reversed;
     }
 }

--- a/gpu_prover/src/prover/memory.rs
+++ b/gpu_prover/src/prover/memory.rs
@@ -1,4 +1,4 @@
-use super::context::ProverContext;
+use super::context::{HostAllocator, ProverContext};
 use super::trace_holder::{transform_tree_caps, TraceHolder};
 use super::tracing_data::{TracingDataDevice, TracingDataTransfer};
 use super::{device_tracing, BF};
@@ -13,14 +13,14 @@ use era_cudart::result::CudaResult;
 use prover::merkle_trees::MerkleTreeCapVarLength;
 use std::sync::Arc;
 
-pub struct MemoryCommitmentJob<'a, C: ProverContext> {
+pub struct MemoryCommitmentJob<'a> {
     range: device_tracing::Range<'a>,
     is_finished_event: CudaEvent,
     callbacks: Callbacks<'a>,
-    tree_caps: Arc<Vec<Vec<Digest, C::HostAllocator>>>,
+    tree_caps: Arc<Vec<Vec<Digest, HostAllocator>>>,
 }
 
-impl<'a, C: ProverContext> MemoryCommitmentJob<'a, C> {
+impl<'a> MemoryCommitmentJob<'a> {
     pub fn is_finished(&self) -> CudaResult<bool> {
         self.is_finished_event.query()
     }
@@ -40,13 +40,13 @@ impl<'a, C: ProverContext> MemoryCommitmentJob<'a, C> {
     }
 }
 
-pub fn commit_memory<'a, C: ProverContext>(
-    tracing_data_transfer: TracingDataTransfer<'a, C>,
+pub fn commit_memory<'a>(
+    tracing_data_transfer: TracingDataTransfer<'a>,
     circuit: &CompiledCircuitArtifact<BF>,
     log_lde_factor: u32,
     log_tree_cap_size: u32,
-    context: &C,
-) -> CudaResult<MemoryCommitmentJob<'a, C>> {
+    context: &ProverContext,
+) -> CudaResult<MemoryCommitmentJob<'a>> {
     let trace_len = circuit.trace_len;
     assert!(trace_len.is_power_of_two());
     let log_domain_size = trace_len.trailing_zeros();

--- a/gpu_prover/src/prover/pow.rs
+++ b/gpu_prover/src/prover/pow.rs
@@ -1,4 +1,5 @@
-use super::context::ProverContext;
+use super::context::{HostAllocator, ProverContext};
+use crate::allocator::tracker::AllocationPlacement;
 use crate::blake2s::{blake2s_pow, STATE_SIZE};
 use crate::prover::callbacks::Callbacks;
 use blake2s_u32::BLAKE2S_DIGEST_SIZE_U32_WORDS;
@@ -9,29 +10,26 @@ use std::ops::{Deref, DerefMut};
 use std::slice;
 use std::sync::{Arc, Mutex};
 
-pub(crate) struct PowOutput<C: ProverContext> {
-    pub nonce: Arc<Mutex<Box<u64, C::HostAllocator>>>,
+pub(crate) struct PowOutput {
+    pub nonce: Arc<Mutex<Box<u64, HostAllocator>>>,
 }
 
-impl<C: ProverContext> PowOutput<C> {
+impl PowOutput {
     pub fn new<'a>(
         seed: Arc<Mutex<Seed>>,
         pow_bits: u32,
         external_nonce: Option<u64>,
         callbacks: &mut Callbacks<'a>,
-        context: &C,
-    ) -> CudaResult<Self>
-    where
-        C::HostAllocator: 'a,
-    {
-        let mut nonce = Box::new_in(0u64, C::HostAllocator::default());
+        context: &ProverContext,
+    ) -> CudaResult<Self> {
+        let mut nonce = Box::new_in(0u64, HostAllocator::default());
         let stream = context.get_exec_stream();
         if let Some(external_nonce) = external_nonce {
             *nonce = external_nonce;
         } else {
             let h_seed = Arc::new(Mutex::new(Box::new_in(
                 [0u32; BLAKE2S_DIGEST_SIZE_U32_WORDS],
-                C::HostAllocator::default(),
+                HostAllocator::default(),
             )));
             let seed_clone = seed.clone();
             let h_seed_clone = h_seed.clone();
@@ -42,8 +40,8 @@ impl<C: ProverContext> PowOutput<C> {
                     .copy_from_slice(&seed_clone.lock().unwrap().0);
             };
             callbacks.schedule(set_h_seed_fn, stream)?;
-            let mut d_seed = context.alloc(STATE_SIZE)?;
-            let mut d_nonce = context.alloc(1)?;
+            let mut d_seed = context.alloc(STATE_SIZE, AllocationPlacement::BestFit)?;
+            let mut d_nonce = context.alloc(1, AllocationPlacement::BestFit)?;
             memory_copy_async(
                 d_seed.deref_mut(),
                 h_seed.lock().unwrap().deref().deref(),

--- a/gpu_prover/src/prover/stage_2.rs
+++ b/gpu_prover/src/prover/stage_2.rs
@@ -1,9 +1,10 @@
-use super::context::ProverContext;
+use super::context::{HostAllocator, ProverContext};
 use super::setup::SetupPrecomputations;
 use super::stage_1::StageOneOutput;
 pub(crate) use super::stage_2_kernels::*;
 use super::trace_holder::{flatten_tree_caps, TraceHolder};
 use super::{BF, E4};
+use crate::allocator::tracker::AllocationPlacement;
 use crate::device_structures::{DeviceMatrix, DeviceMatrixChunk, DeviceMatrixMut};
 use crate::ops_simple::set_by_ref;
 use crate::prover::arg_utils::LookupChallenges;
@@ -21,25 +22,22 @@ use std::ops::{Deref, DerefMut};
 use std::slice;
 use std::sync::{Arc, Mutex};
 
-pub(crate) struct StageTwoOutput<'a, C: ProverContext> {
-    pub(crate) trace_holder: TraceHolder<BF, C>,
-    pub(crate) lookup_challenges: Option<Arc<Mutex<Box<LookupChallenges, C::HostAllocator>>>>,
-    pub(crate) last_row: Option<Arc<Vec<BF, C::HostAllocator>>>,
+pub(crate) struct StageTwoOutput<'a> {
+    pub(crate) trace_holder: TraceHolder<BF>,
+    pub(crate) lookup_challenges: Option<Arc<Mutex<Box<LookupChallenges, HostAllocator>>>>,
+    pub(crate) last_row: Option<Arc<Vec<BF, HostAllocator>>>,
     pub(crate) offset_for_grand_product_poly: usize,
     pub(crate) offset_for_sum_over_delegation_poly: Option<usize>,
     pub(crate) callbacks: Option<Callbacks<'a>>,
 }
 
-impl<'a, C: ProverContext> StageTwoOutput<'a, C> {
+impl<'a> StageTwoOutput<'a> {
     pub fn allocate_trace_evaluations(
         circuit: &CompiledCircuitArtifact<BF>,
         log_lde_factor: u32,
         log_tree_cap_size: u32,
-        context: &C,
-    ) -> CudaResult<Self>
-    where
-        C::HostAllocator: 'a,
-    {
+        context: &ProverContext,
+    ) -> CudaResult<Self> {
         let trace_len = circuit.trace_len;
         assert!(trace_len.is_power_of_two());
         let log_domain_size = trace_len.trailing_zeros();
@@ -69,13 +67,10 @@ impl<'a, C: ProverContext> StageTwoOutput<'a, C> {
         seed: Arc<Mutex<Seed>>,
         circuit: &CompiledCircuitArtifact<BF>,
         cached_data: &ProverCachedData,
-        setup: &SetupPrecomputations<C>,
-        stage_1_output: &mut StageOneOutput<C>,
-        context: &C,
-    ) -> CudaResult<()>
-    where
-        C::HostAllocator: 'a,
-    {
+        setup: &SetupPrecomputations,
+        stage_1_output: &mut StageOneOutput,
+        context: &ProverContext,
+    ) -> CudaResult<()> {
         let trace_len = circuit.trace_len;
         assert!(trace_len.is_power_of_two());
         let log_domain_size = trace_len.trailing_zeros();
@@ -84,7 +79,7 @@ impl<'a, C: ProverContext> StageTwoOutput<'a, C> {
         let mut callbacks = Callbacks::new();
         let lookup_challenges = Arc::new(Mutex::new(Box::<LookupChallenges, _>::new_in(
             Default::default(),
-            C::HostAllocator::default(),
+            HostAllocator::default(),
         )));
         let stream = context.get_exec_stream();
         let lookup_challenges_clone = lookup_challenges.clone();
@@ -122,12 +117,15 @@ impl<'a, C: ProverContext> StageTwoOutput<'a, C> {
         let trace = trace_holder.get_evaluations_mut();
         let mut d_stage_2_cols = DeviceMatrixMut::new(trace, trace_len);
         let num_e4_scratch_elems = get_stage_2_e4_scratch_elems(trace_len, circuit);
-        let mut d_alloc_e4_scratch = context.alloc(num_e4_scratch_elems)?;
+        let mut d_alloc_e4_scratch =
+            context.alloc(num_e4_scratch_elems, AllocationPlacement::BestFit)?;
         let cub_scratch_bytes = get_stage_2_cub_scratch_bytes(trace_len, num_stage_2_bf_cols)?;
-        let mut d_alloc_scratch_for_cub_ops = context.alloc(cub_scratch_bytes)?;
+        let mut d_alloc_scratch_for_cub_ops =
+            context.alloc(cub_scratch_bytes, AllocationPlacement::BestFit)?;
         let num_bf_scratch_elems = get_stage_2_bf_scratch_elems(num_stage_2_bf_cols);
-        let mut d_alloc_scratch_for_col_sums = context.alloc(num_bf_scratch_elems)?;
-        let mut d_lookup_challenges = context.alloc(1)?;
+        let mut d_alloc_scratch_for_col_sums =
+            context.alloc(num_bf_scratch_elems, AllocationPlacement::BestFit)?;
+        let mut d_lookup_challenges = context.alloc(1, AllocationPlacement::BestFit)?;
         let guard = lookup_challenges.lock().unwrap();
         memory_copy_async(
             d_lookup_challenges.deref_mut(),
@@ -156,16 +154,20 @@ impl<'a, C: ProverContext> StageTwoOutput<'a, C> {
             log_domain_size,
             stream,
         )?;
-        drop(generic_lookup_mappings);
+        generic_lookup_mappings.free();
+        d_alloc_e4_scratch.free();
+        d_alloc_scratch_for_cub_ops.free();
+        d_alloc_scratch_for_col_sums.free();
+        d_lookup_challenges.free();
         trace_holder.allocate_to_full(context)?;
         trace_holder.extend_and_commit(0, context)?;
         trace_holder.produce_tree_caps(context)?;
-        let mut d_last_row = context.alloc(num_stage_2_cols)?;
+        let mut d_last_row = context.alloc(num_stage_2_cols, AllocationPlacement::BestFit)?;
         let last_row_src =
             DeviceMatrixChunk::new(trace_holder.get_evaluations(), trace_len, trace_len - 1, 1);
         let mut las_row_dst = DeviceMatrixMut::new(&mut d_last_row, 1);
         set_by_ref(&last_row_src, &mut las_row_dst, stream)?;
-        let mut last_row = Vec::with_capacity_in(num_stage_2_cols, C::HostAllocator::default());
+        let mut last_row = Vec::with_capacity_in(num_stage_2_cols, HostAllocator::default());
         unsafe { last_row.set_len(num_stage_2_cols) };
         memory_copy_async(&mut last_row, d_last_row.deref(), stream)?;
         let last_row = Arc::new(last_row);

--- a/gpu_prover/src/prover/stage_2_kernels.rs
+++ b/gpu_prover/src/prover/stage_2_kernels.rs
@@ -848,7 +848,7 @@ pub fn compute_stage_2_args_on_main_domain(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::Context;
+    use crate::device_context::DeviceContext;
     use crate::device_structures::{DeviceMatrix, DeviceMatrixMut};
 
     use era_cudart::memory::{memory_copy_async, DeviceAllocation};
@@ -1265,7 +1265,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_stage_2_for_delegation_circuit() {
-        let ctx = Context::create(12).unwrap();
+        let ctx = DeviceContext::create(12).unwrap();
         run_basic_delegation_test_impl(
             Some(Box::new(comparison_hook)),
             Some(Box::new(comparison_hook)),

--- a/gpu_prover/src/prover/stage_3.rs
+++ b/gpu_prover/src/prover/stage_3.rs
@@ -1,9 +1,10 @@
-use super::context::ProverContext;
+use super::context::{HostAllocator, ProverContext};
 use super::setup::SetupPrecomputations;
 use super::stage_1::StageOneOutput;
 use super::stage_2::StageTwoOutput;
 use super::stage_3_kernels::*;
 use super::{BF, E2, E4};
+use crate::allocator::tracker::AllocationPlacement;
 use crate::device_structures::{DeviceMatrix, DeviceMatrixMut};
 use crate::prover::arg_utils::LookupChallenges;
 use crate::prover::callbacks::Callbacks;
@@ -27,12 +28,12 @@ use std::ops::{Deref, DerefMut};
 use std::slice;
 use std::sync::{Arc, Mutex};
 
-pub(crate) struct StageThreeOutput<'a, C: ProverContext> {
-    pub(crate) trace_holder: TraceHolder<BF, C>,
+pub(crate) struct StageThreeOutput<'a> {
+    pub(crate) trace_holder: TraceHolder<BF>,
     pub(crate) callbacks: Callbacks<'a>,
 }
 
-impl<'a, C: ProverContext> StageThreeOutput<'a, C> {
+impl<'a> StageThreeOutput<'a> {
     pub fn new(
         seed: Arc<Mutex<Seed>>,
         circuit: &Arc<CompiledCircuitArtifact<BF>>,
@@ -40,16 +41,13 @@ impl<'a, C: ProverContext> StageThreeOutput<'a, C> {
         lde_precomputations: &LdePrecomputations<impl GoodAllocator>,
         twiddles: &Twiddles<E2, impl GoodAllocator>,
         external_values: ExternalValues,
-        setup: &SetupPrecomputations<C>,
-        stage_1_output: &StageOneOutput<C>,
-        stage_2_output: &StageTwoOutput<C>,
+        setup: &SetupPrecomputations,
+        stage_1_output: &StageOneOutput,
+        stage_2_output: &StageTwoOutput,
         log_lde_factor: u32,
         log_tree_cap_size: u32,
-        context: &C,
-    ) -> CudaResult<Self>
-    where
-        C::HostAllocator: 'a,
-    {
+        context: &ProverContext,
+    ) -> CudaResult<Self> {
         const COSET_INDEX: usize = 1;
         let trace_len = circuit.trace_len;
         assert!(trace_len.is_power_of_two());
@@ -73,14 +71,14 @@ impl<'a, C: ProverContext> StageThreeOutput<'a, C> {
             .unwrap()
             .coset_offset;
         let mut h_alpha_powers =
-            Vec::with_capacity_in(alpha_powers_count, C::HostAllocator::default());
+            Vec::with_capacity_in(alpha_powers_count, HostAllocator::default());
         unsafe { h_alpha_powers.set_len(alpha_powers_count) };
-        let h_beta_powers = Box::new_in([E4::ZERO; BETA_POWERS_COUNT], C::HostAllocator::default());
-        let mut h_helpers = Vec::with_capacity_in(MAX_HELPER_VALUES, C::HostAllocator::default());
+        let h_beta_powers = Box::new_in([E4::ZERO; BETA_POWERS_COUNT], HostAllocator::default());
+        let mut h_helpers = Vec::with_capacity_in(MAX_HELPER_VALUES, HostAllocator::default());
         unsafe { h_helpers.set_len(MAX_HELPER_VALUES) };
         let h_constants_times_challenges = Box::new_in(
             ConstantsTimesChallenges::default(),
-            C::HostAllocator::default(),
+            HostAllocator::default(),
         );
         let h_alpha_powers = Arc::new(Mutex::new(h_alpha_powers));
         let h_beta_powers = Arc::new(Mutex::new(h_beta_powers));
@@ -127,11 +125,11 @@ impl<'a, C: ProverContext> StageThreeOutput<'a, C> {
                 .lock()
                 .unwrap()
                 .copy_from_slice(&beta_powers);
-            let grand_product_accumulator = StageTwoOutput::<C>::get_grand_product_accumulator(
+            let grand_product_accumulator = StageTwoOutput::get_grand_product_accumulator(
                 stage_2_offset_for_grand_product_poly,
                 &stage_2_last_row_clone,
             );
-            let sum_over_delegation_poly = StageTwoOutput::<C>::get_sum_over_delegation_poly(
+            let sum_over_delegation_poly = StageTwoOutput::get_sum_over_delegation_poly(
                 offset_for_sum_over_delegation_poly,
                 &stage_2_last_row_clone,
             )
@@ -157,10 +155,11 @@ impl<'a, C: ProverContext> StageThreeOutput<'a, C> {
             h_helpers_clone.lock().unwrap().copy_from_slice(&helpers);
         };
         callbacks.schedule(get_challenges_and_helpers_fn, stream)?;
-        let mut d_alpha_powers = context.alloc(alpha_powers_count)?;
-        let mut d_beta_powers = context.alloc(BETA_POWERS_COUNT)?;
-        let mut d_helpers = context.alloc(MAX_HELPER_VALUES)?;
-        let mut d_constants_times_challenges_sum = context.alloc(1)?;
+        let mut d_alpha_powers = context.alloc(alpha_powers_count, AllocationPlacement::BestFit)?;
+        let mut d_beta_powers = context.alloc(BETA_POWERS_COUNT, AllocationPlacement::BestFit)?;
+        let mut d_helpers = context.alloc(MAX_HELPER_VALUES, AllocationPlacement::BestFit)?;
+        let mut d_constants_times_challenges_sum =
+            context.alloc(1, AllocationPlacement::BestFit)?;
         memory_copy_async(
             d_alpha_powers.deref_mut(),
             h_alpha_powers.lock().unwrap().deref(),

--- a/gpu_prover/src/prover/stage_3_kernels.rs
+++ b/gpu_prover/src/prover/stage_3_kernels.rs
@@ -1997,7 +1997,7 @@ pub fn compute_stage_3_composition_quotient_on_coset(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::Context;
+    use crate::device_context::DeviceContext;
     use crate::device_structures::{DeviceMatrix, DeviceMatrixMut};
     use std::alloc::Global;
 
@@ -2244,7 +2244,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_stage_3_for_delegation_circuit() {
-        let ctx = Context::create(12).unwrap();
+        let ctx = DeviceContext::create(12).unwrap();
         run_basic_delegation_test_impl(
             Some(Box::new(comparison_hook)),
             Some(Box::new(comparison_hook)),

--- a/gpu_prover/src/prover/stage_4.rs
+++ b/gpu_prover/src/prover/stage_4.rs
@@ -1,4 +1,5 @@
 use super::{BF, E2, E4};
+use crate::allocator::tracker::AllocationPlacement;
 use crate::barycentric::{
     batch_barycentric_eval, get_batch_eval_temp_storage_sizes, precompute_lagrange_coeffs,
 };
@@ -6,7 +7,7 @@ use crate::blake2s::build_merkle_tree;
 use crate::device_structures::{DeviceMatrix, DeviceMatrixMut};
 use crate::ops_complex::{bit_reverse_in_place, transpose};
 use crate::prover::callbacks::Callbacks;
-use crate::prover::context::ProverContext;
+use crate::prover::context::{HostAllocator, ProverContext};
 use crate::prover::setup::SetupPrecomputations;
 use crate::prover::stage_1::StageOneOutput;
 use crate::prover::stage_2::StageTwoOutput;
@@ -32,30 +33,27 @@ use std::ops::{Deref, DerefMut};
 use std::slice;
 use std::sync::{Arc, Mutex};
 
-pub(crate) struct StageFourOutput<'a, C: ProverContext> {
-    pub(crate) trace_holder: TraceHolder<E4, C>,
+pub(crate) struct StageFourOutput<'a> {
+    pub(crate) trace_holder: TraceHolder<E4>,
     pub(crate) callbacks: Callbacks<'a>,
-    pub(crate) values_at_z: Arc<Vec<E4, C::HostAllocator>>,
+    pub(crate) values_at_z: Arc<Vec<E4, HostAllocator>>,
 }
 
-impl<'a, C: ProverContext> StageFourOutput<'a, C> {
+impl<'a> StageFourOutput<'a> {
     pub fn new(
         seed: Arc<Mutex<Seed>>,
         circuit: &Arc<CompiledCircuitArtifact<BF>>,
         cached_data: &ProverCachedData,
         twiddles: &Twiddles<E2, impl GoodAllocator>,
-        setup: &SetupPrecomputations<C>,
-        stage_1_output: &StageOneOutput<C>,
-        stage_2_output: &StageTwoOutput<C>,
-        stage_3_output: &StageThreeOutput<C>,
+        setup: &SetupPrecomputations,
+        stage_1_output: &StageOneOutput,
+        stage_2_output: &StageTwoOutput,
+        stage_3_output: &StageThreeOutput,
         log_lde_factor: u32,
         log_tree_cap_size: u32,
         folding_description: &FoldingDescription,
-        context: &C,
-    ) -> CudaResult<Self>
-    where
-        C::HostAllocator: 'a,
-    {
+        context: &ProverContext,
+    ) -> CudaResult<Self> {
         const COSET_INDEX: usize = 0;
         let trace_len = circuit.trace_len;
         assert!(trace_len.is_power_of_two());
@@ -77,15 +75,12 @@ impl<'a, C: ProverContext> StageFourOutput<'a, C> {
         let num_evals = num_evals_at_z + num_evals_at_z_omega;
         let mut vectorized_ldes = vec![];
         for _ in 0..lde_factor {
-            vectorized_ldes.push(context.alloc(4 * trace_len)?);
+            vectorized_ldes.push(context.alloc(4 * trace_len, AllocationPlacement::BestFit)?);
         }
-        let mut values_at_z = Vec::with_capacity_in(num_evals, C::HostAllocator::default());
+        let mut values_at_z = Vec::with_capacity_in(num_evals, HostAllocator::default());
         unsafe { values_at_z.set_len(num_evals) };
         let stream = context.get_exec_stream();
-        let h_z = Arc::new(Mutex::new(Box::new_in(
-            E4::ZERO,
-            C::HostAllocator::default(),
-        )));
+        let h_z = Arc::new(Mutex::new(Box::new_in(E4::ZERO, HostAllocator::default())));
         let seed_clone = seed.clone();
         let h_z_clone = h_z.clone();
         let get_z = move || {
@@ -109,20 +104,21 @@ impl<'a, C: ProverContext> StageFourOutput<'a, C> {
         let num_evals_at_z_omega = circuit.num_openings_at_z_omega();
         let num_evals = num_evals_at_z + num_evals_at_z_omega;
         let row_chunk_size = 2048; // tunable for performance, 2048 is decent
-        let mut d_alloc_z = context.alloc(1)?;
+        let mut d_alloc_z = context.alloc(1, AllocationPlacement::BestFit)?;
         memory_copy_async(
             &mut d_alloc_z,
             slice::from_ref(h_z.lock().unwrap().deref().deref()),
             &context.get_exec_stream(),
         )?;
-        let mut d_alloc_evals = context.alloc(num_evals)?;
+        let mut d_alloc_evals = context.alloc(num_evals, AllocationPlacement::BestFit)?;
         let (partial_reduce_temp_elems, final_cub_reduce_temp_bytes) =
             get_batch_eval_temp_storage_sizes(&circuit, trace_len as u32, row_chunk_size)?;
-        let mut d_alloc_temp_storage_partial_reduce = context.alloc(partial_reduce_temp_elems)?;
+        let mut d_alloc_temp_storage_partial_reduce =
+            context.alloc(partial_reduce_temp_elems, AllocationPlacement::BestFit)?;
         let mut d_alloc_temp_storage_final_cub_reduce =
-            context.alloc(final_cub_reduce_temp_bytes)?;
-        let mut d_common_factor_storage = context.alloc(1)?;
-        let mut d_lagrange_coeffs = context.alloc(trace_len)?;
+            context.alloc(final_cub_reduce_temp_bytes, AllocationPlacement::BestFit)?;
+        let mut d_common_factor_storage = context.alloc(1, AllocationPlacement::BestFit)?;
+        let mut d_lagrange_coeffs = context.alloc(trace_len, AllocationPlacement::BestFit)?;
         let d_setup_cols = DeviceMatrix::new(
             setup.trace_holder.get_coset_evaluations(COSET_INDEX),
             trace_len,
@@ -203,7 +199,7 @@ impl<'a, C: ProverContext> StageFourOutput<'a, C> {
             *alpha_clone.lock().unwrap() = E4::from_coeffs_in_base(&alpha_coeffs);
         };
         callbacks.schedule(get_alpha, stream)?;
-        let mut d_denom_at_z = context.alloc(trace_len)?;
+        let mut d_denom_at_z = context.alloc(trace_len, AllocationPlacement::BestFit)?;
         compute_deep_denom_at_z_on_main_domain(
             &mut d_denom_at_z,
             &d_alloc_z[0],
@@ -212,16 +208,16 @@ impl<'a, C: ProverContext> StageFourOutput<'a, C> {
             &stream,
         )?;
         let e4_scratch_elems = get_e4_scratch_count_for_deep_quotiening();
-        let mut h_e4_scratch = Vec::with_capacity_in(e4_scratch_elems, C::HostAllocator::default());
+        let mut h_e4_scratch = Vec::with_capacity_in(e4_scratch_elems, HostAllocator::default());
         unsafe { h_e4_scratch.set_len(e4_scratch_elems) };
         let h_e4_scratch = Arc::new(Mutex::new(h_e4_scratch));
         let h_challenges_times_evals = Arc::new(Mutex::new(Box::new_in(
             ChallengesTimesEvals::default(),
-            C::HostAllocator::default(),
+            HostAllocator::default(),
         )));
         let h_non_witness_challenges_at_z_omega = Arc::new(Mutex::new(Box::new_in(
             NonWitnessChallengesAtZOmega::default(),
-            C::HostAllocator::default(),
+            HostAllocator::default(),
         )));
         let values_at_z_clone = values_at_z.clone();
         let alpha_clone = alpha.clone();
@@ -244,9 +240,10 @@ impl<'a, C: ProverContext> StageFourOutput<'a, C> {
             );
         };
         callbacks.schedule(get_challenges, stream)?;
-        let mut d_e4_scratch = context.alloc(e4_scratch_elems)?;
-        let mut d_challenges_times_evals = context.alloc(1)?;
-        let mut d_non_witness_challenges_at_z_omega = context.alloc(1)?;
+        let mut d_e4_scratch = context.alloc(e4_scratch_elems, AllocationPlacement::BestFit)?;
+        let mut d_challenges_times_evals = context.alloc(1, AllocationPlacement::BestFit)?;
+        let mut d_non_witness_challenges_at_z_omega =
+            context.alloc(1, AllocationPlacement::BestFit)?;
         memory_copy_async(
             &mut d_e4_scratch,
             h_e4_scratch.lock().unwrap().deref(),

--- a/gpu_prover/src/prover/stage_4_kernels.rs
+++ b/gpu_prover/src/prover/stage_4_kernels.rs
@@ -403,7 +403,7 @@ pub fn compute_deep_quotient_on_main_domain(
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::context::Context;
+    use crate::device_context::DeviceContext;
     use crate::device_structures::DeviceMatrixMut;
     use crate::ops_complex::bit_reverse_in_place;
 
@@ -659,7 +659,7 @@ pub(crate) mod tests {
     #[test]
     #[serial]
     fn test_stage_4_for_delegation_circuit() {
-        let ctx = Context::create(12).unwrap();
+        let ctx = DeviceContext::create(12).unwrap();
         run_basic_delegation_test_impl(
             Some(Box::new(comparison_hook)),
             Some(Box::new(comparison_hook)),

--- a/gpu_prover/src/prover/stage_5.rs
+++ b/gpu_prover/src/prover/stage_5.rs
@@ -1,6 +1,7 @@
-use super::context::ProverContext;
+use super::context::{DeviceAllocation, HostAllocator, ProverContext};
 use super::stage_4::StageFourOutput;
 use super::{BF, E2, E4};
+use crate::allocator::tracker::AllocationPlacement;
 use crate::blake2s::{build_merkle_tree, Digest};
 use crate::ops_complex::fold;
 use crate::prover::callbacks::Callbacks;
@@ -21,34 +22,31 @@ use std::iter;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 
-pub(crate) struct FRIStep<C: ProverContext> {
-    pub ldes: Vec<C::Allocation<E4>>,
-    pub trees: Vec<C::Allocation<Digest>>,
-    pub tree_caps: Arc<Vec<Vec<Digest, C::HostAllocator>>>,
+pub(crate) struct FRIStep {
+    pub ldes: Vec<DeviceAllocation<E4>>,
+    pub trees: Vec<DeviceAllocation<Digest>>,
+    pub tree_caps: Arc<Vec<Vec<Digest, HostAllocator>>>,
 }
 
-pub(crate) struct StageFiveOutput<'a, C: ProverContext> {
-    pub(crate) fri_oracles: Vec<FRIStep<C>>,
-    pub(crate) last_fri_step_plain_leaf_values: Arc<Vec<Vec<E4, C::HostAllocator>>>,
+pub(crate) struct StageFiveOutput<'a> {
+    pub(crate) fri_oracles: Vec<FRIStep>,
+    pub(crate) last_fri_step_plain_leaf_values: Arc<Vec<Vec<E4, HostAllocator>>>,
     pub(crate) final_monomials: Arc<Mutex<Vec<E4>>>,
     pub(crate) callbacks: Callbacks<'a>,
 }
 
-impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
+impl<'a> StageFiveOutput<'a> {
     pub fn new(
         seed: Arc<Mutex<Seed>>,
-        stage_4_output: &StageFourOutput<C>,
+        stage_4_output: &StageFourOutput,
         log_domain_size: u32,
         log_lde_factor: u32,
         folding_description: &FoldingDescription,
         num_queries: usize,
         lde_precomputations: &LdePrecomputations<impl GoodAllocator>,
         twiddles: &Twiddles<E2, impl GoodAllocator>,
-        context: &C,
-    ) -> CudaResult<Self>
-    where
-        C::HostAllocator: 'a,
-    {
+        context: &ProverContext,
+    ) -> CudaResult<Self> {
         assert_eq!(log_domain_size, stage_4_output.trace_holder.log_domain_size);
         let log_tree_cap_size = folding_description.total_caps_size_log2 as u32;
         let lde_factor = 1usize << log_lde_factor;
@@ -58,10 +56,10 @@ impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
             .as_ref()
             .unwrap()
             .taus;
-        let mut taus = Vec::with_capacity_in(taus_ref.len(), C::HostAllocator::default());
+        let mut taus = Vec::with_capacity_in(taus_ref.len(), HostAllocator::default());
         taus.extend_from_slice(taus_ref);
         let taus = Arc::new(Mutex::new(taus));
-        let mut fri_oracles: Vec<FRIStep<C>> = vec![];
+        let mut fri_oracles: Vec<FRIStep> = vec![];
         let mut last_fri_step_plain_leaf_values = Default::default();
         let mut callbacks = Callbacks::new();
         let stream = context.get_exec_stream();
@@ -77,7 +75,7 @@ impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
             let log_num_leafs = log_folded_domain_size - next_log_fold;
             let mut ldes = Vec::with_capacity(lde_factor);
             for _ in 0..lde_factor {
-                ldes.push(context.alloc(1 << log_folded_domain_size)?);
+                ldes.push(context.alloc(1 << log_folded_domain_size, AllocationPlacement::Bottom)?);
             }
             let folding_inputs = if i == 0 {
                 &stage_4_output.trace_holder.ldes
@@ -85,8 +83,7 @@ impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
                 &fri_oracles[i - 1].ldes
             };
             let challenges_len = lde_factor * current_log_fold;
-            let mut h_challenges =
-                Vec::with_capacity_in(challenges_len, C::HostAllocator::default());
+            let mut h_challenges = Vec::with_capacity_in(challenges_len, HostAllocator::default());
             unsafe { h_challenges.set_len(challenges_len) };
             let h_challenges = Arc::new(Mutex::new(h_challenges));
             let seed_clone = seed.clone();
@@ -101,7 +98,7 @@ impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
                 );
             };
             callbacks.schedule(set_folding_challenges_fn, stream)?;
-            let mut d_challenges = context.alloc(challenges_len)?;
+            let mut d_challenges = context.alloc(challenges_len, AllocationPlacement::BestFit)?;
             memory_copy_async(
                 &mut d_challenges,
                 h_challenges.lock().unwrap().deref(),
@@ -120,6 +117,7 @@ impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
                     context,
                 )?;
             }
+            d_challenges.free();
             let expose_all_leafs = if i == oracles_count - 1 {
                 let log_bound = num_queries.next_power_of_two().trailing_zeros();
                 log_num_leafs + 1 - log_lde_factor <= log_bound
@@ -130,7 +128,7 @@ impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
                 let mut leaf_values = vec![];
                 for d_coset in ldes.iter() {
                     let len = d_coset.len();
-                    let mut h_coset = Vec::with_capacity_in(len, C::HostAllocator::default());
+                    let mut h_coset = Vec::with_capacity_in(len, HostAllocator::default());
                     unsafe { h_coset.set_len(len) };
                     memory_copy_async(&mut h_coset, d_coset, stream)?;
                     leaf_values.push(h_coset);
@@ -156,9 +154,11 @@ impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
             } else {
                 let mut trees = Vec::with_capacity(lde_factor);
                 for _ in 0..lde_factor {
-                    trees.push(context.alloc(1 << (log_num_leafs + 1))?);
+                    trees.push(
+                        context.alloc(1 << (log_num_leafs + 1), AllocationPlacement::Bottom)?,
+                    );
                 }
-                let mut tree_caps = allocate_tree_caps::<C>(log_lde_factor, log_tree_cap_size);
+                let mut tree_caps = allocate_tree_caps(log_lde_factor, log_tree_cap_size);
                 let next_log_fold = folding_description.folding_sequence[i + 1] as u32;
                 let log_num_leafs = log_folded_domain_size - next_log_fold;
                 let log_cap_size = folding_description.total_caps_size_log2 as u32;
@@ -211,8 +211,7 @@ impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
         let final_monomials = {
             let log_folding_degree = *folding_description.folding_sequence.last().unwrap() as u32;
             let challenges_len = log_folding_degree as usize;
-            let mut h_challenges =
-                Vec::with_capacity_in(challenges_len, C::HostAllocator::default());
+            let mut h_challenges = Vec::with_capacity_in(challenges_len, HostAllocator::default());
             unsafe { h_challenges.set_len(challenges_len) };
             let h_challenges = Arc::new(Mutex::new(h_challenges));
             let seed_clone = seed.clone();
@@ -227,7 +226,7 @@ impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
                 );
             };
             callbacks.schedule(set_folding_challenges_fn, stream)?;
-            let mut d_challenges = context.alloc(challenges_len)?;
+            let mut d_challenges = context.alloc(challenges_len, AllocationPlacement::BestFit)?;
             memory_copy_async(
                 &mut d_challenges,
                 &h_challenges.lock().unwrap().deref(),
@@ -235,7 +234,8 @@ impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
             )?;
             let log_folded_domain_size = log_current_domain_size - log_folding_degree;
             let folded_domain_size = 1 << log_folded_domain_size;
-            let mut d_folded_domain = context.alloc(folded_domain_size)?;
+            let mut d_folded_domain =
+                context.alloc(folded_domain_size, AllocationPlacement::BestFit)?;
             Self::fold_coset(
                 log_folding_degree,
                 &d_challenges,
@@ -244,7 +244,7 @@ impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
                 context,
             )?;
             let mut h_folded_domain =
-                Vec::with_capacity_in(folded_domain_size, C::HostAllocator::default());
+                Vec::with_capacity_in(folded_domain_size, HostAllocator::default());
             unsafe { h_folded_domain.set_len(folded_domain_size) };
             memory_copy_async(&mut h_folded_domain, d_folded_domain.deref(), stream)?;
             log_current_domain_size -= log_folding_degree;
@@ -335,16 +335,16 @@ impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
     fn fold_coset(
         log_degree: u32,
         challenges: &DeviceSlice<E4>,
-        input: &C::Allocation<E4>,
-        output: &mut C::Allocation<E4>,
-        context: &C,
+        input: &DeviceAllocation<E4>,
+        output: &mut DeviceAllocation<E4>,
+        context: &ProverContext,
     ) -> CudaResult<()> {
         let log_degree = log_degree as usize;
         assert_eq!(log_degree, challenges.len());
         let domain_size = input.len();
         assert!(domain_size.is_power_of_two());
         let log_domain_size = domain_size.trailing_zeros();
-        let mut temp_alloc: Option<C::Allocation<E4>> = None;
+        let mut temp_alloc: Option<DeviceAllocation<E4>> = None;
         let mut output = Some(output);
         let stream = context.get_exec_stream();
         for i in 0..log_degree {
@@ -359,7 +359,8 @@ impl<'a, C: ProverContext> StageFiveOutput<'a, C> {
             let dst = if i == log_degree - 1 {
                 output.take().unwrap()
             } else {
-                temp_alloc = Some(context.alloc(1 << log_next_domain_size)?);
+                temp_alloc =
+                    Some(context.alloc(1 << log_next_domain_size, AllocationPlacement::BestFit)?);
                 temp_alloc.as_mut().unwrap()
             };
             fold(&challenges[i], src, dst, 0, stream)?;

--- a/gpu_prover/src/prover/trace_holder.rs
+++ b/gpu_prover/src/prover/trace_holder.rs
@@ -1,5 +1,6 @@
-use super::context::{DeviceProperties, ProverContext};
+use super::context::{DeviceAllocation, DeviceProperties, HostAllocator, ProverContext};
 use super::BF;
+use crate::allocator::tracker::AllocationPlacement;
 use crate::blake2s::{build_merkle_tree, merkle_tree_cap, Digest};
 use crate::device_structures::{DeviceMatrix, DeviceMatrixChunkMut, DeviceMatrixMut};
 use crate::ntt::{
@@ -19,20 +20,20 @@ use prover::merkle_trees::MerkleTreeCapVarLength;
 use std::ops::DerefMut;
 use std::sync::Arc;
 
-pub struct TraceHolder<T: Sync, C: ProverContext> {
+pub struct TraceHolder<T> {
     pub(crate) log_domain_size: u32,
     pub(crate) log_lde_factor: u32,
     pub(crate) log_rows_per_leaf: u32,
     pub(crate) log_tree_cap_size: u32,
     pub(crate) columns_count: usize,
     pub(crate) padded_to_even: bool,
-    pub(crate) ldes: Vec<C::Allocation<T>>,
-    pub(crate) trees: Vec<C::Allocation<Digest>>,
-    pub(crate) tree_caps: Option<Arc<Vec<Vec<Digest, C::HostAllocator>>>>,
+    pub(crate) ldes: Vec<DeviceAllocation<T>>,
+    pub(crate) trees: Vec<DeviceAllocation<Digest>>,
+    pub(crate) tree_caps: Option<Arc<Vec<Vec<Digest, HostAllocator>>>>,
 }
 
-impl<C: ProverContext> TraceHolder<BF, C> {
-    pub fn make_evaluations_sum_to_zero(&mut self, context: &C) -> CudaResult<()> {
+impl TraceHolder<BF> {
+    pub fn make_evaluations_sum_to_zero(&mut self, context: &ProverContext) -> CudaResult<()> {
         make_evaluations_sum_to_zero(
             &mut self.ldes[0],
             self.log_domain_size,
@@ -42,7 +43,11 @@ impl<C: ProverContext> TraceHolder<BF, C> {
         )
     }
 
-    pub fn extend_and_commit(&mut self, source_coset_index: usize, context: &C) -> CudaResult<()> {
+    pub fn extend_and_commit(
+        &mut self,
+        source_coset_index: usize,
+        context: &ProverContext,
+    ) -> CudaResult<()> {
         extend_trace(
             &mut self.ldes,
             source_coset_index,
@@ -52,7 +57,7 @@ impl<C: ProverContext> TraceHolder<BF, C> {
             context.get_aux_stream(),
             context.get_device_properties(),
         )?;
-        populate_trees_from_trace_ldes::<C>(
+        populate_trees_from_trace_ldes(
             &self.ldes,
             &mut self.trees,
             self.log_domain_size,
@@ -66,13 +71,13 @@ impl<C: ProverContext> TraceHolder<BF, C> {
 
     pub fn make_evaluations_sum_to_zero_extend_and_commit(
         &mut self,
-        context: &C,
+        context: &ProverContext,
     ) -> CudaResult<()> {
         self.make_evaluations_sum_to_zero(context)?;
         self.extend_and_commit(0, context)
     }
 }
-impl<T: Sync, C: ProverContext> TraceHolder<T, C> {
+impl<T> TraceHolder<T> {
     pub fn new(
         log_domain_size: u32,
         log_lde_factor: u32,
@@ -80,7 +85,7 @@ impl<T: Sync, C: ProverContext> TraceHolder<T, C> {
         log_tree_cap_size: u32,
         columns_count: usize,
         pad_to_even: bool,
-        context: &C,
+        context: &ProverContext,
     ) -> CudaResult<Self> {
         let padded_to_even = pad_to_even && columns_count.next_multiple_of(2) != columns_count;
         let instances_count = 1 << log_lde_factor;
@@ -112,7 +117,7 @@ impl<T: Sync, C: ProverContext> TraceHolder<T, C> {
         log_tree_cap_size: u32,
         columns_count: usize,
         pad_to_even: bool,
-        context: &C,
+        context: &ProverContext,
     ) -> CudaResult<Self> {
         let padded_to_even = pad_to_even && columns_count.next_multiple_of(2) != columns_count;
         let ldes = allocate_ldes(log_domain_size, 1, columns_count, pad_to_even, context)?;
@@ -130,7 +135,7 @@ impl<T: Sync, C: ProverContext> TraceHolder<T, C> {
         })
     }
 
-    pub fn allocate_to_full(&mut self, context: &C) -> CudaResult<()> {
+    pub fn allocate_to_full(&mut self, context: &ProverContext) -> CudaResult<()> {
         let instances_count = 1 << self.log_lde_factor;
         assert_eq!(self.ldes.len(), 1);
         let ldes = allocate_ldes(
@@ -168,11 +173,11 @@ impl<T: Sync, C: ProverContext> TraceHolder<T, C> {
         self.get_coset_evaluations_mut(0)
     }
 
-    pub fn produce_tree_caps(&mut self, context: &C) -> CudaResult<()> {
+    pub fn produce_tree_caps(&mut self, context: &ProverContext) -> CudaResult<()> {
         if self.tree_caps.is_some() {
             return Ok(());
         }
-        let mut tree_caps = allocate_tree_caps::<C>(self.log_lde_factor, self.log_tree_cap_size);
+        let mut tree_caps = allocate_tree_caps(self.log_lde_factor, self.log_tree_cap_size);
         transfer_tree_caps(
             &self.trees,
             &mut tree_caps,
@@ -184,18 +189,18 @@ impl<T: Sync, C: ProverContext> TraceHolder<T, C> {
         Ok(())
     }
 
-    pub fn get_tree_caps(&self) -> Arc<Vec<Vec<Digest, C::HostAllocator>>> {
+    pub fn get_tree_caps(&self) -> Arc<Vec<Vec<Digest, HostAllocator>>> {
         self.tree_caps.clone().unwrap()
     }
 }
 
-pub(crate) fn allocate_ldes<T: Sync, C: ProverContext>(
+pub(crate) fn allocate_ldes<T>(
     log_domain_size: u32,
     instances_count: usize,
     columns_count: usize,
     pad_to_even: bool,
-    context: &C,
-) -> CudaResult<Vec<C::Allocation<T>>> {
+    context: &ProverContext,
+) -> CudaResult<Vec<DeviceAllocation<T>>> {
     let columns_count = if pad_to_even {
         columns_count.next_multiple_of(2)
     } else {
@@ -204,54 +209,56 @@ pub(crate) fn allocate_ldes<T: Sync, C: ProverContext>(
     let size = columns_count << log_domain_size;
     let mut result = Vec::with_capacity(instances_count);
     for _ in 0..instances_count {
-        result.push(context.alloc(size)?);
+        result.push(context.alloc(size, AllocationPlacement::Bottom)?);
     }
     Ok(result)
 }
 
-pub(crate) fn allocate_trees<C: ProverContext>(
+pub(crate) fn allocate_trees(
     log_domain_size: u32,
     instances_count: usize,
     log_rows_per_leaf: u32,
-    context: &C,
-) -> CudaResult<Vec<C::Allocation<Digest>>> {
+    context: &ProverContext,
+) -> CudaResult<Vec<DeviceAllocation<Digest>>> {
     let size = 1 << (log_domain_size + 1 - log_rows_per_leaf);
     let mut result = Vec::with_capacity(instances_count);
     for _ in 0..instances_count {
-        result.push(context.alloc(size)?);
+        result.push(context.alloc(size, AllocationPlacement::Bottom)?);
     }
     Ok(result)
 }
 
-pub(crate) fn allocate_tree_caps<C: ProverContext>(
+pub(crate) fn allocate_tree_caps(
     log_lde_factor: u32,
     log_tree_cap_size: u32,
-) -> Vec<Vec<Digest, C::HostAllocator>> {
+) -> Vec<Vec<Digest, HostAllocator>> {
     let lde_factor = 1 << log_lde_factor;
     let log_coset_tree_cap_size = log_tree_cap_size - log_lde_factor;
     let coset_tree_cap_size = 1 << log_coset_tree_cap_size;
     let mut result = Vec::with_capacity(lde_factor);
     for _ in 0..lde_factor {
-        let mut tree_cap = Vec::with_capacity_in(coset_tree_cap_size, C::HostAllocator::default());
+        let mut tree_cap = Vec::with_capacity_in(coset_tree_cap_size, HostAllocator::default());
         unsafe { tree_cap.set_len(coset_tree_cap_size) };
         result.push(tree_cap);
     }
     result
 }
 
-pub(crate) fn make_evaluations_sum_to_zero<C: ProverContext>(
+pub(crate) fn make_evaluations_sum_to_zero(
     evaluations: &mut DeviceSlice<BF>,
     log_domain_size: u32,
     columns_count: usize,
     padded_to_even: bool,
-    context: &C,
+    context: &ProverContext,
 ) -> CudaResult<()> {
     let domain_size = 1 << log_domain_size;
-    let mut reduce_result = context.alloc(columns_count)?;
+    let mut reduce_result = context.alloc(columns_count, AllocationPlacement::BestFit)?;
     let reduce_temp_storage_bytes =
         get_reduce_temp_storage_bytes::<BF>(ReduceOperation::Sum, (domain_size - 1) as i32)?;
-    let mut reduce_temp_storage_0 = context.alloc(reduce_temp_storage_bytes)?;
-    let mut reduce_temp_storage_1 = context.alloc(reduce_temp_storage_bytes)?;
+    let mut reduce_temp_storage_0 =
+        context.alloc(reduce_temp_storage_bytes, AllocationPlacement::BestFit)?;
+    let mut reduce_temp_storage_1 =
+        context.alloc(reduce_temp_storage_bytes, AllocationPlacement::BestFit)?;
     let reduce_temp_storage_refs = [&mut reduce_temp_storage_0, &mut reduce_temp_storage_1];
     let exec_stream = context.get_exec_stream();
     let aux_stream = context.get_aux_stream();
@@ -275,8 +282,8 @@ pub(crate) fn make_evaluations_sum_to_zero<C: ProverContext>(
     }
     end_event.record(aux_stream)?;
     exec_stream.wait_event(&end_event, CudaStreamWaitEventFlags::DEFAULT)?;
-    context.free(reduce_temp_storage_0)?;
-    context.free(reduce_temp_storage_1)?;
+    reduce_temp_storage_0.free();
+    reduce_temp_storage_1.free();
     neg(
         &DeviceMatrix::new(&reduce_result, 1),
         &mut DeviceMatrixChunkMut::new(
@@ -287,7 +294,7 @@ pub(crate) fn make_evaluations_sum_to_zero<C: ProverContext>(
         ),
         exec_stream,
     )?;
-    context.free(reduce_result)?;
+    reduce_result.free();
     if padded_to_even {
         set_to_zero(
             &mut evaluations[columns_count << log_domain_size..],
@@ -382,9 +389,9 @@ pub(crate) fn commit_trace(
     )
 }
 
-pub(crate) fn populate_trees_from_trace_ldes<C: ProverContext>(
-    ldes: &[C::Allocation<BF>],
-    trees: &mut [C::Allocation<Digest>],
+pub(crate) fn populate_trees_from_trace_ldes(
+    ldes: &[DeviceAllocation<BF>],
+    trees: &mut [DeviceAllocation<Digest>],
     log_domain_size: u32,
     log_lde_factor: u32,
     log_rows_per_leaf: u32,

--- a/gpu_prover/src/prover/transfer.rs
+++ b/gpu_prover/src/prover/transfer.rs
@@ -8,28 +8,26 @@ use era_cudart::stream::CudaStreamWaitEventFlags;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 
-pub struct Transfer<'a, C: ProverContext> {
+pub struct Transfer<'a> {
     pub(crate) allocated: CudaEvent,
     pub(crate) transferred: CudaEvent,
     pub(crate) callbacks: Callbacks<'a>,
-    _phantom: std::marker::PhantomData<C>,
 }
 
-impl<'a, C: ProverContext> Transfer<'a, C> {
+impl<'a> Transfer<'a> {
     pub(crate) fn new() -> CudaResult<Self> {
         Ok(Self {
             allocated: CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?,
             transferred: CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?,
             callbacks: Callbacks::new(),
-            _phantom: std::marker::PhantomData,
         })
     }
 
-    pub(crate) fn record_allocated(&self, context: &C) -> CudaResult<()> {
+    pub(crate) fn record_allocated(&self, context: &ProverContext) -> CudaResult<()> {
         self.allocated.record(context.get_exec_stream())
     }
 
-    pub(crate) fn ensure_allocated(&self, context: &C) -> CudaResult<()> {
+    pub(crate) fn ensure_allocated(&self, context: &ProverContext) -> CudaResult<()> {
         context
             .get_h2d_stream()
             .wait_event(&self.allocated, CudaStreamWaitEventFlags::DEFAULT)
@@ -39,7 +37,7 @@ impl<'a, C: ProverContext> Transfer<'a, C> {
         &mut self,
         src: Arc<impl CudaSlice<T> + Send + Sync + ?Sized + 'a>,
         dst: &mut (impl CudaSliceMut<T> + ?Sized),
-        context: &C,
+        context: &ProverContext,
     ) -> CudaResult<()> {
         assert_eq!(src.len(), dst.len());
         self.ensure_allocated(context)?;
@@ -52,11 +50,11 @@ impl<'a, C: ProverContext> Transfer<'a, C> {
         self.callbacks.schedule(f, stream)
     }
 
-    pub(crate) fn record_transferred(&self, context: &C) -> CudaResult<()> {
+    pub(crate) fn record_transferred(&self, context: &ProverContext) -> CudaResult<()> {
         self.transferred.record(context.get_h2d_stream())
     }
 
-    pub fn ensure_transferred(&self, context: &C) -> CudaResult<()> {
+    pub fn ensure_transferred(&self, context: &ProverContext) -> CudaResult<()> {
         context
             .get_exec_stream()
             .wait_event(&self.transferred, CudaStreamWaitEventFlags::DEFAULT)
@@ -66,14 +64,15 @@ impl<'a, C: ProverContext> Transfer<'a, C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prover::context::{MemPoolProverContext, ProverContextConfig};
+    use crate::allocator::tracker::AllocationPlacement;
+    use crate::prover::context::ProverContextConfig;
 
     #[test]
     fn test_transfer() -> CudaResult<()> {
-        let context = MemPoolProverContext::new(&ProverContextConfig::default())?;
+        let context = ProverContext::new(&ProverContextConfig::default())?;
         let src = Arc::new(vec![0; 1024]);
         let mut transfer = Transfer::new()?;
-        let mut dst = context.alloc(1024)?;
+        let mut dst = context.alloc(1024, AllocationPlacement::BestFit)?;
         transfer.record_allocated(&context)?;
         transfer.schedule(src, &mut dst, &context)?;
         transfer.record_transferred(&context)?;

--- a/gpu_prover/src/witness/memory_delegation.rs
+++ b/gpu_prover/src/witness/memory_delegation.rs
@@ -7,7 +7,6 @@ use super::BF;
 use crate::device_structures::{
     DeviceMatrixImpl, DeviceMatrixMut, DeviceMatrixMutImpl, MutPtrAndStride,
 };
-use crate::prover::context::ProverContext;
 use crate::utils::{get_grid_block_dims_for_threads_count, WARP_SIZE};
 use cs::definitions::MemorySubtree;
 use era_cudart::cuda_kernel;
@@ -73,7 +72,7 @@ cuda_kernel!(GenerateMemoryAndWitnessValuesDelegation,
 
 pub(crate) fn generate_memory_values_delegation(
     subtree: &MemorySubtree,
-    trace: &DelegationTraceDevice<impl ProverContext>,
+    trace: &DelegationTraceDevice,
     memory: &mut DeviceMatrixMut<BF>,
     stream: &CudaStream,
 ) -> CudaResult<()> {
@@ -94,7 +93,7 @@ pub(crate) fn generate_memory_values_delegation(
 pub(crate) fn generate_memory_and_witness_values_delegation(
     subtree: &MemorySubtree,
     aux_vars: &cs::definitions::RegisterAndIndirectAccessTimestampComparisonAuxVars,
-    trace: &DelegationTraceDevice<impl ProverContext>,
+    trace: &DelegationTraceDevice,
     memory: &mut DeviceMatrixMut<BF>,
     witness: &mut DeviceMatrixMut<BF>,
     stream: &CudaStream,

--- a/gpu_prover/src/witness/memory_main.rs
+++ b/gpu_prover/src/witness/memory_main.rs
@@ -8,7 +8,6 @@ use super::BF;
 use crate::device_structures::{
     DeviceMatrixImpl, DeviceMatrixMut, DeviceMatrixMutImpl, MutPtrAndStride,
 };
-use crate::prover::context::ProverContext;
 use crate::utils::{get_grid_block_dims_for_threads_count, WARP_SIZE};
 use cs::definitions::{MemorySubtree, TimestampScalar};
 use era_cudart::cuda_kernel;
@@ -98,8 +97,8 @@ cuda_kernel!(GenerateMemoryAndWitnessValuesMain,
 
 pub(crate) fn generate_memory_values_main(
     subtree: &MemorySubtree,
-    setup_and_teardown: &ShuffleRamSetupAndTeardownDevice<impl ProverContext>,
-    trace: &MainTraceDevice<impl ProverContext>,
+    setup_and_teardown: &ShuffleRamSetupAndTeardownDevice,
+    trace: &MainTraceDevice,
     memory: &mut DeviceMatrixMut<BF>,
     stream: &CudaStream,
 ) -> CudaResult<()> {
@@ -123,9 +122,9 @@ pub(crate) fn generate_memory_values_main(
 pub(crate) fn generate_memory_and_witness_values_main(
     subtree: &MemorySubtree,
     memory_queries_timestamp_comparison_aux_vars: &[cs::definitions::ColumnAddress],
-    setup_and_teardown: &ShuffleRamSetupAndTeardownDevice<impl ProverContext>,
+    setup_and_teardown: &ShuffleRamSetupAndTeardownDevice,
     lazy_init_address_aux_vars: &cs::definitions::ShuffleRamAuxComparisonSet,
-    trace: &MainTraceDevice<impl ProverContext>,
+    trace: &MainTraceDevice,
     timestamp_high_from_circuit_sequence: TimestampScalar,
     memory: &mut DeviceMatrixMut<BF>,
     witness: &mut DeviceMatrixMut<BF>,

--- a/gpu_prover/src/witness/trace_delegation.rs
+++ b/gpu_prover/src/witness/trace_delegation.rs
@@ -1,4 +1,4 @@
-use crate::prover::context::ProverContext;
+use crate::prover::context::DeviceAllocation;
 use cs::definitions::TimestampData;
 use era_cudart::slice::CudaSlice;
 use fft::GoodAllocator;
@@ -8,7 +8,7 @@ use prover::risc_v_simulator::abstractions::tracer::{
 use prover::tracers::delegation::{DelegationWitness, IndirectAccessLocation};
 use std::sync::Arc;
 
-pub struct DelegationTraceDevice<C: ProverContext> {
+pub struct DelegationTraceDevice {
     pub num_requests: usize,
     pub num_register_accesses_per_delegation: usize,
     pub num_indirect_reads_per_delegation: usize,
@@ -16,10 +16,10 @@ pub struct DelegationTraceDevice<C: ProverContext> {
     pub base_register_index: u32,
     pub delegation_type: u16,
     pub indirect_accesses_properties: Vec<Vec<IndirectAccessLocation>>,
-    pub write_timestamp: C::Allocation<TimestampData>,
-    pub register_accesses: C::Allocation<RegisterOrIndirectReadWriteData>,
-    pub indirect_reads: C::Allocation<RegisterOrIndirectReadData>,
-    pub indirect_writes: C::Allocation<RegisterOrIndirectReadWriteData>,
+    pub write_timestamp: DeviceAllocation<TimestampData>,
+    pub register_accesses: DeviceAllocation<RegisterOrIndirectReadWriteData>,
+    pub indirect_reads: DeviceAllocation<RegisterOrIndirectReadData>,
+    pub indirect_writes: DeviceAllocation<RegisterOrIndirectReadWriteData>,
 }
 
 const MAX_INDIRECT_ACCESS_REGISTERS: usize = 2;
@@ -41,8 +41,8 @@ pub(crate) struct DelegationTraceRaw {
     pub indirect_writes: *const RegisterOrIndirectReadWriteData,
 }
 
-impl<C: ProverContext> From<&DelegationTraceDevice<C>> for DelegationTraceRaw {
-    fn from(value: &DelegationTraceDevice<C>) -> Self {
+impl From<&DelegationTraceDevice> for DelegationTraceRaw {
+    fn from(value: &DelegationTraceDevice) -> Self {
         Self {
             num_requests: value.write_timestamp.len() as u32,
             num_register_accesses_per_delegation: value.num_register_accesses_per_delegation as u32,

--- a/gpu_prover/src/witness/trace_main.rs
+++ b/gpu_prover/src/witness/trace_main.rs
@@ -1,4 +1,4 @@
-use crate::prover::context::ProverContext;
+use crate::prover::context::DeviceAllocation;
 use crate::witness::BF;
 use cs::utils::{split_timestamp, split_u32_into_pair_u16};
 use era_cudart::slice::CudaSlice;
@@ -9,8 +9,8 @@ use prover::tracers::main_cycle_optimized::{CycleData, SingleCycleTracingData};
 use prover::ShuffleRamSetupAndTeardown;
 use std::sync::Arc;
 
-pub struct MainTraceDevice<C: ProverContext> {
-    pub(crate) cycle_data: C::Allocation<SingleCycleTracingData>,
+pub struct MainTraceDevice {
+    pub(crate) cycle_data: DeviceAllocation<SingleCycleTracingData>,
 }
 
 #[repr(C)]
@@ -18,8 +18,8 @@ pub(crate) struct MainTraceRaw {
     cycle_data: *const SingleCycleTracingData,
 }
 
-impl<C: ProverContext> From<&MainTraceDevice<C>> for MainTraceRaw {
-    fn from(value: &MainTraceDevice<C>) -> Self {
+impl From<&MainTraceDevice> for MainTraceRaw {
+    fn from(value: &MainTraceDevice) -> Self {
         Self {
             cycle_data: value.cycle_data.as_ptr(),
         }
@@ -43,8 +43,8 @@ impl<M: MachineConfig, A: GoodAllocator> From<CycleData<M, A>> for MainTraceHost
     }
 }
 
-pub struct ShuffleRamSetupAndTeardownDevice<C: ProverContext> {
-    pub lazy_init_data: C::Allocation<LazyInitAndTeardown>,
+pub struct ShuffleRamSetupAndTeardownDevice {
+    pub lazy_init_data: DeviceAllocation<LazyInitAndTeardown>,
 }
 
 #[repr(C)]
@@ -52,10 +52,8 @@ pub(crate) struct ShuffleRamSetupAndTeardownRaw {
     pub lazy_init_data: *const LazyInitAndTeardown,
 }
 
-impl<C: ProverContext> From<&ShuffleRamSetupAndTeardownDevice<C>>
-    for ShuffleRamSetupAndTeardownRaw
-{
-    fn from(value: &ShuffleRamSetupAndTeardownDevice<C>) -> Self {
+impl From<&ShuffleRamSetupAndTeardownDevice> for ShuffleRamSetupAndTeardownRaw {
+    fn from(value: &ShuffleRamSetupAndTeardownDevice) -> Self {
         Self {
             lazy_init_data: value.lazy_init_data.as_ptr(),
         }

--- a/gpu_prover/src/witness/witness_delegation.rs
+++ b/gpu_prover/src/witness/witness_delegation.rs
@@ -4,7 +4,6 @@ use crate::circuit_type::DelegationCircuitType;
 use crate::device_structures::{
     DeviceMatrix, DeviceMatrixChunkImpl, DeviceMatrixMut, DeviceMatrixMutImpl,
 };
-use crate::prover::context::ProverContext;
 use crate::utils::{get_grid_block_dims_for_threads_count, WARP_SIZE};
 use era_cudart::cuda_kernel;
 use era_cudart::execution::{CudaLaunchConfig, KernelFunction};
@@ -25,9 +24,9 @@ cuda_kernel!(GenerateWitnessDelegationKernel,
 generate_witness_delegation_kernel!(generate_bigint_with_control_witness_kernel);
 generate_witness_delegation_kernel!(generate_blake2_with_compression_witness_kernel);
 
-pub fn generate_witness_values_delegation<C: ProverContext>(
+pub fn generate_witness_values_delegation(
     circuit_type: DelegationCircuitType,
-    trace: &DelegationTraceDevice<C>,
+    trace: &DelegationTraceDevice,
     generic_lookup_tables: &DeviceMatrix<BF>,
     memory: &DeviceMatrix<BF>,
     witness: &mut DeviceMatrixMut<BF>,

--- a/gpu_prover/src/witness/witness_main.rs
+++ b/gpu_prover/src/witness/witness_main.rs
@@ -4,7 +4,6 @@ use crate::circuit_type::MainCircuitType;
 use crate::device_structures::{
     DeviceMatrix, DeviceMatrixChunkImpl, DeviceMatrixMut, DeviceMatrixMutImpl,
 };
-use crate::prover::context::ProverContext;
 use crate::utils::{get_grid_block_dims_for_threads_count, WARP_SIZE};
 use era_cudart::cuda_kernel;
 use era_cudart::execution::{CudaLaunchConfig, KernelFunction};
@@ -28,9 +27,9 @@ generate_witness_main_kernel!(generate_machine_without_signed_mul_div_witness_ke
 generate_witness_main_kernel!(generate_reduced_risc_v_machine_witness_kernel);
 generate_witness_main_kernel!(generate_risc_v_cycles_witness_kernel);
 
-pub fn generate_witness_values_main<C: ProverContext>(
+pub fn generate_witness_values_main(
     circuit_type: MainCircuitType,
-    trace: &MainTraceDevice<C>,
+    trace: &MainTraceDevice,
     generic_lookup_tables: &DeviceMatrix<BF>,
     memory: &DeviceMatrix<BF>,
     witness: &mut DeviceMatrixMut<BF>,

--- a/tools/cli/src/prover_utils.rs
+++ b/tools/cli/src/prover_utils.rs
@@ -386,12 +386,12 @@ fn should_stop_recursion(proof_metadata: &ProofMetadata) -> bool {
 
 // For now, we share the setup cache, only for GPU (as we really care for performance there).
 #[cfg(feature = "gpu")]
-pub struct GpuSharedState<'a> {
-    pub prover: gpu_prover::execution::prover::ExecutionProver<'a, usize>,
+pub struct GpuSharedState {
+    pub prover: gpu_prover::execution::prover::ExecutionProver<usize>,
 }
 
 #[cfg(feature = "gpu")]
-impl<'a> GpuSharedState<'a> {
+impl GpuSharedState {
     const MAIN_BINARY_KEY: usize = 0;
     const RECURSION_BINARY_KEY: usize = 1;
 

--- a/tools/zksmith/src/main.rs
+++ b/tools/zksmith/src/main.rs
@@ -64,13 +64,13 @@ async fn fetch_data_from_json_rpc(
     }
 }
 
-struct LocalProver<'a> {
+struct LocalProver {
     pub binary: Vec<u32>,
-    pub gpu_state: GpuSharedState<'a>,
+    pub gpu_state: GpuSharedState,
 }
 
-impl<'a> LocalProver<'a> {
-    fn new(zksync_os_bin_path: String) -> LocalProver<'a> {
+impl LocalProver {
+    fn new(zksync_os_bin_path: String) -> LocalProver {
         let binary = load_binary_from_path(&zksync_os_bin_path);
         LocalProver::new_internal(binary)
     }
@@ -81,7 +81,7 @@ impl<'a> LocalProver<'a> {
         LocalProver::new_internal(padded_binary)
     }
 
-    fn new_internal(padded_binary: Vec<u32>) -> LocalProver<'a> {
+    fn new_internal(padded_binary: Vec<u32>) -> LocalProver {
         let gpu_state = GpuSharedState::new(&padded_binary);
         LocalProver {
             binary: padded_binary,


### PR DESCRIPTION
## What ❔

This PR implements a custom GPU memory allocator and replacing all the allocations that used the CUDA mem pool allocator with the new allocator.

## Why ❔

We have no control over the way that the CUDA mem pool allocator handles the allocations and we were running into memory fragmentation issues so a new allocator with more allocation placement control was needed.
As part of this PR, the ProverContext trait was transformed into a struct making the code simpler.
Also the allocation tracking code used by the new device allocator but also by the host allocator was updated, assertions about certain invariants were added.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted.