### PR TITLE
feat: adapt cli run to parse sequencer json input format

### DIFF
--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -45,6 +45,8 @@ sha3 = { package = "sha3_ce", version = "=0.10.6" }
 gpu_prover = { workspace = true, optional = true }
 
 env_logger = "0.11"
+base64 = "0.21.7"
+
 
 [features]
 

--- a/tools/cli/src/prover_utils.rs
+++ b/tools/cli/src/prover_utils.rs
@@ -61,7 +61,7 @@ pub fn u32_from_hex_string(hex_string: &str) -> Vec<u32> {
 pub fn create_proofs(
     bin_path: &String,
     output_dir: &String,
-    input_hex: &Option<String>,
+    input_data: Option<Vec<u32>>,
     prev_metadata: &Option<String>,
     machine: &Machine,
     cycles: &Option<usize>,
@@ -83,11 +83,7 @@ pub fn create_proofs(
         num_instances
     );
 
-    let non_determinism_data = if let Some(input_hex) = input_hex {
-        u32_from_hex_string(input_hex)
-    } else {
-        vec![]
-    };
+    let non_determinism_data = input_data.unwrap_or_default();
 
     // Serialization and deserialization of artifacts
     // (as requested by user arguments) can take a lot of time,


### PR DESCRIPTION
## What ❔

* CLI 'run' command can now read inputs in the sequencer format (json + base64 encoded)
* It can also fetch them from sequencer directly.

Example usage:

```shell
cargo run -p cli --  run --input-file ~/Desktop/proof_input.json --input-type prover-input-json --bin ../zksync-os/zksync_os/multiblock_batch_logging_enabled.bin
```


