### PR TITLE
docs: fix typos in doc and code comments

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -6,7 +6,7 @@
 To run the Airbender, you need three things:
 * a cli tool (tools/cli)
 * your compiled program (app.bin)
-* opitonally - file with inputs to your program.
+* optionally - file with inputs to your program.
 
 The TL;DR of creating a proof is (run this from tools/cli directory):
 
@@ -83,7 +83,7 @@ Most programs require reading external data. This is done via a special CSR regi
 Example: `examples/dynamic_fibonacci` demonstrates reading input (n) and computing the n-th Fibonacci number.
 
 ### Delegations (Custom Circuits)
-Custom circuits are triggered using dedicated CSR IDs. Currently, we have 2 delegation circtuits - one for blake and one for big integer.
+Custom circuits are triggered using dedicated CSR IDs. Currently, we have 2 delegation circuits - one for blake and one for big integer.
 
 
 **How It Works:**


### PR DESCRIPTION
## What ❔

corrected typos in code comments and documentation:

* `opitonally` → `optionally`
* `circtuits` → `circuits`

## Why ❔

these typos could cause confusion.
fixing them improves clarity and ensures documentation matches the intended meaning.

## Is this a breaking change?

* [ ] Yes
* [x] No

## Checklist

* [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
* [ ] Tests for the changes have been added / updated.
* [x] Documentation comments have been added / updated.
* [ ] Code has been formatted.