### PR TITLE
feat(gpu_prover): coset and tree recomputations

### DIFF
--- a/circuit_defs/prover_examples/src/gpu.rs
+++ b/circuit_defs/prover_examples/src/gpu.rs
@@ -256,8 +256,14 @@ pub fn gpu_prove_image_execution_for_machine_with_gpu_tracers<
         let log_domain_size = trace_len.trailing_zeros();
         let log_tree_cap_size =
             OPTIMAL_FOLDING_PROPERTIES[log_domain_size as usize].total_caps_size_log2 as u32;
-        let mut setup =
-            SetupPrecomputations::new(circuit, log_lde_factor, log_tree_cap_size, prover_context)?;
+        let mut setup = SetupPrecomputations::new(
+            circuit,
+            log_lde_factor,
+            log_tree_cap_size,
+            false,
+            false,
+            prover_context,
+        )?;
         setup.schedule_transfer(Arc::new(setup_evaluations), prover_context)?;
         setup
     };
@@ -302,6 +308,8 @@ pub fn gpu_prove_image_execution_for_machine_with_gpu_tracers<
                 NUM_QUERIES,
                 POW_BITS,
                 None,
+                false,
+                false,
                 prover_context,
             )?;
             job.finish()?
@@ -372,6 +380,8 @@ pub fn gpu_prove_image_execution_for_machine_with_gpu_tracers<
                 circuit,
                 log_lde_factor,
                 log_tree_cap_size,
+                false,
+                false,
                 prover_context,
             )?;
             setup.schedule_transfer(Arc::new(setup_evaluations), prover_context)?;
@@ -407,6 +417,8 @@ pub fn gpu_prove_image_execution_for_machine_with_gpu_tracers<
                     NUM_QUERIES,
                     POW_BITS,
                     None,
+                    false,
+                    false,
                     prover_context,
                 )?;
                 job.finish()?

--- a/gpu_prover/native/ntt/ntt.cuh
+++ b/gpu_prover/native/ntt/ntt.cuh
@@ -151,20 +151,22 @@ DEVICE_FORCEINLINE void load_noninitial_twiddles_warp(e2f *twiddle_cache, const 
 }
 
 // Assumes coset_idx > 0
+template <bool inverse = false>
 DEVICE_FORCEINLINE e2f get_lde_scale_and_shift_factor(const unsigned k, const unsigned log_extension_degree, const unsigned coset_idx, const unsigned log_n) {
   // following the notation of https://eprint.iacr.org/2023/824.pdf Section 4
   const unsigned tau_power_of_w = coset_idx << (CIRCLE_GROUP_LOG_ORDER - log_n - log_extension_degree);
   const unsigned H_over_two = 1u << (log_n - 1);
   const unsigned power_of_w = k >= H_over_two ? tau_power_of_w * (k - H_over_two) : (1u << CIRCLE_GROUP_LOG_ORDER) - tau_power_of_w * (H_over_two - k);
-  return get_power_of_w(power_of_w, false);
+  return get_power_of_w(power_of_w, inverse);
 }
 
+template <bool inverse = false>
 DEVICE_FORCEINLINE e2f lde_scale_and_shift(const e2f Zk, const unsigned k, const unsigned log_extension_degree, const unsigned coset_idx,
                                            const unsigned log_n) {
   // Assumes the 0th coset is the main domain, as in zksync_airbender
   if (coset_idx == 0)
     return Zk;
-  const auto gauged_shift_factor = get_lde_scale_and_shift_factor(k, log_extension_degree, coset_idx, log_n);
+  const auto gauged_shift_factor = get_lde_scale_and_shift_factor<inverse>(k, log_extension_degree, coset_idx, log_n);
   return e2f::mul(Zk, gauged_shift_factor);
 }
 

--- a/gpu_prover/src/prover/setup.rs
+++ b/gpu_prover/src/prover/setup.rs
@@ -18,6 +18,8 @@ impl<'a> SetupPrecomputations<'a> {
         circuit: &CompiledCircuitArtifact<BF>,
         log_lde_factor: u32,
         log_tree_cap_size: u32,
+        recompute_cosets: bool,
+        recompute_trees: bool,
         context: &ProverContext,
     ) -> CudaResult<Self> {
         let trace_len = circuit.trace_len;
@@ -31,6 +33,9 @@ impl<'a> SetupPrecomputations<'a> {
             log_tree_cap_size,
             columns_count,
             true,
+            true,
+            recompute_cosets,
+            recompute_trees,
             context,
         )?;
         let transfer = Transfer::new()?;
@@ -47,7 +52,7 @@ impl<'a> SetupPrecomputations<'a> {
         trace: Arc<Vec<BF, impl GoodAllocator + 'a>>,
         context: &ProverContext,
     ) -> CudaResult<()> {
-        let dst = self.trace_holder.get_evaluations_mut();
+        let dst = self.trace_holder.get_uninit_evaluations_mut();
         self.transfer.schedule(trace, dst, context)?;
         self.transfer.record_transferred(context)
     }

--- a/gpu_prover/src/tests.rs
+++ b/gpu_prover/src/tests.rs
@@ -60,6 +60,10 @@ use worker::Worker;
 
 pub const NUM_QUERIES: usize = 53;
 pub const POW_BITS: u32 = 28;
+const RECOMPUTE_COSETS_FOR_CORRECTNESS: bool = true;
+const RECOMPUTE_TREES_FOR_CORRECTNESS: bool = true;
+const RECOMPUTE_COSETS_FOR_BENCHMARKS: bool = false;
+const RECOMPUTE_TREES_FOR_BENCHMARKS: bool = false;
 
 fn init_logger() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
@@ -475,6 +479,8 @@ fn prove_image_execution_for_machine_with_gpu_tracers<
                 circuit,
                 log_lde_factor,
                 log_tree_cap_size,
+                RECOMPUTE_COSETS_FOR_CORRECTNESS,
+                RECOMPUTE_TREES_FOR_CORRECTNESS,
                 prover_context,
             )?;
             setup.schedule_transfer(Arc::new(setup_evaluations), prover_context)?;
@@ -513,6 +519,8 @@ fn prove_image_execution_for_machine_with_gpu_tracers<
                 NUM_QUERIES,
                 POW_BITS,
                 Some(cpu_proof.pow_nonce),
+                RECOMPUTE_COSETS_FOR_CORRECTNESS,
+                RECOMPUTE_TREES_FOR_CORRECTNESS,
                 prover_context,
             )?;
             job.finish()?
@@ -627,6 +635,8 @@ fn prove_image_execution_for_machine_with_gpu_tracers<
                     &gpu_circuit,
                     log_lde_factor,
                     log_tree_cap_size,
+                    RECOMPUTE_COSETS_FOR_CORRECTNESS,
+                    RECOMPUTE_TREES_FOR_CORRECTNESS,
                     prover_context,
                 )?;
                 setup.schedule_transfer(Arc::new(setup_evaluations), prover_context)?;
@@ -647,6 +657,8 @@ fn prove_image_execution_for_machine_with_gpu_tracers<
                     NUM_QUERIES,
                     POW_BITS,
                     Some(cpu_proof.pow_nonce),
+                    RECOMPUTE_COSETS_FOR_CORRECTNESS,
+                    RECOMPUTE_TREES_FOR_CORRECTNESS,
                     prover_context,
                 )?;
                 job.finish()?
@@ -753,8 +765,14 @@ fn bench_proof_main<ND: NonDeterminismCSRSource<VectorMemoryImplWithRom>>(
     let mut setups = Vec::with_capacity(contexts.len());
     for context in contexts.iter() {
         context.switch_to_device()?;
-        let mut setup =
-            SetupPrecomputations::new(circuit, log_lde_factor, log_tree_cap_size, context)?;
+        let mut setup = SetupPrecomputations::new(
+            circuit,
+            log_lde_factor,
+            log_tree_cap_size,
+            RECOMPUTE_COSETS_FOR_BENCHMARKS,
+            RECOMPUTE_TREES_FOR_BENCHMARKS,
+            context,
+        )?;
         setup.schedule_transfer(setup_evaluations.clone(), context)?;
         setups.push(setup);
     }
@@ -781,6 +799,8 @@ fn bench_proof_main<ND: NonDeterminismCSRSource<VectorMemoryImplWithRom>>(
                 NUM_QUERIES,
                 POW_BITS,
                 None,
+                RECOMPUTE_COSETS_FOR_BENCHMARKS,
+                RECOMPUTE_TREES_FOR_BENCHMARKS,
                 context,
             )?;
             job.finish()?;
@@ -840,6 +860,8 @@ fn bench_proof_main<ND: NonDeterminismCSRSource<VectorMemoryImplWithRom>>(
                 NUM_QUERIES,
                 POW_BITS,
                 None,
+                RECOMPUTE_COSETS_FOR_BENCHMARKS,
+                RECOMPUTE_TREES_FOR_BENCHMARKS,
                 context,
             )?;
             let mut job = Some(job);


### PR DESCRIPTION
## What ❔

This PR implements the re-computation capability for cosets and trees inside the proving workflow. 

## Why ❔

Re-conputing cosets and/or trees for prover stages instead of keeping them trades memory usage for performance allows us to trade VRAM usage for performance.
With this capability we are able to prove the reduced risc-v 2^23 circuit on GPUs with 24GB VRAM with a small performance penalty (estimated to be on the order of 10% on the L4 GPU).
With this feature we can switch our recursion strategy to exclusive use of the 2^23 sized reduced risc-v circuit and therefore improve the reduction performance significantly and reduce recursion complexity.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.