### PR TITLE
fix: Return common_constants to blake2s_u32 deps

### DIFF
--- a/blake2s_u32/Cargo.toml
+++ b/blake2s_u32/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 
 [dependencies]
 unroll.workspace = true
+common_constants.workspace = true
 
 [dev-dependencies]
 blake2 = "*"


### PR DESCRIPTION
In https://github.com/matter-labs/zksync-airbender/pull/184 I by mistake removed `common_constants` from blake2s_u32 deps, `cargo udeps` falsely reported it because it's only used on riscv arch.

This PR restores it.