### PR TITLE
fix(prover_examples): correct the argument in `trace_execution_for_gpu` call

### DIFF
--- a/circuit_defs/prover_examples/src/lib.rs
+++ b/circuit_defs/prover_examples/src/lib.rs
@@ -234,7 +234,6 @@ pub fn prove_image_execution_for_machine_with_gpu_tracers<
 ) -> (Vec<Proof>, Vec<(u32, Vec<Proof>)>, Vec<FinalRegisterValue>) {
     let trace_len = risc_v_circuit_precomputations.compiled_circuit.trace_len;
     let cycles_per_circuit = trace_len - 1;
-    let max_cycles_to_run = num_instances_upper_bound * cycles_per_circuit;
 
     let lde_factor = risc_v_circuit_precomputations
         .lde_precomputations
@@ -246,7 +245,7 @@ pub fn prove_image_execution_for_machine_with_gpu_tracers<
         delegation_circuits_witness,
         final_register_values,
     ) = trace_execution_for_gpu::<ND, C, A>(
-        max_cycles_to_run,
+        num_instances_upper_bound,
         bytecode,
         non_determinism,
         trace_len,


### PR DESCRIPTION
## What ❔

This PR fixes the `max_cycles_to_run` argument value in the `trace_execution_for_gpu` call, it was incorrectly called with number of cycles instead of number of instances.