### PR TITLE
feat(gpu_prover): setup trees offloading to and querying from host memory

### DIFF
--- a/gpu_prover/src/execution/prover.rs
+++ b/gpu_prover/src/execution/prover.rs
@@ -257,7 +257,7 @@ impl<K: Clone + Debug + Eq + Hash> ExecutionProver<K> {
         let gpu_manager = GpuManager::new(setups_to_cache, gpu_wait_group.clone());
         gpu_wait_group.wait();
         for value in binaries.values() {
-            assert!(value.precomputations.tree_caps.get().is_some());
+            assert!(value.precomputations.setup_trees_and_caps.get().is_some());
         }
         Self {
             device_count,
@@ -975,12 +975,14 @@ impl<K: Clone + Debug + Eq + Hash> ExecutionProver<K> {
             chunks_cache.as_ref().unwrap().len(),
             min(cache_capacity, maximum_cached_count)
         );
+        let caps = &self.binaries[&binary_key]
+            .precomputations
+            .setup_trees_and_caps
+            .get()
+            .unwrap()
+            .caps;
         let memory_challenges_seed = fs_transform_for_memory_and_delegation_arguments(
-            self.binaries[&binary_key]
-                .precomputations
-                .tree_caps
-                .get()
-                .unwrap(),
+            caps,
             &final_register_values,
             &main_memory_commitments,
             &delegation_memory_commitments,

--- a/gpu_prover/src/lib.rs
+++ b/gpu_prover/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(iter_array_chunks)]
 #![feature(iter_advance_by)]
 #![feature(sync_unsafe_cell)]
+#![feature(once_cell_try)]
 
 pub mod allocator;
 pub mod barycentric;

--- a/gpu_prover/src/prover/context.rs
+++ b/gpu_prover/src/prover/context.rs
@@ -8,6 +8,7 @@ use crate::device_context::DeviceContext;
 use era_cudart::device::{device_get_attribute, get_device, set_device};
 use era_cudart::memory::{memory_get_info, CudaHostAllocFlags};
 use era_cudart::result::CudaResult;
+use era_cudart::slice::{CudaSlice, CudaSliceMut};
 use era_cudart::stream::CudaStream;
 use era_cudart_sys::{CudaDeviceAttr, CudaError};
 use log::error;
@@ -349,5 +350,17 @@ impl<T: ?Sized> HostAllocation<T> {
 impl<T> HostAllocation<[T]> {
     unsafe fn new_uninit_slice(len: usize, context: &ProverContext) -> Self {
         Self(Box::new_uninit_slice_in(len, context.get_host_allocator()).assume_init())
+    }
+}
+
+impl<T> CudaSlice<T> for HostAllocation<[T]> {
+    unsafe fn as_slice(&self) -> &[T] {
+        self.0.as_slice()
+    }
+}
+
+impl<T> CudaSliceMut<T> for HostAllocation<[T]> {
+    unsafe fn as_mut_slice(&mut self) -> &mut [T] {
+        self.0.as_mut_slice()
     }
 }

--- a/gpu_prover/src/prover/memory.rs
+++ b/gpu_prover/src/prover/memory.rs
@@ -1,5 +1,5 @@
 use super::context::{ProverContext, UnsafeMutAccessor};
-use super::trace_holder::{get_tree_caps, TraceHolder};
+use super::trace_holder::{get_tree_caps, TraceHolder, TreesCacheMode};
 use super::tracing_data::{TracingDataDevice, TracingDataTransfer};
 use super::{device_tracing, BF};
 use crate::device_structures::DeviceMatrixMut;
@@ -60,7 +60,7 @@ pub fn commit_memory<'a>(
         true,
         true,
         false,
-        false,
+        TreesCacheMode::CacheFull,
         context,
     )?;
     let TracingDataTransfer {

--- a/gpu_prover/src/prover/mod.rs
+++ b/gpu_prover/src/prover/mod.rs
@@ -16,7 +16,7 @@ mod stage_3_kernels;
 mod stage_4;
 mod stage_4_kernels;
 mod stage_5;
-pub(crate) mod trace_holder;
+pub mod trace_holder;
 pub mod tracing_data;
 pub mod transfer;
 

--- a/gpu_prover/src/prover/setup.rs
+++ b/gpu_prover/src/prover/setup.rs
@@ -1,16 +1,27 @@
 use super::context::ProverContext;
-use super::trace_holder::TraceHolder;
+use super::trace_holder::{get_tree_caps, TraceHolder, TreesCacheMode, TreesHolder};
 use super::transfer::Transfer;
 use super::BF;
+use crate::blake2s::Digest;
 use cs::one_row_compiler::CompiledCircuitArtifact;
+use era_cudart::memory::memory_copy_async;
 use era_cudart::result::CudaResult;
 use fft::GoodAllocator;
+use itertools::Itertools;
+use prover::merkle_trees::MerkleTreeCapVarLength;
 use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct SetupTreesAndCaps {
+    pub trees: Vec<Arc<Box<[Digest]>>>,
+    pub caps: Arc<Vec<MerkleTreeCapVarLength>>,
+}
 
 pub struct SetupPrecomputations<'a> {
     pub(crate) trace_holder: TraceHolder<BF>,
     pub(crate) transfer: Transfer<'a>,
-    pub(crate) is_commitment_produced: bool,
+    pub(crate) trees_and_caps: SetupTreesAndCaps,
+    pub(crate) is_extended: bool,
 }
 
 impl<'a> SetupPrecomputations<'a> {
@@ -19,7 +30,7 @@ impl<'a> SetupPrecomputations<'a> {
         log_lde_factor: u32,
         log_tree_cap_size: u32,
         recompute_cosets: bool,
-        recompute_trees: bool,
+        trees_and_caps: SetupTreesAndCaps,
         context: &ProverContext,
     ) -> CudaResult<Self> {
         let trace_len = circuit.trace_len;
@@ -35,7 +46,7 @@ impl<'a> SetupPrecomputations<'a> {
             true,
             true,
             recompute_cosets,
-            recompute_trees,
+            TreesCacheMode::CacheNone,
             context,
         )?;
         let transfer = Transfer::new()?;
@@ -43,7 +54,8 @@ impl<'a> SetupPrecomputations<'a> {
         Ok(Self {
             trace_holder,
             transfer,
-            is_commitment_produced: false,
+            trees_and_caps,
+            is_extended: false,
         })
     }
 
@@ -57,18 +69,104 @@ impl<'a> SetupPrecomputations<'a> {
         self.transfer.record_transferred(context)
     }
 
-    pub fn ensure_commitment_produced(&mut self, context: &ProverContext) -> CudaResult<()> {
-        if self.is_commitment_produced {
+    pub fn ensure_is_extended(&mut self, context: &ProverContext) -> CudaResult<()> {
+        if self.is_extended {
             return Ok(());
         }
-        self.produce_commitment(context)
+        self.extend(context)
     }
 
-    fn produce_commitment(&mut self, context: &ProverContext) -> CudaResult<()> {
+    fn extend(&mut self, context: &ProverContext) -> CudaResult<()> {
         self.transfer.ensure_transferred(context)?;
         self.trace_holder
-            .make_evaluations_sum_to_zero_extend_and_commit(context)?;
-        self.is_commitment_produced = true;
+            .make_evaluations_sum_to_zero_and_extend(context)?;
+        self.is_extended = true;
         Ok(())
+    }
+
+    pub fn get_trees_and_caps(
+        circuit: &CompiledCircuitArtifact<BF>,
+        log_lde_factor: u32,
+        log_tree_cap_size: u32,
+        trace: Arc<Vec<BF, impl GoodAllocator>>,
+        context: &ProverContext,
+    ) -> CudaResult<SetupTreesAndCaps> {
+        let trace_len = circuit.trace_len;
+        assert!(trace_len.is_power_of_two());
+        let log_domain_size = trace_len.trailing_zeros();
+        let columns_count = circuit.setup_layout.total_width;
+        let mut trace_holder = TraceHolder::new(
+            log_domain_size,
+            log_lde_factor,
+            0,
+            log_tree_cap_size,
+            columns_count,
+            true,
+            true,
+            false,
+            TreesCacheMode::CacheFull,
+            context,
+        )?;
+        let mut transfer = Transfer::new()?;
+        transfer.record_allocated(context)?;
+        let dst = trace_holder.get_uninit_evaluations_mut();
+        transfer.schedule(trace, dst, context)?;
+        transfer.record_transferred(context)?;
+        transfer.ensure_transferred(context)?;
+        trace_holder.make_evaluations_sum_to_zero_extend_and_commit(context)?;
+        let streams = [context.get_exec_stream(), context.get_aux_stream()];
+        for stream in streams {
+            stream.synchronize()?;
+        }
+        let caps = get_tree_caps(&trace_holder.get_tree_caps_accessors());
+        let d_trees = match &trace_holder.trees {
+            TreesHolder::Full(trees) => trees,
+            _ => unreachable!(),
+        };
+        let lde_factor = 1usize << log_lde_factor;
+        let tree_len = 1usize << (log_domain_size + 1);
+        assert!(tree_len.is_multiple_of(CHUNK_SIZE));
+        let mut trees = (0..lde_factor)
+            .into_iter()
+            .map(|_| unsafe { Box::new_uninit_slice(tree_len).assume_init() })
+            .collect_vec();
+        const CHUNK_SIZE: usize = 1 << 20; // 32 MB
+        let mut chunks = unsafe {
+            [
+                context.alloc_host_uninit_slice(CHUNK_SIZE),
+                context.alloc_host_uninit_slice(CHUNK_SIZE),
+            ]
+        };
+        let mut callbacks = transfer.callbacks;
+        let mut i = 0;
+        for (coset_index, tree) in trees.iter_mut().enumerate() {
+            let d_tree = &d_trees[coset_index];
+            assert_eq!(d_tree.len(), tree_len);
+            for (src, dst) in d_tree
+                .chunks(CHUNK_SIZE)
+                .zip_eq(tree.chunks_exact_mut(CHUNK_SIZE))
+            {
+                let stream = streams[i % 2];
+                let chunk = &mut chunks[i % 2];
+                i += 1;
+                memory_copy_async(chunk, src, stream)?;
+                let chunk = chunk.get_accessor();
+                let copy_fn = {
+                    move || unsafe {
+                        let chunk = <[Digest]>::as_ptr(chunk.get());
+                        let dst = <[Digest]>::as_ptr(dst) as *mut Digest;
+                        std::ptr::copy_nonoverlapping(chunk, dst, CHUNK_SIZE);
+                    }
+                };
+                callbacks.schedule(copy_fn, stream)?;
+            }
+        }
+        for stream in streams {
+            stream.synchronize()?;
+        }
+        drop(callbacks);
+        let trees = trees.into_iter().map(Arc::new).collect_vec();
+        let caps = Arc::new(caps);
+        Ok(SetupTreesAndCaps { trees, caps })
     }
 }

--- a/gpu_prover/src/prover/stage_1.rs
+++ b/gpu_prover/src/prover/stage_1.rs
@@ -1,7 +1,7 @@
 use super::callbacks::Callbacks;
 use super::context::{DeviceAllocation, HostAllocation, ProverContext};
 use super::setup::SetupPrecomputations;
-use super::trace_holder::TraceHolder;
+use super::trace_holder::{TraceHolder, TreesCacheMode};
 use super::tracing_data::{TracingDataDevice, TracingDataTransfer};
 use super::BF;
 use crate::allocator::tracker::AllocationPlacement;
@@ -38,7 +38,7 @@ impl StageOneOutput {
         log_lde_factor: u32,
         log_tree_cap_size: u32,
         recompute_cosets: bool,
-        recompute_trees: bool,
+        trees_cache_mode: TreesCacheMode,
         context: &ProverContext,
     ) -> CudaResult<Self> {
         let trace_len = circuit.trace_len;
@@ -54,7 +54,7 @@ impl StageOneOutput {
             true,
             true,
             recompute_cosets,
-            recompute_trees,
+            trees_cache_mode,
             context,
         )?;
         let memory_columns_count = circuit.memory_layout.total_width;
@@ -67,7 +67,7 @@ impl StageOneOutput {
             true,
             true,
             recompute_cosets,
-            recompute_trees,
+            trees_cache_mode,
             context,
         )?;
         Ok(Self {

--- a/gpu_prover/src/prover/stage_2.rs
+++ b/gpu_prover/src/prover/stage_2.rs
@@ -4,7 +4,7 @@ use super::context::{HostAllocation, ProverContext};
 use super::setup::SetupPrecomputations;
 use super::stage_1::StageOneOutput;
 pub(crate) use super::stage_2_kernels::*;
-use super::trace_holder::{flatten_tree_caps, TraceHolder};
+use super::trace_holder::{flatten_tree_caps, TraceHolder, TreesCacheMode};
 use super::{BF, E4};
 use crate::allocator::tracker::AllocationPlacement;
 use crate::device_structures::{DeviceMatrix, DeviceMatrixChunk, DeviceMatrixMut};
@@ -35,7 +35,7 @@ impl StageTwoOutput {
         log_lde_factor: u32,
         log_tree_cap_size: u32,
         recompute_cosets: bool,
-        recompute_trees: bool,
+        trees_cache_mode: TreesCacheMode,
         context: &ProverContext,
     ) -> CudaResult<Self> {
         let trace_len = circuit.trace_len;
@@ -52,7 +52,7 @@ impl StageTwoOutput {
             true,
             true,
             recompute_cosets,
-            recompute_trees,
+            trees_cache_mode,
             context,
         )?;
         Ok(Self {

--- a/gpu_prover/src/prover/stage_3.rs
+++ b/gpu_prover/src/prover/stage_3.rs
@@ -5,7 +5,7 @@ use super::setup::SetupPrecomputations;
 use super::stage_1::StageOneOutput;
 use super::stage_2::StageTwoOutput;
 use super::stage_3_kernels::*;
-use super::trace_holder::TraceHolder;
+use super::trace_holder::{TraceHolder, TreesCacheMode};
 use super::{BF, E4};
 use crate::allocator::tracker::AllocationPlacement;
 use crate::device_structures::{DeviceMatrix, DeviceMatrixMut};
@@ -41,7 +41,7 @@ impl StageThreeOutput {
         stage_2_output: &mut StageTwoOutput,
         log_lde_factor: u32,
         log_tree_cap_size: u32,
-        recompute_trees: bool,
+        trees_cache_mode: TreesCacheMode,
         callbacks: &mut Callbacks,
         context: &ProverContext,
     ) -> CudaResult<Self> {
@@ -58,7 +58,7 @@ impl StageThreeOutput {
             true,
             false,
             false,
-            recompute_trees,
+            trees_cache_mode,
             context,
         )?;
         let stream = context.get_exec_stream();

--- a/gpu_prover/src/prover/stage_4.rs
+++ b/gpu_prover/src/prover/stage_4.rs
@@ -11,7 +11,7 @@ use super::stage_4_kernels::{
 };
 use super::trace_holder::{
     allocate_tree_caps, compute_coset_evaluations, split_evaluations_pair, transfer_tree_cap,
-    CosetsHolder, TraceHolder, TreesHolder,
+    CosetsHolder, TraceHolder, TreesCacheMode, TreesHolder,
 };
 use super::{BF, E2, E4};
 use crate::allocator::tracker::AllocationPlacement;
@@ -70,7 +70,7 @@ impl StageFourOutput {
             false,
             true,
             false,
-            false,
+            TreesCacheMode::CacheFull,
             context,
         )?;
         let seed_accessor = seed.get_mut_accessor();
@@ -309,11 +309,12 @@ impl StageFourOutput {
         for (((vectorized_lde, lde), tree), caps) in vectorized_ldes
             .iter()
             .zip_eq(match &mut trace_holder.cosets {
-                CosetsHolder::Full { evaluations } => evaluations.iter_mut(),
+                CosetsHolder::Full(evaluations) => evaluations.iter_mut(),
                 CosetsHolder::Single { .. } => unreachable!(),
             })
             .zip_eq(match &mut trace_holder.trees {
-                TreesHolder::Device { trees } => trees.iter_mut(),
+                TreesHolder::Full(trees) => trees.iter_mut(),
+                TreesHolder::Partial(_) => unimplemented!(),
                 TreesHolder::None => unreachable!(),
             })
             .zip_eq(tree_caps.iter_mut())

--- a/gpu_prover/src/prover/stage_5.rs
+++ b/gpu_prover/src/prover/stage_5.rs
@@ -90,7 +90,7 @@ impl StageFiveOutput {
             }
             let folding_inputs = if i == 0 {
                 match &stage_4_output.trace_holder.cosets {
-                    CosetsHolder::Full { evaluations } => evaluations,
+                    CosetsHolder::Full(evaluations) => evaluations,
                     CosetsHolder::Single { .. } => unreachable!(),
                 }
             } else {


### PR DESCRIPTION
## What ❔

This PR implements setup trees offloading to and querying from host memory.

## Why ❔

Setup trees offloading to and reading from host memory means that no VRAM has to be allocated for setup tree storage leaving more free VRAM to work with.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.