### PR TITLE
feat(gpu_prover): new logic for rotation of trace buffers

### DIFF
--- a/circuit_defs/prover_examples/src/gpu.rs
+++ b/circuit_defs/prover_examples/src/gpu.rs
@@ -46,9 +46,9 @@ use trace_and_split::{
 use crate::{NUM_QUERIES, POW_BITS};
 
 pub fn initialize_host_allocator_if_needed() {
-    if !ProverContext::is_concurrent_host_allocator_initialized() {
+    if !ProverContext::is_global_host_allocator_initialized() {
         // allocate 8 x 1 GB ((1 << 8) << 22) of pinned host memory with 4 MB (1 << 22) chunking
-        ProverContext::initialize_concurrent_host_allocator(8, 1 << 8, 22).unwrap();
+        ProverContext::initialize_global_host_allocator(8, 1 << 8, 22).unwrap();
     }
 }
 

--- a/circuit_defs/setups/src/lib.rs
+++ b/circuit_defs/setups/src/lib.rs
@@ -113,6 +113,7 @@ pub fn delegation_factories_for_machine<C: MachineConfig, A: GoodAllocator>(
                         blake2_with_control_factory_fn(
                             blake2_with_compression::DELEGATION_TYPE_ID as u16,
                             blake2_with_compression::NUM_DELEGATION_CYCLES,
+                            A::default(),
                         )
                     })
                         as Box<dyn Fn() -> prover::tracers::delegation::DelegationWitness<A>>,
@@ -123,6 +124,7 @@ pub fn delegation_factories_for_machine<C: MachineConfig, A: GoodAllocator>(
                         bigint_with_control_factory_fn(
                             bigint_with_control::DELEGATION_TYPE_ID as u16,
                             bigint_with_control::NUM_DELEGATION_CYCLES,
+                            A::default(),
                         )
                     })
                         as Box<dyn Fn() -> prover::tracers::delegation::DelegationWitness<A>>,
@@ -139,6 +141,7 @@ pub fn delegation_factories_for_machine<C: MachineConfig, A: GoodAllocator>(
                     blake2_with_control_factory_fn(
                         blake2_with_compression::DELEGATION_TYPE_ID as u16,
                         blake2_with_compression::NUM_DELEGATION_CYCLES,
+                        A::default(),
                     )
                 })
                     as Box<dyn Fn() -> prover::tracers::delegation::DelegationWitness<A>>,

--- a/gpu_prover/Cargo.toml
+++ b/gpu_prover/Cargo.toml
@@ -29,6 +29,7 @@ era_cudart_sys = "0.154"
 crossbeam-channel = "0.5"
 crossbeam-utils = "0.8"
 nvtx = "1"
+rayon = "1.11"
 transpose = "0.2"
 
 [features]

--- a/gpu_prover/src/execution/cpu_worker.rs
+++ b/gpu_prover/src/execution/cpu_worker.rs
@@ -14,7 +14,6 @@ use prover::risc_v_simulator::abstractions::non_determinism::NonDeterminismCSRSo
 use prover::risc_v_simulator::cycle::state_new::RiscV32StateForUnrolledProver;
 use prover::risc_v_simulator::cycle::MachineConfig;
 use prover::risc_v_simulator::delegations::DelegationsCSRProcessor;
-use prover::tracers::delegation::DelegationWitness;
 use prover::ShuffleRamSetupAndTeardown;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -57,19 +56,19 @@ pub enum CpuWorkerMode<A: GoodAllocator> {
     TraceTouchedRam {
         circuit_type: MainCircuitType,
         skip_set: HashSet<(CircuitType, usize)>,
-        free_setup_and_teardowns: Receiver<ShuffleRamSetupAndTeardown<A>>,
+        free_allocator: Receiver<A>,
     },
     TraceCycles {
         circuit_type: MainCircuitType,
         skip_set: HashSet<(CircuitType, usize)>,
         split_count: usize,
         split_index: usize,
-        free_cycle_tracing_data: Receiver<CycleTracingData<A>>,
+        free_allocator: Receiver<A>,
     },
     TraceDelegations {
         skip_set: HashSet<(CircuitType, usize)>,
         delegation_num_requests: HashMap<DelegationCircuitType, usize>,
-        free_delegation_witnesses: HashMap<DelegationCircuitType, Receiver<DelegationWitness<A>>>,
+        free_allocator: Receiver<A>,
     },
 }
 
@@ -88,7 +87,7 @@ pub fn get_cpu_worker_func<C: MachineConfig, A: GoodAllocator + 'static>(
             CpuWorkerMode::TraceTouchedRam {
                 circuit_type,
                 skip_set,
-                free_setup_and_teardowns,
+                free_allocator,
             } => trace_touched_ram::<C, A>(
                 batch_id,
                 worker_id,
@@ -97,7 +96,7 @@ pub fn get_cpu_worker_func<C: MachineConfig, A: GoodAllocator + 'static>(
                 binary,
                 non_determinism,
                 skip_set,
-                free_setup_and_teardowns,
+                free_allocator,
                 results,
             ),
             CpuWorkerMode::TraceCycles {
@@ -105,7 +104,7 @@ pub fn get_cpu_worker_func<C: MachineConfig, A: GoodAllocator + 'static>(
                 skip_set,
                 split_count,
                 split_index,
-                free_cycle_tracing_data,
+                free_allocator,
             } => trace_cycles::<C, A>(
                 batch_id,
                 worker_id,
@@ -116,13 +115,13 @@ pub fn get_cpu_worker_func<C: MachineConfig, A: GoodAllocator + 'static>(
                 skip_set,
                 split_count,
                 split_index,
-                free_cycle_tracing_data,
+                free_allocator,
                 results,
             ),
             CpuWorkerMode::TraceDelegations {
                 skip_set,
                 delegation_num_requests,
-                free_delegation_witnesses,
+                free_allocator,
             } => trace_delegations::<C, A>(
                 batch_id,
                 worker_id,
@@ -131,7 +130,7 @@ pub fn get_cpu_worker_func<C: MachineConfig, A: GoodAllocator + 'static>(
                 non_determinism,
                 skip_set,
                 delegation_num_requests,
-                free_delegation_witnesses,
+                free_allocator,
                 results,
             ),
         };
@@ -147,7 +146,7 @@ fn trace_touched_ram<C: MachineConfig, A: GoodAllocator>(
     binary: impl Deref<Target = impl Deref<Target = [u32]>>,
     non_determinism: impl Deref<Target = impl NonDeterminism>,
     skip_set: HashSet<(CircuitType, usize)>,
-    free_setup_and_teardowns: Receiver<ShuffleRamSetupAndTeardown<A>>,
+    free_allocator: Receiver<A>,
     results: Sender<WorkerResult<A>>,
 ) {
     trace!("BATCH[{batch_id}] CPU_WORKER[{worker_id}] worker for tracing touched RAM started");
@@ -266,7 +265,9 @@ fn trace_touched_ram<C: MachineConfig, A: GoodAllocator>(
                 index
             );
         } else {
-            let mut setup_and_teardown = free_setup_and_teardowns.recv().unwrap();
+            let allocator = free_allocator.recv().unwrap();
+            let lazy_init_data = Vec::with_capacity_in(cycles_per_chunk, allocator);
+            let mut setup_and_teardown = ShuffleRamSetupAndTeardown { lazy_init_data };
             unsafe { setup_and_teardown.lazy_init_data.set_len(cycles_per_chunk) };
             chunker.populate_next_chunk(&mut setup_and_teardown.lazy_init_data);
             let chunk = Some(setup_and_teardown);
@@ -308,7 +309,7 @@ fn trace_cycles<C: MachineConfig, A: GoodAllocator + 'static>(
     skip_set: HashSet<(CircuitType, usize)>,
     split_count: usize,
     split_index: usize,
-    free_cycle_tracing_data: Receiver<CycleTracingData<A>>,
+    free_allocator: Receiver<A>,
     results: Sender<WorkerResult<A>>,
 ) {
     trace!("BATCH[{batch_id}] CPU_WORKER[{worker_id}] worker for tracing cycles started");
@@ -337,7 +338,9 @@ fn trace_cycles<C: MachineConfig, A: GoodAllocator + 'static>(
         if chunk_index % split_count == split_index
             && !skip_set.contains(&(CircuitType::Main(circuit_type), chunk_index))
         {
-            let cycle_tracing_data = free_cycle_tracing_data.recv().unwrap();
+            let allocator = free_allocator.recv().unwrap();
+            let per_cycle_data = Vec::with_capacity_in(cycles_per_chunk, allocator);
+            let cycle_tracing_data = CycleTracingData { per_cycle_data };
             trace!(
                 "BATCH[{batch_id}] CPU_WORKER[{worker_id}] tracing cycles for chunk {chunk_index}"
             );
@@ -425,7 +428,7 @@ fn trace_delegations<C: MachineConfig, A: GoodAllocator + 'static>(
     non_determinism: impl Deref<Target = impl NonDeterminism>,
     skip_set: HashSet<(CircuitType, usize)>,
     delegation_num_requests: HashMap<DelegationCircuitType, usize>,
-    free_delegation_witnesses: HashMap<DelegationCircuitType, Receiver<DelegationWitness<A>>>,
+    free_allocator: Receiver<A>,
     results: Sender<WorkerResult<A>>,
 ) {
     trace!("BATCH[{batch_id}] CPU_WORKER[{worker_id}] worker for tracing delegations started");
@@ -479,11 +482,9 @@ fn trace_delegations<C: MachineConfig, A: GoodAllocator + 'static>(
             };
             DelegationTracingType::Counter(counter)
         } else {
-            let witness = free_delegation_witnesses
-                .get(&circuit_type)
-                .unwrap()
-                .recv()
-                .unwrap();
+            let allocator = free_allocator.recv().unwrap();
+            let factory = circuit_type.get_witness_factory_fn();
+            let witness = factory(allocator);
             DelegationTracingType::Witness(witness)
         }
     };

--- a/gpu_prover/src/tests.rs
+++ b/gpu_prover/src/tests.rs
@@ -73,7 +73,7 @@ fn init_logger() {
 fn test_prove_hashed_fibonacci() -> CudaResult<()> {
     init_logger();
     let instant = std::time::Instant::now();
-    ProverContext::initialize_concurrent_host_allocator(4, 1 << 8, 22)?;
+    ProverContext::initialize_global_host_allocator(4, 1 << 8, 22)?;
     let mut prover_context_config = ProverContextConfig::default();
     prover_context_config.allocation_block_log_size = 22;
     let prover_context = ProverContext::new(&prover_context_config)?;
@@ -128,7 +128,7 @@ fn test_prove_hashed_fibonacci() -> CudaResult<()> {
 fn bench_prove_hashed_fibonacci() -> CudaResult<()> {
     init_logger();
     let instant = std::time::Instant::now();
-    ProverContext::initialize_concurrent_host_allocator(4, 1 << 8, 22)?;
+    ProverContext::initialize_global_host_allocator(4, 1 << 8, 22)?;
     println!("host allocator initialized in {:?}", instant.elapsed());
     let instant = std::time::Instant::now();
     let device_count = get_device_count()?;

--- a/prover/src/tracers/delegation.rs
+++ b/prover/src/tracers/delegation.rs
@@ -102,6 +102,7 @@ impl<A: GoodAllocator> DelegationWitness<A> {
 pub fn blake2_with_control_factory_fn<A: GoodAllocator>(
     delegation_type: u16,
     num_requests: usize,
+    allocator: A,
 ) -> DelegationWitness<A> {
     let capacity = num_requests + 1;
     assert!(
@@ -136,17 +137,18 @@ pub fn blake2_with_control_factory_fn<A: GoodAllocator>(
             x11_indirect_access_properties,
         ], // rest is unreachable
 
-        write_timestamp: Vec::with_capacity_in(capacity, A::default()),
+        write_timestamp: Vec::with_capacity_in(capacity, allocator.clone()),
 
-        register_accesses: Vec::with_capacity_in(capacity * 4, A::default()),
-        indirect_reads: Vec::with_capacity_in(capacity * 16, A::default()),
-        indirect_writes: Vec::with_capacity_in(capacity * 24, A::default()),
+        register_accesses: Vec::with_capacity_in(capacity * 4, allocator.clone()),
+        indirect_reads: Vec::with_capacity_in(capacity * 16, allocator.clone()),
+        indirect_writes: Vec::with_capacity_in(capacity * 24, allocator),
     }
 }
 
 pub fn bigint_with_control_factory_fn<A: GoodAllocator>(
     delegation_type: u16,
     num_requests: usize,
+    allocator: A,
 ) -> DelegationWitness<A> {
     let capacity = num_requests + 1;
     assert!(
@@ -181,10 +183,10 @@ pub fn bigint_with_control_factory_fn<A: GoodAllocator>(
             x11_indirect_access_properties,
         ], // rest is unreachable
 
-        write_timestamp: Vec::with_capacity_in(capacity, A::default()),
+        write_timestamp: Vec::with_capacity_in(capacity, allocator.clone()),
 
-        register_accesses: Vec::with_capacity_in(capacity * 3, A::default()),
-        indirect_reads: Vec::with_capacity_in(capacity * 8, A::default()),
-        indirect_writes: Vec::with_capacity_in(capacity * 8, A::default()),
+        register_accesses: Vec::with_capacity_in(capacity * 3, allocator.clone()),
+        indirect_reads: Vec::with_capacity_in(capacity * 8, allocator.clone()),
+        indirect_writes: Vec::with_capacity_in(capacity * 8, allocator.clone()),
     }
 }

--- a/prover/src/witness_evaluator/ext_calls_with_gpu_tracers.rs
+++ b/prover/src/witness_evaluator/ext_calls_with_gpu_tracers.rs
@@ -88,8 +88,9 @@ where
         if *delegation_type == BLAKE2_ROUND_FUNCTION_WITH_EXTENDED_CONTROL_ACCESS_ID {
             let num_requests_per_circuit = circuit.num_requests_per_circuit;
             let delegation_type = *delegation_type as u16;
-            let factory_fn =
-                move || blake2_with_control_factory_fn(delegation_type, num_requests_per_circuit);
+            let factory_fn = move || {
+                blake2_with_control_factory_fn(delegation_type, num_requests_per_circuit, Global)
+            };
             factories.insert(
                 delegation_type,
                 Box::new(factory_fn) as Box<dyn Fn() -> DelegationWitness>,
@@ -97,8 +98,9 @@ where
         } else if *delegation_type == U256_OPS_WITH_CONTROL_ACCESS_ID {
             let num_requests_per_circuit = circuit.num_requests_per_circuit;
             let delegation_type = *delegation_type as u16;
-            let factory_fn =
-                move || bigint_with_control_factory_fn(delegation_type, num_requests_per_circuit);
+            let factory_fn = move || {
+                bigint_with_control_factory_fn(delegation_type, num_requests_per_circuit, Global)
+            };
             factories.insert(
                 delegation_type,
                 Box::new(factory_fn) as Box<dyn Fn() -> DelegationWitness>,


### PR DESCRIPTION
## What ❔

This PR implements a new logic for the rotation of trace buffers.

## Why ❔

The old way had separate buffers allocated for each type of circuit, as more circuit will be introduced, this will not work well, therefore a new logic is implemented that is using allocators with unified size for all types of buffer allocations.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.