### PR TITLE
fix(riscv_transpiler,gpu_prover): prevent counter overflow in long executions

### DIFF
--- a/gpu_prover/src/execution/simulation_runner.rs
+++ b/gpu_prover/src/execution/simulation_runner.rs
@@ -260,7 +260,7 @@ impl<ND: NonDeterminismCSRSource + Send + 'static, T: TracingType + 'static>
             .map(|(a, b)| a - b)
             .collect_array::<MAX_NUM_COUNTERS>()
             .unwrap();
-        let expected_cycles = counters_diff.iter().take(6).sum::<u32>() as usize;
+        let expected_cycles = counters_diff.iter().take(6).sum::<u64>() as usize;
         assert_eq!(expected_cycles, cycles_count);
         let trace_ranges = self
             .tracing_data_producers

--- a/gpu_prover/src/execution/tracing.rs
+++ b/gpu_prover/src/execution/tracing.rs
@@ -41,7 +41,7 @@ pub(crate) trait TracingType {
     type Ranges: DataTraceRanges;
     type Producers: TracingDataProducers<Ranges = Self::Ranges>;
     type Tracer: Tracer<Ranges = Self::Ranges>;
-    type Counters: Counters + From<[u32; MAX_NUM_COUNTERS]>;
+    type Counters: Counters + From<[u64; MAX_NUM_COUNTERS]>;
 }
 
 pub(crate) struct SplitTracingType;
@@ -470,8 +470,8 @@ pub(crate) trait TracingDataProducers {
     fn process_snapshot(
         &mut self,
         snapshot_index: usize,
-        initial_counters: &[u32; MAX_NUM_COUNTERS],
-        final_counters: &[u32; MAX_NUM_COUNTERS],
+        initial_counters: &[u64; MAX_NUM_COUNTERS],
+        final_counters: &[u64; MAX_NUM_COUNTERS],
     ) -> Self::Ranges;
 
     fn finalize(self);
@@ -580,8 +580,8 @@ impl TracingDataProducers for SplitTracingDataProducers {
     fn process_snapshot(
         &mut self,
         snapshot_index: usize,
-        initial_counters: &[u32; MAX_NUM_COUNTERS],
-        final_counters: &[u32; MAX_NUM_COUNTERS],
+        initial_counters: &[u64; MAX_NUM_COUNTERS],
+        final_counters: &[u64; MAX_NUM_COUNTERS],
     ) -> Self::Ranges {
         let mut trace_ranges = SplitDataTraceRanges::default();
         for i in 0..CounterType::FormalEnd as u8 {
@@ -712,8 +712,8 @@ impl TracingDataProducers for UnifiedTracingDataProducers {
     fn process_snapshot(
         &mut self,
         snapshot_index: usize,
-        initial_counters: &[u32; MAX_NUM_COUNTERS],
-        final_counters: &[u32; MAX_NUM_COUNTERS],
+        initial_counters: &[u64; MAX_NUM_COUNTERS],
+        final_counters: &[u64; MAX_NUM_COUNTERS],
     ) -> Self::Ranges {
         let mut trace_ranges = UnifiedDataTraceRanges::default();
         let mut cycles_initial_count = 0;

--- a/riscv_transpiler/src/jit/impls.rs
+++ b/riscv_transpiler/src/jit/impls.rs
@@ -437,11 +437,11 @@ fn record_circuit_type(ops: &mut x64::Assembler, circuit_type: CounterType, by: 
 
     if by == 1 {
         dynasm!(ops
-            ; inc DWORD [rsp + 4 * (x as i32) + (MachineState::COUNTERS_OFFSET as i32)]
+            ; inc QWORD [rsp + 8 * (x as i32) + (MachineState::COUNTERS_OFFSET as i32)]
         );
     } else {
         dynasm!(ops
-            ; add DWORD [rsp + 4 * (x as i32) + (MachineState::COUNTERS_OFFSET as i32)], by as i32
+            ; add QWORD [rsp + 8 * (x as i32) + (MachineState::COUNTERS_OFFSET as i32)], by as i32
         );
     }
 }

--- a/riscv_transpiler/src/jit/mod.rs
+++ b/riscv_transpiler/src/jit/mod.rs
@@ -66,7 +66,7 @@ const _: () = const {
 pub struct MachineState {
     pub registers: [u32; 32], // aligned at 16, so we can write XMMs directly into the stack
     pub register_timestamps: [TimestampScalar; 32],
-    pub counters: [u32; MAX_NUM_COUNTERS],
+    pub counters: [u64; MAX_NUM_COUNTERS],
     pub pc: u32,
     pub timestamp: TimestampScalar,
     pub(crate) context_ptr: *mut (),

--- a/riscv_transpiler/src/jit/tests.rs
+++ b/riscv_transpiler/src/jit/tests.rs
@@ -355,39 +355,39 @@ fn run_and_compare() {
         // println!("Final instr = 0x{:08x}", text[(reference_state.pc as usize/4) - 1]);
 
         assert_eq!(
-            reference_state.counters.add_sub_family as u32,
+            reference_state.counters.add_sub_family as u64,
             jit_state.counters[CounterType::AddSubLui as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.slt_branch_family as u32,
+            reference_state.counters.slt_branch_family as u64,
             jit_state.counters[CounterType::BranchSlt as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.binary_shift_csr_family as u32,
+            reference_state.counters.binary_shift_csr_family as u64,
             jit_state.counters[CounterType::ShiftBinaryCsr as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.mul_div_family as u32,
+            reference_state.counters.mul_div_family as u64,
             jit_state.counters[CounterType::MulDiv as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.word_size_mem_family as u32,
+            reference_state.counters.word_size_mem_family as u64,
             jit_state.counters[CounterType::MemWord as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.subword_size_mem_family as u32,
+            reference_state.counters.subword_size_mem_family as u64,
             jit_state.counters[CounterType::MemSubword as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.blake_calls as u32,
+            reference_state.counters.blake_calls as u64,
             jit_state.counters[CounterType::BlakeDelegation as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.bigint_calls as u32,
+            reference_state.counters.bigint_calls as u64,
             jit_state.counters[CounterType::BigintDelegation as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.keccak_calls as u32,
+            reference_state.counters.keccak_calls as u64,
             jit_state.counters[CounterType::KeccakDelegation as u8 as usize]
         );
 
@@ -566,39 +566,39 @@ fn run_recursion_and_compare() {
         // println!("Final instr = 0x{:08x}", text[(reference_state.pc as usize/4) - 1]);
 
         assert_eq!(
-            reference_state.counters.add_sub_family as u32,
+            reference_state.counters.add_sub_family as u64,
             jit_state.counters[CounterType::AddSubLui as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.slt_branch_family as u32,
+            reference_state.counters.slt_branch_family as u64,
             jit_state.counters[CounterType::BranchSlt as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.binary_shift_csr_family as u32,
+            reference_state.counters.binary_shift_csr_family as u64,
             jit_state.counters[CounterType::ShiftBinaryCsr as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.mul_div_family as u32,
+            reference_state.counters.mul_div_family as u64,
             jit_state.counters[CounterType::MulDiv as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.word_size_mem_family as u32,
+            reference_state.counters.word_size_mem_family as u64,
             jit_state.counters[CounterType::MemWord as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.subword_size_mem_family as u32,
+            reference_state.counters.subword_size_mem_family as u64,
             jit_state.counters[CounterType::MemSubword as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.blake_calls as u32,
+            reference_state.counters.blake_calls as u64,
             jit_state.counters[CounterType::BlakeDelegation as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.bigint_calls as u32,
+            reference_state.counters.bigint_calls as u64,
             jit_state.counters[CounterType::BigintDelegation as u8 as usize]
         );
         assert_eq!(
-            reference_state.counters.keccak_calls as u32,
+            reference_state.counters.keccak_calls as u64,
             jit_state.counters[CounterType::KeccakDelegation as u8 as usize]
         );
 

--- a/riscv_transpiler/src/vm/mod.rs
+++ b/riscv_transpiler/src/vm/mod.rs
@@ -59,7 +59,7 @@ impl<C: Counters> State<C> {
     }
 }
 
-impl<C: Counters + From<[u32; MAX_NUM_COUNTERS]>> From<MachineState> for State<C> {
+impl<C: Counters + From<[u64; MAX_NUM_COUNTERS]>> From<MachineState> for State<C> {
     fn from(state: MachineState) -> Self {
         Self {
             registers: std::array::from_fn(|i| Register {

--- a/riscv_transpiler/src/vm/replay_snapshotter.rs
+++ b/riscv_transpiler/src/vm/replay_snapshotter.rs
@@ -119,8 +119,8 @@ impl Counters for DelegationsAndFamiliesCounters {
     }
 }
 
-impl From<[u32; MAX_NUM_COUNTERS]> for DelegationsAndFamiliesCounters {
-    fn from(counters: [u32; MAX_NUM_COUNTERS]) -> Self {
+impl From<[u64; MAX_NUM_COUNTERS]> for DelegationsAndFamiliesCounters {
+    fn from(counters: [u64; MAX_NUM_COUNTERS]) -> Self {
         Self {
             add_sub_family: counters[CounterType::AddSubLui as u8 as usize] as usize,
             slt_branch_family: counters[CounterType::BranchSlt as u8 as usize] as usize,
@@ -204,8 +204,8 @@ impl Counters for DelegationsAndUnifiedCounters {
     }
 }
 
-impl From<[u32; MAX_NUM_COUNTERS]> for DelegationsAndUnifiedCounters {
-    fn from(counters: [u32; MAX_NUM_COUNTERS]) -> Self {
+impl From<[u64; MAX_NUM_COUNTERS]> for DelegationsAndUnifiedCounters {
+    fn from(counters: [u64; MAX_NUM_COUNTERS]) -> Self {
         let add_sub_family = counters[CounterType::AddSubLui as u8 as usize] as usize;
         let slt_branch_family = counters[CounterType::BranchSlt as u8 as usize] as usize;
         let binary_shift_csr_family = counters[CounterType::ShiftBinaryCsr as u8 as usize] as usize;


### PR DESCRIPTION
## What ❔

This PR fixes counter overflows during long executions by widening JIT machine counters from `u32` to `u64` and propagating the type change through VM conversion and GPU prover tracing paths.

Concrete updates:
- `MachineState.counters` changed to `[u64; MAX_NUM_COUNTERS]`.
- JIT counter writes switched from `DWORD`/`4 * index` to `QWORD`/`8 * index`.
- VM `From<MachineState>` and counter conversion impls updated to accept `[u64; MAX_NUM_COUNTERS]`.
- GPU prover tracing interfaces updated to `[u64; MAX_NUM_COUNTERS]`.
- Cycle expectation summation in `gpu_prover` updated to `u64`.
- JIT tests updated to compare against `u64` counters.

## Why ❔

During long-running executions, `u32` counters can overflow, producing incorrect execution accounting and downstream tracing behavior.

Using `u64` removes this practical overflow limit for runtime counters while keeping existing semantics unchanged. This unblocks long runs and avoids incorrect prover-side assumptions derived from wrapped counters.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.
