### PR TITLE
docs: fix typo in verification function name

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -44,7 +44,7 @@ cargo run --release prove  --bin ../../examples/basic_fibonacci/app.bin --output
 
 where the .bin file is the riscV compiled file. You can see more instructions on how to create such file in the basic_fibonacci dir.
 
-**Compilation times** - you might want to use `--profile cli` to minimise the compilation time, as --release might take a long time to compile the veirfication code, and --dev might be generating a proof for a really long time.
+**Compilation times** - you might want to use `--profile cli` to minimise the compilation time, as --release might take a long time to compile the verification code, and --dev might be generating a proof for a really long time.
 
 ### Proofs
 You will get one or more proofs as the result - depending on the length of your program (proofs in format `proof_XX.json`) and the amount of delegations (precompiles) that you used (proofs in format `delegation_PRECOMPILE-ID_XX.json`)


### PR DESCRIPTION
## What ❔

<img width="903" height="52" alt="Снимок экрана 2025-09-14 в 17 44 18" src="https://github.com/user-attachments/assets/12aba270-9529-412f-9380-7cd2b6516169" />

corrected a typo in the code where `veirfication` was mistakenly used. Changed it to `verification`.

## Why ❔

to ensure consistency and prevent potential errors caused by the misspelled function/variable name.

## Is this a breaking change?

* [ ] Yes
* [x] No

## Checklist

* [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
* [ ] Tests for the changes have been added / updated.
* [ ] Documentation comments have been added / updated.
* [ ] Code has been formatted.