### PR TITLE
chore: Pin rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2025-05-20"
 


### PR DESCRIPTION
Given airbender doesn't compile under any nightly, nightly should be pinned. This PR pins the version to a version that builds the repository (albeit newer/older versions might do as well)