### PR TITLE
chore(warnings): reduce warnings across workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
+/.vscode
 /target
 /Cargo.lock
 /output

--- a/blake2s_u32/src/lib.rs
+++ b/blake2s_u32/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(test), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 
 // special purpose designated blake2s implementaition, that has no internal buffer,
 // and operates on u32 basis. Has options for reduced number of rounds

--- a/circuit_defs/bigint_with_control/verifier/src/lib.rs
+++ b/circuit_defs/bigint_with_control/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/blake2_with_compression/verifier/src/lib.rs
+++ b/circuit_defs/blake2_with_compression/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/final_reduced_risc_v_machine/verifier/src/lib.rs
+++ b/circuit_defs/final_reduced_risc_v_machine/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/keccak_special5/verifier/src/lib.rs
+++ b/circuit_defs/keccak_special5/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/machine_without_signed_mul_div/verifier/src/lib.rs
+++ b/circuit_defs/machine_without_signed_mul_div/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/prover_examples/src/lib.rs
+++ b/circuit_defs/prover_examples/src/lib.rs
@@ -1,11 +1,8 @@
 #![allow(incomplete_features)]
-#![allow(unused_imports, unused_variables)]
 #![feature(generic_const_exprs)]
 #![feature(allocator_api)]
 
-use std::alloc::Global;
 use std::collections::HashMap;
-use std::path::Path;
 
 pub use ::prover;
 pub use ::setups;
@@ -34,7 +31,6 @@ use risc_v_simulator::cycle::IWithoutByteAccessIsaConfigWithDelegation;
 use risc_v_simulator::cycle::MachineConfig;
 use setups::*;
 use trace_and_split::*;
-use verifier_common::SECURITY_BITS;
 
 #[cfg(feature = "gpu")]
 pub mod gpu;
@@ -370,6 +366,7 @@ pub fn prove_image_execution_for_machine_with_gpu_tracers<
     );
 
     // same for delegation circuits
+    #[cfg(feature = "timing_logs")]
     let now = std::time::Instant::now();
     let mut delegation_memory_trees = vec![];
 
@@ -509,6 +506,7 @@ pub fn prove_image_execution_for_machine_with_gpu_tracers<
             cycle_data: witness_chunk,
         };
 
+        #[cfg(feature = "timing_logs")]
         let now = std::time::Instant::now();
         let witness_trace = evaluate_witness(
             &risc_v_circuit_precomputations.compiled_circuit,

--- a/circuit_defs/prover_examples/src/lib.rs
+++ b/circuit_defs/prover_examples/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(incomplete_features)]
+#![allow(unused_imports, unused_variables)]
 #![feature(generic_const_exprs)]
 #![feature(allocator_api)]
 
@@ -6,13 +7,13 @@ use std::alloc::Global;
 use std::collections::HashMap;
 use std::path::Path;
 
-pub use prover;
+pub use ::prover;
+pub use ::setups;
 use prover::cs::utils::split_timestamp;
 use prover::trace_holder::RowMajorTrace;
 use prover::tracers::oracles::chunk_lazy_init_and_teardown;
 use prover::tracers::oracles::delegation_oracle::DelegationCircuitOracle;
 use prover::tracers::oracles::main_risc_v_circuit::MainRiscVOracle;
-pub use setups;
 
 use merkle_trees::DefaultTreeConstructor;
 use prover::cs::definitions::ColumnSet;

--- a/circuit_defs/prover_examples/src/unified.rs
+++ b/circuit_defs/prover_examples/src/unified.rs
@@ -1,16 +1,9 @@
-#![allow(unused_imports, unused_variables)]
-
 use crate::bincode_serialize_to_file;
-use crate::cs::cs::oracle::ExecutorFamilyDecoderData;
-use crate::cs::machine::ops::unrolled::*;
-use crate::u32_from_field_elems;
-use crate::NonDeterminismCSRSource;
 use crate::DUMP_WITNESS_VAR;
 use crate::MEMORY_DELEGATION_POW_BITS;
 use common_constants::TimestampScalar;
 use common_constants::INITIAL_TIMESTAMP;
 use common_constants::REDUCED_MACHINE_CIRCUIT_FAMILY_IDX;
-use common_constants::TIMESTAMP_STEP;
 use prover::check_satisfied;
 use prover::cs::utils::split_timestamp;
 use prover::definitions::*;
@@ -21,27 +14,11 @@ use prover::merkle_trees::DefaultTreeConstructor;
 use prover::prover_stages::unrolled_prover::UnrolledModeProof;
 use prover::prover_stages::Proof;
 use prover::risc_v_simulator;
-use prover::tracers::delegation::DelegationWitness;
-use prover::tracers::oracles::delegation_oracle::DelegationCircuitOracle;
 use prover::tracers::oracles::transpiler_oracles::delegation::DelegationOracle;
-use prover::tracers::unrolled::tracer::MemTracingFamilyChunk;
-use prover::tracers::unrolled::tracer::NonMemTracingFamilyChunk;
-use prover::unrolled::evaluate_init_and_teardown_witness;
-use prover::unrolled::MemoryCircuitOracle;
-use prover::unrolled::NonMemoryCircuitOracle;
 use prover::unrolled::UnifiedRiscvCircuitOracle;
 use prover::worker;
-use prover::ExecutorFamilyWitnessEvaluationAuxData;
-use prover::ShuffleRamSetupAndTeardown;
-use prover::VectorMemoryImplWithRom;
-use prover::WitnessEvaluationData;
-use prover::WitnessEvaluationDataForExecutionFamily;
 use prover::DEFAULT_TRACE_PADDING_MULTIPLE;
-use risc_v_simulator::cycle::IMStandardIsaConfigWithUnsignedMulDiv;
-use risc_v_simulator::cycle::IWithoutByteAccessIsaConfigWithDelegation;
 use risc_v_simulator::cycle::MachineConfig;
-use risc_v_simulator::delegations::DelegationsCSRProcessor;
-use risc_v_simulator::machine_mode_only_unrolled::DelegationCSRProcessor;
 use riscv_transpiler::witness::delegation::bigint::BigintAbiDescription;
 use riscv_transpiler::witness::delegation::blake2_round_function::Blake2sRoundFunctionAbiDescription;
 use riscv_transpiler::witness::delegation::keccak_special5::KeccakSpecial5AbiDescription;
@@ -49,19 +26,13 @@ use riscv_transpiler::witness::DelegationAbiDescription;
 use setups::DelegationCircuitPrecomputations;
 use setups::UnrolledCircuitPrecomputations;
 use setups::UnrolledCircuitWitnessEvalFn;
-use std::alloc::Global;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use trace_and_split::commit_memory_tree_for_delegation_circuit_with_gpu_tracer;
 use trace_and_split::commit_memory_tree_for_delegation_circuit_with_replayer_format;
-use trace_and_split::commit_memory_tree_for_inits_and_teardowns_unrolled_circuit;
 use trace_and_split::commit_memory_tree_for_unified_circuits;
-use trace_and_split::commit_memory_tree_for_unrolled_mem_circuits;
-use trace_and_split::commit_memory_tree_for_unrolled_nonmem_circuits;
 use trace_and_split::fs_transform_for_memory_and_delegation_arguments_for_unrolled_circuits;
 use trace_and_split::FinalRegisterValue;
 use trace_and_split::ENTRY_POINT;
-use verifier_common::SECURITY_BITS;
 
 pub fn prove_unified_execution_with_replayer<
     C: MachineConfig,
@@ -106,7 +77,7 @@ pub fn prove_unified_execution_with_replayer<
     let (
         final_pc,
         final_timestamp,
-        cycles_used,
+        _cycles_used,
         unified_circuits,
         (blake_circuits, bigint_circuits, keccak_circuits),
         register_final_state,
@@ -132,8 +103,8 @@ pub fn prove_unified_execution_with_replayer<
         .map(|el| el.parse::<u32>().unwrap_or(0) == 1)
         .unwrap_or(false);
 
-    #[cfg(feature = "timing_logs")]
-    let now = std::time::Instant::now();
+    // #[cfg(feature = "timing_logs")]
+    // let now = std::time::Instant::now();
     let mut memory_trees = vec![];
 
     // restructure inits/teardowns
@@ -144,7 +115,7 @@ pub fn prove_unified_execution_with_replayer<
             .shuffle_ram_inits_and_teardowns
             .len();
 
-    let total_input_len: usize = shuffle_ram_touched_addresses
+    let _total_input_len: usize = shuffle_ram_touched_addresses
         .iter()
         .map(|el| el.len())
         .sum();
@@ -210,6 +181,7 @@ pub fn prove_unified_execution_with_replayer<
     // );
 
     // same for delegation circuits
+    #[cfg(feature = "timing_logs")]
     let now = std::time::Instant::now();
     let mut delegation_memory_trees = vec![];
     {
@@ -428,7 +400,7 @@ pub fn prove_unified_execution_with_replayer<
     //     main_circuits_witness.len()
     // );
 
-    let total_proving_start = std::time::Instant::now();
+    let _total_proving_start = std::time::Instant::now();
 
     // now prove one by one
     let mut main_proofs = BTreeMap::new();
@@ -469,6 +441,7 @@ pub fn prove_unified_execution_with_replayer<
                 &inits_and_teardowns[idx - num_trivial].lazy_init_data
             };
 
+            #[cfg(feature = "timing_logs")]
             let now = std::time::Instant::now();
             let witness_trace = prover::unrolled::evaluate_witness_for_unified_executor::<_, A>(
                 &precomputation.compiled_circuit,
@@ -503,7 +476,7 @@ pub fn prove_unified_execution_with_replayer<
             );
 
             let now = std::time::Instant::now();
-            let (prover_data, proof) =
+            let (_, proof) =
                 prover::prover_stages::unrolled_prover::prove_configured_for_unrolled_circuits::<
                     DEFAULT_TRACE_PADDING_MULTIPLE,
                     A,

--- a/circuit_defs/prover_examples/src/unified.rs
+++ b/circuit_defs/prover_examples/src/unified.rs
@@ -103,8 +103,6 @@ pub fn prove_unified_execution_with_replayer<
         .map(|el| el.parse::<u32>().unwrap_or(0) == 1)
         .unwrap_or(false);
 
-    // #[cfg(feature = "timing_logs")]
-    // let now = std::time::Instant::now();
     let mut memory_trees = vec![];
 
     // restructure inits/teardowns
@@ -172,13 +170,6 @@ pub fn prove_unified_execution_with_replayer<
         }
         memory_trees.push((REDUCED_MACHINE_CIRCUIT_FAMILY_IDX as u32, family_caps));
     }
-
-    // #[cfg(feature = "timing_logs")]
-    // println!(
-    //     "=== Commitment for {} RISC-V circuits memory trees took {:?}",
-    //     main_circuits_witness.len(),
-    //     now.elapsed()
-    // );
 
     // same for delegation circuits
     #[cfg(feature = "timing_logs")]
@@ -399,8 +390,6 @@ pub fn prove_unified_execution_with_replayer<
     //     "Producing proofs for main RISC-V circuit, {} proofs in total",
     //     main_circuits_witness.len()
     // );
-
-    let _total_proving_start = std::time::Instant::now();
 
     // now prove one by one
     let mut main_proofs = BTreeMap::new();

--- a/circuit_defs/prover_examples/src/unified.rs
+++ b/circuit_defs/prover_examples/src/unified.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports, unused_variables)]
+
 use crate::bincode_serialize_to_file;
 use crate::cs::cs::oracle::ExecutorFamilyDecoderData;
 use crate::cs::machine::ops::unrolled::*;

--- a/circuit_defs/prover_examples/src/unrolled.rs
+++ b/circuit_defs/prover_examples/src/unrolled.rs
@@ -249,8 +249,6 @@ pub fn prove_unrolled_execution<
         .map(|el| el.parse::<u32>().unwrap_or(0) == 1)
         .unwrap_or(false);
 
-    // #[cfg(feature = "timing_logs")]
-    // let now = std::time::Instant::now();
     let mut memory_trees = vec![];
 
     // let decoder_preprocessing = preprocess_text_section_for_machine_config::<C, ROM_ADDRESS_SPACE_SECOND_WORD_BITS>(text_section);
@@ -370,16 +368,7 @@ pub fn prove_unrolled_execution<
         }
     }
 
-    // #[cfg(feature = "timing_logs")]
-    // println!(
-    //     "=== Commitment for {} RISC-V circuits memory trees took {:?}",
-    //     main_circuits_witness.len(),
-    //     now.elapsed()
-    // );
-
     // same for delegation circuits
-    // #[cfg(feature = "timing_logs")]
-    // let now = std::time::Instant::now();
     let mut delegation_memory_trees = vec![];
 
     for (delegation_type, els) in delegation_circuits.iter() {
@@ -408,13 +397,6 @@ pub fn prove_unrolled_execution<
 
         delegation_memory_trees.push((*delegation_type as u32, per_tree_set));
     }
-    // #[cfg(feature = "timing_logs")]
-    // println!(
-    //     "=== Commitment for {} delegation circuits memory trees took {:?}",
-    //     delegation_circuits_witness.len(),
-    //     now.elapsed()
-    // );
-
     #[cfg(feature = "debug_logs")]
     println!("Will create FS transformation challenge for memory and delegation arguments");
 
@@ -500,8 +482,6 @@ pub fn prove_unrolled_execution<
     //     "Producing proofs for main RISC-V circuit, {} proofs in total",
     //     main_circuits_witness.len()
     // );
-
-    let _total_proving_start = std::time::Instant::now();
 
     // now prove one by one
     let mut main_proofs = BTreeMap::new();
@@ -1073,8 +1053,6 @@ pub fn prove_unrolled_execution_with_replayer<
         .map(|el| el.parse::<u32>().unwrap_or(0) == 1)
         .unwrap_or(false);
 
-    // #[cfg(feature = "timing_logs")]
-    // let now = std::time::Instant::now();
     let mut memory_trees = vec![];
 
     // let decoder_preprocessing = preprocess_text_section_for_machine_config::<C, ROM_ADDRESS_SPACE_SECOND_WORD_BITS>(text_section);
@@ -1225,13 +1203,6 @@ pub fn prove_unrolled_execution_with_replayer<
             previous_aux = Some(*aux_data);
         }
     }
-
-    // #[cfg(feature = "timing_logs")]
-    // println!(
-    //     "=== Commitment for {} RISC-V circuits memory trees took {:?}",
-    //     main_circuits_witness.len(),
-    //     now.elapsed()
-    // );
 
     // same for delegation circuits
     #[cfg(feature = "timing_logs")]
@@ -1452,8 +1423,6 @@ pub fn prove_unrolled_execution_with_replayer<
     //     "Producing proofs for main RISC-V circuit, {} proofs in total",
     //     main_circuits_witness.len()
     // );
-
-    let _total_proving_start = std::time::Instant::now();
 
     // now prove one by one
     let mut main_proofs = BTreeMap::new();
@@ -2058,94 +2027,99 @@ pub(crate) mod test {
     use std::alloc::Global;
     use std::path::Path;
 
-    use crate::cs::one_row_compiler::CompiledCircuitArtifact;
-    use common_constants::TimestampScalar;
-    use prover::prover_stages::unrolled_prover::UnrolledModeProof;
+    #[cfg(feature = "verifiers")]
+    mod verifiers_only {
+        use super::*;
+        use crate::cs::one_row_compiler::CompiledCircuitArtifact;
+        use common_constants::TimestampScalar;
+        use prover::prover_stages::unrolled_prover::UnrolledModeProof;
 
-    #[allow(dead_code)]
-    #[derive(Clone, Debug, Hash, serde::Serialize, serde::Deserialize)]
-    pub struct UnrolledProgramProof {
-        pub final_pc: u32,
-        pub final_timestamp: TimestampScalar,
-        pub compiled_circuit_families: BTreeMap<u8, CompiledCircuitArtifact<Mersenne31Field>>,
-        pub circuit_families_proofs: BTreeMap<u8, Vec<UnrolledModeProof>>,
-        pub compiled_inits_and_teardowns: CompiledCircuitArtifact<Mersenne31Field>,
-        pub inits_and_teardowns_proofs: Vec<UnrolledModeProof>,
-        pub delegation_proofs: BTreeMap<u32, Vec<Proof>>,
-        pub register_final_values: [FinalRegisterValue; 32],
-        pub recursion_chain_preimage: Option<[u32; 16]>,
-        pub recursion_chain_hash: Option<[u32; 8]>,
-    }
+        #[derive(Clone, Debug, Hash, serde::Serialize, serde::Deserialize)]
+        pub(super) struct UnrolledProgramProof {
+            pub final_pc: u32,
+            pub final_timestamp: TimestampScalar,
+            pub compiled_circuit_families: BTreeMap<u8, CompiledCircuitArtifact<Mersenne31Field>>,
+            pub circuit_families_proofs: BTreeMap<u8, Vec<UnrolledModeProof>>,
+            pub compiled_inits_and_teardowns: CompiledCircuitArtifact<Mersenne31Field>,
+            pub inits_and_teardowns_proofs: Vec<UnrolledModeProof>,
+            pub delegation_proofs: BTreeMap<u32, Vec<Proof>>,
+            pub register_final_values: [FinalRegisterValue; 32],
+            pub recursion_chain_preimage: Option<[u32; 16]>,
+            pub recursion_chain_hash: Option<[u32; 8]>,
+        }
 
-    #[allow(dead_code)]
-    impl UnrolledProgramProof {
-        pub fn flatten_into_responses(&self, allowed_delegation_circuits: &[u32]) -> Vec<u32> {
-            let mut responses = Vec::with_capacity(32 + 32 * 2);
+        impl UnrolledProgramProof {
+            pub fn flatten_into_responses(&self, allowed_delegation_circuits: &[u32]) -> Vec<u32> {
+                let mut responses = Vec::with_capacity(32 + 32 * 2);
 
-            assert_eq!(self.register_final_values.len(), 32);
-            // registers
-            for final_values in self.register_final_values.iter() {
-                responses.push(final_values.value);
-                let (low, high) = split_timestamp(final_values.last_access_timestamp);
-                responses.push(low);
-                responses.push(high);
-            }
-
-            // final PC and timestamp
-            {
-                responses.push(self.final_pc);
-                let (low, high) = split_timestamp(self.final_timestamp);
-                responses.push(low);
-                responses.push(high);
-            }
-
-            // families ones
-            for (family, proofs) in self.circuit_families_proofs.iter() {
-                responses.push(proofs.len() as u32);
-                for proof in proofs.iter() {
-                    let t = verifier_common::proof_flattener::flatten_full_unrolled_proof(
-                        proof,
-                        &self.compiled_circuit_families[family],
-                    );
-                    responses.extend(t);
+                assert_eq!(self.register_final_values.len(), 32);
+                // registers
+                for final_values in self.register_final_values.iter() {
+                    responses.push(final_values.value);
+                    let (low, high) = split_timestamp(final_values.last_access_timestamp);
+                    responses.push(low);
+                    responses.push(high);
                 }
-            }
 
-            // inits and teardowns
-            {
-                responses.push(self.inits_and_teardowns_proofs.len() as u32);
-                for proof in self.inits_and_teardowns_proofs.iter() {
-                    let t = verifier_common::proof_flattener::flatten_full_unrolled_proof(
-                        proof,
-                        &self.compiled_inits_and_teardowns,
-                    );
-                    responses.extend(t);
+                // final PC and timestamp
+                {
+                    responses.push(self.final_pc);
+                    let (low, high) = split_timestamp(self.final_timestamp);
+                    responses.push(low);
+                    responses.push(high);
                 }
-            }
 
-            // then for every allowed delegation circuit
-            for delegation_type in allowed_delegation_circuits.iter() {
-                if *delegation_type == common_constants::NON_DETERMINISM_CSR {
-                    continue;
-                }
-                if let Some(proofs) = self.delegation_proofs.get(&delegation_type) {
+                // families ones
+                for (family, proofs) in self.circuit_families_proofs.iter() {
                     responses.push(proofs.len() as u32);
                     for proof in proofs.iter() {
-                        let t = verifier_common::proof_flattener::flatten_full_proof(proof, 0);
+                        let t = verifier_common::proof_flattener::flatten_full_unrolled_proof(
+                            proof,
+                            &self.compiled_circuit_families[family],
+                        );
                         responses.extend(t);
                     }
-                } else {
-                    responses.push(0);
                 }
-            }
 
-            if let Some(preimage) = self.recursion_chain_preimage {
-                responses.extend(preimage);
-            }
+                // inits and teardowns
+                {
+                    responses.push(self.inits_and_teardowns_proofs.len() as u32);
+                    for proof in self.inits_and_teardowns_proofs.iter() {
+                        let t = verifier_common::proof_flattener::flatten_full_unrolled_proof(
+                            proof,
+                            &self.compiled_inits_and_teardowns,
+                        );
+                        responses.extend(t);
+                    }
+                }
 
-            responses
+                // then for every allowed delegation circuit
+                for delegation_type in allowed_delegation_circuits.iter() {
+                    if *delegation_type == common_constants::NON_DETERMINISM_CSR {
+                        continue;
+                    }
+                    if let Some(proofs) = self.delegation_proofs.get(&delegation_type) {
+                        responses.push(proofs.len() as u32);
+                        for proof in proofs.iter() {
+                            let t = verifier_common::proof_flattener::flatten_full_proof(proof, 0);
+                            responses.extend(t);
+                        }
+                    } else {
+                        responses.push(0);
+                    }
+                }
+
+                if let Some(preimage) = self.recursion_chain_preimage {
+                    responses.extend(preimage);
+                }
+
+                responses
+            }
         }
     }
+
+    #[cfg(feature = "verifiers")]
+    use verifiers_only::UnrolledProgramProof;
 
     #[test]
     fn test_prove_unrolled_fibonacci() {

--- a/circuit_defs/prover_examples/src/unrolled.rs
+++ b/circuit_defs/prover_examples/src/unrolled.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated, unused_imports, unused_mut, unused_variables)]
-
 use crate::bincode_serialize_to_file;
 use crate::cs::cs::oracle::ExecutorFamilyDecoderData;
 use crate::cs::machine::ops::unrolled::*;
@@ -9,7 +7,6 @@ use crate::DUMP_WITNESS_VAR;
 use crate::MEMORY_DELEGATION_POW_BITS;
 use common_constants::TimestampScalar;
 use common_constants::INITIAL_TIMESTAMP;
-use common_constants::TIMESTAMP_STEP;
 use prover::check_satisfied;
 use prover::cs::utils::split_timestamp;
 use prover::definitions::*;
@@ -24,7 +21,6 @@ use prover::tracers::oracles::delegation_oracle::DelegationCircuitOracle;
 use prover::tracers::oracles::transpiler_oracles::delegation::DelegationOracle;
 use prover::tracers::unrolled::tracer::MemTracingFamilyChunk;
 use prover::tracers::unrolled::tracer::NonMemTracingFamilyChunk;
-use prover::transcript::pow;
 use prover::unrolled::evaluate_init_and_teardown_witness;
 use prover::unrolled::MemoryCircuitOracle;
 use prover::unrolled::NonMemoryCircuitOracle;
@@ -35,11 +31,7 @@ use prover::VectorMemoryImplWithRom;
 use prover::WitnessEvaluationData;
 use prover::WitnessEvaluationDataForExecutionFamily;
 use prover::DEFAULT_TRACE_PADDING_MULTIPLE;
-use risc_v_simulator::cycle::IMStandardIsaConfigWithUnsignedMulDiv;
-use risc_v_simulator::cycle::IWithoutByteAccessIsaConfigWithDelegation;
 use risc_v_simulator::cycle::MachineConfig;
-use risc_v_simulator::delegations::DelegationsCSRProcessor;
-use risc_v_simulator::machine_mode_only_unrolled::DelegationCSRProcessor;
 use riscv_transpiler::witness::delegation::bigint::BigintAbiDescription;
 use riscv_transpiler::witness::delegation::blake2_round_function::Blake2sRoundFunctionAbiDescription;
 use riscv_transpiler::witness::delegation::keccak_special5::KeccakSpecial5AbiDescription;
@@ -47,7 +39,6 @@ use riscv_transpiler::witness::DelegationAbiDescription;
 use setups::DelegationCircuitPrecomputations;
 use setups::UnrolledCircuitPrecomputations;
 use setups::UnrolledCircuitWitnessEvalFn;
-use std::alloc::Global;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use trace_and_split::commit_memory_tree_for_delegation_circuit_with_gpu_tracer;
@@ -58,7 +49,6 @@ use trace_and_split::commit_memory_tree_for_unrolled_nonmem_circuits;
 use trace_and_split::fs_transform_for_memory_and_delegation_arguments_for_unrolled_circuits;
 use trace_and_split::FinalRegisterValue;
 use trace_and_split::ENTRY_POINT;
-use verifier_common::SECURITY_BITS;
 
 pub fn preprocess_text_section_for_machine_config<
     C: MachineConfig,
@@ -107,24 +97,21 @@ pub fn run_and_split_unrolled<
     A: GoodAllocator,
     const ROM_ADDRESS_SPACE_SECOND_WORD_BITS: usize,
 >(
-    cycles_bound: usize,
-    binary_image: &[u32],
-    text_section: &[u32],
-    non_determinism: &mut ND,
-    non_mem_factories: HashMap<
+    _cycles_bound: usize,
+    _binary_image: &[u32],
+    _text_section: &[u32],
+    _non_determinism: &mut ND,
+    _non_mem_factories: HashMap<
         u8,
         Box<dyn Fn() -> NonMemTracingFamilyChunk<A> + Send + Sync + 'static>,
     >,
-    mut mem_factories: HashMap<
-        u8,
-        Box<dyn Fn() -> MemTracingFamilyChunk<A> + Send + Sync + 'static>,
-    >,
-    delegation_factories: HashMap<
+    _mem_factories: HashMap<u8, Box<dyn Fn() -> MemTracingFamilyChunk<A> + Send + Sync + 'static>>,
+    _delegation_factories: HashMap<
         u16,
         Box<dyn Fn() -> DelegationWitness<A> + Send + Sync + 'static>,
     >,
-    ram_bound: usize,
-    worker: &worker::Worker,
+    _ram_bound: usize,
+    _worker: &worker::Worker,
 ) -> (
     u32,
     TimestampScalar,
@@ -138,6 +125,7 @@ pub fn run_and_split_unrolled<
     panic!("deprecated");
 }
 
+#[allow(deprecated)]
 pub fn trace_unrolled_execution<
     ND: NonDeterminismCSRSource<VectorMemoryImplWithRom>,
     C: MachineConfig,
@@ -175,7 +163,7 @@ pub fn trace_unrolled_execution<
     let (
         final_pc,
         final_timestamp,
-        cycles_used,
+        _cycles_used,
         family_circuits,
         (word_mem_circuits, subword_mem_circuits),
         delegation_circuits,
@@ -207,7 +195,7 @@ pub fn trace_unrolled_execution<
     (
         final_pc,
         final_timestamp,
-        cycles_used,
+        _cycles_used,
         family_circuits,
         (word_mem_circuits, subword_mem_circuits),
         delegation_circuits,
@@ -242,7 +230,7 @@ pub fn prove_unrolled_execution<
     let (
         final_pc,
         final_timestamp,
-        cycles_used,
+        _cycles_used,
         family_circuits,
         (word_mem_circuits, subword_mem_circuits),
         delegation_circuits,
@@ -261,8 +249,8 @@ pub fn prove_unrolled_execution<
         .map(|el| el.parse::<u32>().unwrap_or(0) == 1)
         .unwrap_or(false);
 
-    #[cfg(feature = "timing_logs")]
-    let now = std::time::Instant::now();
+    // #[cfg(feature = "timing_logs")]
+    // let now = std::time::Instant::now();
     let mut memory_trees = vec![];
 
     // let decoder_preprocessing = preprocess_text_section_for_machine_config::<C, ROM_ADDRESS_SPACE_SECOND_WORD_BITS>(text_section);
@@ -390,7 +378,8 @@ pub fn prove_unrolled_execution<
     // );
 
     // same for delegation circuits
-    let now = std::time::Instant::now();
+    // #[cfg(feature = "timing_logs")]
+    // let now = std::time::Instant::now();
     let mut delegation_memory_trees = vec![];
 
     for (delegation_type, els) in delegation_circuits.iter() {
@@ -512,7 +501,7 @@ pub fn prove_unrolled_execution<
     //     main_circuits_witness.len()
     // );
 
-    let total_proving_start = std::time::Instant::now();
+    let _total_proving_start = std::time::Instant::now();
 
     // now prove one by one
     let mut main_proofs = BTreeMap::new();
@@ -556,6 +545,7 @@ pub fn prove_unrolled_execution<
                 default_pc_value_in_padding: *default_pc_value_in_padding,
             };
 
+            #[cfg(feature = "timing_logs")]
             let now = std::time::Instant::now();
             let witness_trace = prover::unrolled::evaluate_witness_for_executor_family::<_, A>(
                 &precomputation.compiled_circuit,
@@ -584,7 +574,7 @@ pub fn prove_unrolled_execution<
             }
 
             let now = std::time::Instant::now();
-            let (prover_data, proof) =
+            let (_, proof) =
                 prover::prover_stages::unrolled_prover::prove_configured_for_unrolled_circuits::<
                     DEFAULT_TRACE_PADDING_MULTIPLE,
                     A,
@@ -674,6 +664,7 @@ pub fn prove_unrolled_execution<
                 decoder_table,
             };
 
+            #[cfg(feature = "timing_logs")]
             let now = std::time::Instant::now();
             let witness_trace = prover::unrolled::evaluate_witness_for_executor_family::<_, A>(
                 &precomputation.compiled_circuit,
@@ -702,7 +693,7 @@ pub fn prove_unrolled_execution<
             }
 
             let now = std::time::Instant::now();
-            let (prover_data, proof) =
+            let (_, proof) =
                 prover::prover_stages::unrolled_prover::prove_configured_for_unrolled_circuits::<
                     DEFAULT_TRACE_PADDING_MULTIPLE,
                     A,
@@ -758,6 +749,7 @@ pub fn prove_unrolled_execution<
     let mut aux_inits_and_teardown_trees = vec![];
     let mut inits_and_teardowns_proofs = vec![];
     for witness_chunk in inits_and_teardowns.into_iter() {
+        #[cfg(feature = "timing_logs")]
         let now = std::time::Instant::now();
         let witness_trace = evaluate_init_and_teardown_witness::<A>(
             &inits_and_teardowns_precomputation.compiled_circuit,
@@ -785,8 +777,9 @@ pub fn prove_unrolled_execution<
             lookup_mapping,
         };
 
+        #[cfg(feature = "timing_logs")]
         let now = std::time::Instant::now();
-        let (prover_data, proof) =
+        let (_, proof) =
             prover::prover_stages::unrolled_prover::prove_configured_for_unrolled_circuits::<
                 DEFAULT_TRACE_PADDING_MULTIPLE,
                 A,
@@ -1053,7 +1046,7 @@ pub fn prove_unrolled_execution_with_replayer<
     let (
         final_pc,
         final_timestamp,
-        cycles_used,
+        _cycles_used,
         non_mem_circuits,
         mem_circuits,
         (blake_circuits, bigint_circuits, keccak_circuits),
@@ -1080,8 +1073,8 @@ pub fn prove_unrolled_execution_with_replayer<
         .map(|el| el.parse::<u32>().unwrap_or(0) == 1)
         .unwrap_or(false);
 
-    #[cfg(feature = "timing_logs")]
-    let now = std::time::Instant::now();
+    // #[cfg(feature = "timing_logs")]
+    // let now = std::time::Instant::now();
     let mut memory_trees = vec![];
 
     // let decoder_preprocessing = preprocess_text_section_for_machine_config::<C, ROM_ADDRESS_SPACE_SECOND_WORD_BITS>(text_section);
@@ -1241,6 +1234,7 @@ pub fn prove_unrolled_execution_with_replayer<
     // );
 
     // same for delegation circuits
+    #[cfg(feature = "timing_logs")]
     let now = std::time::Instant::now();
     let mut delegation_memory_trees = vec![];
     {
@@ -1459,7 +1453,7 @@ pub fn prove_unrolled_execution_with_replayer<
     //     main_circuits_witness.len()
     // );
 
-    let total_proving_start = std::time::Instant::now();
+    let _total_proving_start = std::time::Instant::now();
 
     // now prove one by one
     let mut main_proofs = BTreeMap::new();
@@ -1505,6 +1499,7 @@ pub fn prove_unrolled_execution_with_replayer<
                 default_pc_value_in_padding: *default_pc_value_in_padding,
             };
 
+            #[cfg(feature = "timing_logs")]
             let now = std::time::Instant::now();
             let witness_trace = prover::unrolled::evaluate_witness_for_executor_family::<_, A>(
                 &precomputation.compiled_circuit,
@@ -1533,7 +1528,7 @@ pub fn prove_unrolled_execution_with_replayer<
             }
 
             let now = std::time::Instant::now();
-            let (prover_data, proof) =
+            let (_, proof) =
                 prover::prover_stages::unrolled_prover::prove_configured_for_unrolled_circuits::<
                     DEFAULT_TRACE_PADDING_MULTIPLE,
                     A,
@@ -1625,6 +1620,7 @@ pub fn prove_unrolled_execution_with_replayer<
                 decoder_table,
             };
 
+            #[cfg(feature = "timing_logs")]
             let now = std::time::Instant::now();
             let witness_trace = prover::unrolled::evaluate_witness_for_executor_family::<_, A>(
                 &precomputation.compiled_circuit,
@@ -1653,7 +1649,7 @@ pub fn prove_unrolled_execution_with_replayer<
             }
 
             let now = std::time::Instant::now();
-            let (prover_data, proof) =
+            let (_, proof) =
                 prover::prover_stages::unrolled_prover::prove_configured_for_unrolled_circuits::<
                     DEFAULT_TRACE_PADDING_MULTIPLE,
                     A,
@@ -1699,6 +1695,7 @@ pub fn prove_unrolled_execution_with_replayer<
     let mut aux_inits_and_teardown_trees = vec![];
     let mut inits_and_teardowns_proofs = vec![];
     for witness_chunk in inits_and_teardowns.into_iter() {
+        #[cfg(feature = "timing_logs")]
         let now = std::time::Instant::now();
         let witness_trace = evaluate_init_and_teardown_witness::<A>(
             &inits_and_teardowns_precomputation.compiled_circuit,
@@ -1726,8 +1723,9 @@ pub fn prove_unrolled_execution_with_replayer<
             lookup_mapping,
         };
 
+        #[cfg(feature = "timing_logs")]
         let now = std::time::Instant::now();
-        let (prover_data, proof) =
+        let (_, proof) =
             prover::prover_stages::unrolled_prover::prove_configured_for_unrolled_circuits::<
                 DEFAULT_TRACE_PADDING_MULTIPLE,
                 A,
@@ -2055,10 +2053,7 @@ fn prove_delegation_circuit_with_replayer_format<
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
-    use crate::bincode_deserialize_from_file;
-    use crate::deserialize_from_file;
     use crate::risc_v_simulator::cycle::IMStandardIsaConfigWithUnsignedMulDiv;
-    use prover::prover_stages::pow_bits;
     use risc_v_simulator::abstractions::non_determinism::QuasiUARTSource;
     use std::alloc::Global;
     use std::path::Path;

--- a/circuit_defs/prover_examples/src/unrolled.rs
+++ b/circuit_defs/prover_examples/src/unrolled.rs
@@ -2053,6 +2053,8 @@ fn prove_delegation_circuit_with_replayer_format<
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
+    use crate::bincode_deserialize_from_file;
+    use crate::deserialize_from_file;
     use crate::risc_v_simulator::cycle::IMStandardIsaConfigWithUnsignedMulDiv;
     use risc_v_simulator::abstractions::non_determinism::QuasiUARTSource;
     use std::alloc::Global;

--- a/circuit_defs/prover_examples/src/unrolled.rs
+++ b/circuit_defs/prover_examples/src/unrolled.rs
@@ -125,7 +125,7 @@ pub fn run_and_split_unrolled<
     panic!("deprecated");
 }
 
-#[allow(deprecated)]
+#[expect(deprecated, reason = "calls deprecated unrolled tracing entrypoint")]
 pub fn trace_unrolled_execution<
     ND: NonDeterminismCSRSource<VectorMemoryImplWithRom>,
     C: MachineConfig,

--- a/circuit_defs/prover_examples/src/unrolled.rs
+++ b/circuit_defs/prover_examples/src/unrolled.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated, unused_imports, unused_mut, unused_variables)]
+
 use crate::bincode_serialize_to_file;
 use crate::cs::cs::oracle::ExecutorFamilyDecoderData;
 use crate::cs::machine::ops::unrolled::*;
@@ -2065,6 +2067,7 @@ pub(crate) mod test {
     use common_constants::TimestampScalar;
     use prover::prover_stages::unrolled_prover::UnrolledModeProof;
 
+    #[allow(dead_code)]
     #[derive(Clone, Debug, Hash, serde::Serialize, serde::Deserialize)]
     pub struct UnrolledProgramProof {
         pub final_pc: u32,
@@ -2079,6 +2082,7 @@ pub(crate) mod test {
         pub recursion_chain_hash: Option<[u32; 8]>,
     }
 
+    #[allow(dead_code)]
     impl UnrolledProgramProof {
         pub fn flatten_into_responses(&self, allowed_delegation_circuits: &[u32]) -> Vec<u32> {
             let mut responses = Vec::with_capacity(32 + 32 * 2);

--- a/circuit_defs/prover_examples/src/unrolled.rs
+++ b/circuit_defs/prover_examples/src/unrolled.rs
@@ -2053,8 +2053,6 @@ fn prove_delegation_circuit_with_replayer_format<
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
-    use crate::bincode_deserialize_from_file;
-    use crate::deserialize_from_file;
     use crate::risc_v_simulator::cycle::IMStandardIsaConfigWithUnsignedMulDiv;
     use risc_v_simulator::abstractions::non_determinism::QuasiUARTSource;
     use std::alloc::Global;
@@ -2215,6 +2213,8 @@ pub(crate) mod test {
     #[cfg(feature = "verifiers")]
     #[test]
     fn test_verify_simple_fib() {
+        use crate::bincode_deserialize_from_file;
+        use crate::deserialize_from_file;
         use setups::*;
 
         let t: (

--- a/circuit_defs/reduced_risc_v_log_23_machine/verifier/src/lib.rs
+++ b/circuit_defs/reduced_risc_v_log_23_machine/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/reduced_risc_v_machine/verifier/src/lib.rs
+++ b/circuit_defs/reduced_risc_v_machine/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/risc_v_cycles/verifier/src/lib.rs
+++ b/circuit_defs/risc_v_cycles/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/setups/src/unrolled_circuits/add_sub_lui_auipc_mop_circuit/mod.rs
+++ b/circuit_defs/setups/src/unrolled_circuits/add_sub_lui_auipc_mop_circuit/mod.rs
@@ -11,6 +11,8 @@ pub fn add_sub_lui_auipc_mop_circuit_setup<A: GoodAllocator + 'static, B: GoodAl
     let table_driver = ::add_sub_lui_auipc_mop::get_table_driver(binary_image);
     let (decoder_table_data, witness_gen_data) =
         ::add_sub_lui_auipc_mop::get_decoder_table::<B>(bytecode);
+    #[cfg(not(feature = "witness_eval_fn"))]
+    let _ = &witness_gen_data;
     use prover::cs::machine::ops::unrolled::materialize_flattened_decoder_table;
     let decoder_table = materialize_flattened_decoder_table::<Mersenne31Field>(&decoder_table_data);
 

--- a/circuit_defs/setups/src/unrolled_circuits/jump_branch_slt_circuit/mod.rs
+++ b/circuit_defs/setups/src/unrolled_circuits/jump_branch_slt_circuit/mod.rs
@@ -11,6 +11,8 @@ pub fn jump_branch_slt_circuit_setup<A: GoodAllocator + 'static, B: GoodAllocato
     let table_driver = ::jump_branch_slt::get_table_driver(binary_image);
     let (decoder_table_data, witness_gen_data) =
         ::jump_branch_slt::get_decoder_table::<B>(bytecode);
+    #[cfg(not(feature = "witness_eval_fn"))]
+    let _ = &witness_gen_data;
     use prover::cs::machine::ops::unrolled::materialize_flattened_decoder_table;
     let decoder_table = materialize_flattened_decoder_table::<Mersenne31Field>(&decoder_table_data);
 

--- a/circuit_defs/setups/src/unrolled_circuits/load_store_subword_only_circuit/mod.rs
+++ b/circuit_defs/setups/src/unrolled_circuits/load_store_subword_only_circuit/mod.rs
@@ -11,6 +11,8 @@ pub fn load_store_subword_only_circuit_setup<A: GoodAllocator + 'static, B: Good
     let table_driver = ::load_store_subword_only::get_table_driver(binary_image);
     let (decoder_table_data, witness_gen_data) =
         ::load_store_subword_only::get_decoder_table::<B>(bytecode);
+    #[cfg(not(feature = "witness_eval_fn"))]
+    let _ = &witness_gen_data;
     use prover::cs::machine::ops::unrolled::materialize_flattened_decoder_table;
     let decoder_table = materialize_flattened_decoder_table::<Mersenne31Field>(&decoder_table_data);
 

--- a/circuit_defs/setups/src/unrolled_circuits/load_store_word_only_circuit/mod.rs
+++ b/circuit_defs/setups/src/unrolled_circuits/load_store_word_only_circuit/mod.rs
@@ -11,6 +11,8 @@ pub fn load_store_word_only_circuit_setup<A: GoodAllocator + 'static, B: GoodAll
     let table_driver = ::load_store_word_only::get_table_driver(binary_image);
     let (decoder_table_data, witness_gen_data) =
         ::load_store_word_only::get_decoder_table::<B>(bytecode);
+    #[cfg(not(feature = "witness_eval_fn"))]
+    let _ = &witness_gen_data;
     use prover::cs::machine::ops::unrolled::materialize_flattened_decoder_table;
     let decoder_table = materialize_flattened_decoder_table::<Mersenne31Field>(&decoder_table_data);
 

--- a/circuit_defs/setups/src/unrolled_circuits/mul_div_circuit/mod.rs
+++ b/circuit_defs/setups/src/unrolled_circuits/mul_div_circuit/mod.rs
@@ -10,6 +10,8 @@ pub fn mul_div_circuit_setup<A: GoodAllocator + 'static, B: GoodAllocator>(
     >(binary_image);
     let table_driver = ::mul_div::get_table_driver(binary_image);
     let (decoder_table_data, witness_gen_data) = ::mul_div::get_decoder_table::<B>(bytecode);
+    #[cfg(not(feature = "witness_eval_fn"))]
+    let _ = &witness_gen_data;
     use prover::cs::machine::ops::unrolled::materialize_flattened_decoder_table;
     let decoder_table = materialize_flattened_decoder_table::<Mersenne31Field>(&decoder_table_data);
 

--- a/circuit_defs/setups/src/unrolled_circuits/mul_div_unsigned_circuit/mod.rs
+++ b/circuit_defs/setups/src/unrolled_circuits/mul_div_unsigned_circuit/mod.rs
@@ -11,6 +11,8 @@ pub fn mul_div_unsigned_circuit_setup<A: GoodAllocator + 'static, B: GoodAllocat
     let table_driver = ::mul_div_unsigned::get_table_driver(binary_image);
     let (decoder_table_data, witness_gen_data) =
         ::mul_div_unsigned::get_decoder_table::<B>(bytecode);
+    #[cfg(not(feature = "witness_eval_fn"))]
+    let _ = &witness_gen_data;
     use prover::cs::machine::ops::unrolled::materialize_flattened_decoder_table;
     let decoder_table = materialize_flattened_decoder_table::<Mersenne31Field>(&decoder_table_data);
 

--- a/circuit_defs/setups/src/unrolled_circuits/shift_binary_csr_circuit/mod.rs
+++ b/circuit_defs/setups/src/unrolled_circuits/shift_binary_csr_circuit/mod.rs
@@ -11,6 +11,8 @@ pub fn shift_binary_csr_circuit_setup<A: GoodAllocator + 'static, B: GoodAllocat
     let table_driver = ::shift_binary_csr::get_table_driver(binary_image);
     let (decoder_table_data, witness_gen_data) =
         ::shift_binary_csr::get_decoder_table::<B>(bytecode);
+    #[cfg(not(feature = "witness_eval_fn"))]
+    let _ = &witness_gen_data;
     use prover::cs::machine::ops::unrolled::materialize_flattened_decoder_table;
     let decoder_table = materialize_flattened_decoder_table::<Mersenne31Field>(&decoder_table_data);
 

--- a/circuit_defs/setups/src/unrolled_circuits/unifier_reduced_machine_circuit/mod.rs
+++ b/circuit_defs/setups/src/unrolled_circuits/unifier_reduced_machine_circuit/mod.rs
@@ -11,6 +11,8 @@ pub fn unified_reduced_machine_circuit_setup<A: GoodAllocator + 'static, B: Good
     let table_driver = ::unified_reduced_machine::get_table_driver(binary_image);
     let (decoder_table_data, witness_gen_data) =
         ::unified_reduced_machine::get_decoder_table::<B>(bytecode);
+    #[cfg(not(feature = "witness_eval_fn"))]
+    let _ = &witness_gen_data;
     use prover::cs::machine::ops::unrolled::materialize_flattened_decoder_table;
     let decoder_table = materialize_flattened_decoder_table::<Mersenne31Field>(&decoder_table_data);
     let twiddles = Twiddles::get(::unified_reduced_machine::DOMAIN_SIZE, &worker);

--- a/circuit_defs/unrolled_circuits/add_sub_lui_auipc_mop/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/add_sub_lui_auipc_mop/src/lib.rs
@@ -132,7 +132,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::witness_placer::scalar_witness_type_set::ScalarWitnessTypeSet;

--- a/circuit_defs/unrolled_circuits/add_sub_lui_auipc_mop/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/add_sub_lui_auipc_mop/src/lib.rs
@@ -132,6 +132,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
+#[allow(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::witness_placer::scalar_witness_type_set::ScalarWitnessTypeSet;

--- a/circuit_defs/unrolled_circuits/add_sub_lui_auipc_mop/verifier/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/add_sub_lui_auipc_mop/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/unrolled_circuits/inits_and_teardowns/verifier/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/inits_and_teardowns/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/unrolled_circuits/jump_branch_slt/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/jump_branch_slt/src/lib.rs
@@ -130,7 +130,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::witness_placer::scalar_witness_type_set::ScalarWitnessTypeSet;

--- a/circuit_defs/unrolled_circuits/jump_branch_slt/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/jump_branch_slt/src/lib.rs
@@ -130,6 +130,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
+#[allow(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::witness_placer::scalar_witness_type_set::ScalarWitnessTypeSet;

--- a/circuit_defs/unrolled_circuits/jump_branch_slt/verifier/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/jump_branch_slt/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/unrolled_circuits/load_store_subword_only/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/load_store_subword_only/src/lib.rs
@@ -170,7 +170,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::witness_placer::scalar_witness_type_set::ScalarWitnessTypeSet;

--- a/circuit_defs/unrolled_circuits/load_store_subword_only/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/load_store_subword_only/src/lib.rs
@@ -170,6 +170,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
+#[allow(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::witness_placer::scalar_witness_type_set::ScalarWitnessTypeSet;

--- a/circuit_defs/unrolled_circuits/load_store_subword_only/verifier/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/load_store_subword_only/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/unrolled_circuits/load_store_word_only/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/load_store_word_only/src/lib.rs
@@ -173,6 +173,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
+#[allow(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::witness_placer::scalar_witness_type_set::ScalarWitnessTypeSet;

--- a/circuit_defs/unrolled_circuits/load_store_word_only/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/load_store_word_only/src/lib.rs
@@ -173,7 +173,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::witness_placer::scalar_witness_type_set::ScalarWitnessTypeSet;

--- a/circuit_defs/unrolled_circuits/load_store_word_only/verifier/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/load_store_word_only/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/unrolled_circuits/mul_div/verifier/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/mul_div/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/unrolled_circuits/mul_div_unsigned/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/mul_div_unsigned/src/lib.rs
@@ -133,6 +133,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
+#[allow(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::witness_placer::scalar_witness_type_set::ScalarWitnessTypeSet;

--- a/circuit_defs/unrolled_circuits/mul_div_unsigned/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/mul_div_unsigned/src/lib.rs
@@ -133,7 +133,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::witness_placer::scalar_witness_type_set::ScalarWitnessTypeSet;

--- a/circuit_defs/unrolled_circuits/mul_div_unsigned/verifier/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/mul_div_unsigned/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/unrolled_circuits/shift_binary_csr/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/shift_binary_csr/src/lib.rs
@@ -186,6 +186,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
+#[allow(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::placeholder::Placeholder;

--- a/circuit_defs/unrolled_circuits/shift_binary_csr/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/shift_binary_csr/src/lib.rs
@@ -186,7 +186,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::placeholder::Placeholder;

--- a/circuit_defs/unrolled_circuits/shift_binary_csr/verifier/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/shift_binary_csr/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/circuit_defs/unrolled_circuits/unified_reduced_machine/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/unified_reduced_machine/src/lib.rs
@@ -179,7 +179,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::placeholder::Placeholder;

--- a/circuit_defs/unrolled_circuits/unified_reduced_machine/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/unified_reduced_machine/src/lib.rs
@@ -179,6 +179,7 @@ pub fn get_decoder_table_for_rom_bound<
 }
 
 #[cfg(feature = "witness_eval_fn")]
+#[allow(unused_imports)]
 mod sealed {
     use crate::field::Mersenne31Field;
     use prover::cs::cs::placeholder::Placeholder;

--- a/circuit_defs/unrolled_circuits/unified_reduced_machine/verifier/src/lib.rs
+++ b/circuit_defs/unrolled_circuits/unified_reduced_machine/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/cs/src/lib.rs
+++ b/cs/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 #![feature(iter_advance_by)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(option_zip)]
 #![feature(assert_matches)]
 #![feature(allocator_api)]

--- a/cs/src/machine/ops/unrolled/decoder/memory.rs
+++ b/cs/src/machine/ops/unrolled/decoder/memory.rs
@@ -40,7 +40,7 @@ impl OpcodeFamilyDecoder for MemoryFamilyDecoder {
 
     fn define_decoder_subspace(
         &self,
-        opcode: u32,
+        _opcode: u32,
     ) -> Result<ExecutorFamilyDecoderExtendedData, ()> {
         todo!();
 

--- a/cs/src/machine/ops/unrolled/decoder/memory_subword_only.rs
+++ b/cs/src/machine/ops/unrolled/decoder/memory_subword_only.rs
@@ -46,7 +46,7 @@ impl OpcodeFamilyDecoder for SubwordOnlyMemoryFamilyDecoder {
         let op = get_opcode_bits(opcode);
         let func3 = funct3_bits(opcode);
         let func7 = funct7_bits(opcode);
-        let mut imm = 0;
+        let imm;
         let (rs1_index, mut rs2_index, mut rd_index) =
             formally_parse_rs1_rs2_rd_props_for_tracer(opcode);
         let instruction_type;

--- a/cs/src/machine/ops/unrolled/decoder/memory_word_only.rs
+++ b/cs/src/machine/ops/unrolled/decoder/memory_word_only.rs
@@ -46,7 +46,7 @@ impl OpcodeFamilyDecoder for WordOnlyMemoryFamilyDecoder {
         let op = get_opcode_bits(opcode);
         let func3 = funct3_bits(opcode);
         let func7 = funct7_bits(opcode);
-        let mut imm = 0;
+        let imm;
         let (rs1_index, mut rs2_index, mut rd_index) =
             formally_parse_rs1_rs2_rd_props_for_tracer(opcode);
         let instruction_type;

--- a/cs/src/one_row_compiler/executor_compilation.rs
+++ b/cs/src/one_row_compiler/executor_compilation.rs
@@ -3,6 +3,7 @@ use crate::one_row_compiler::compile_layout::*;
 use crate::one_row_compiler::delegation::*;
 
 impl<F: PrimeField> OneRowCompiler<F> {
+    #[allow(unreachable_code, unused_variables)]
     pub fn compile_executor_circuit(
         &self,
         circuit_output: CircuitOutput<F>,

--- a/cs/src/utils.rs
+++ b/cs/src/utils.rs
@@ -167,11 +167,13 @@ where
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn serialize_to_file<T: serde::Serialize>(el: &T, filename: &str) {
     let mut dst = std::fs::File::create(filename).unwrap();
     serde_json::to_writer_pretty(&mut dst, el).unwrap();
 }
 
+#[allow(dead_code)]
 pub(crate) fn bincode_serialize_to_file<T: serde::Serialize>(el: &T, filename: &str) {
     let mut dst = std::fs::File::create(filename).unwrap();
     bincode::serialize_into(&mut dst, el).unwrap();

--- a/cs/src/utils.rs
+++ b/cs/src/utils.rs
@@ -167,14 +167,8 @@ where
     }
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 pub(crate) fn serialize_to_file<T: serde::Serialize>(el: &T, filename: &str) {
     let mut dst = std::fs::File::create(filename).unwrap();
     serde_json::to_writer_pretty(&mut dst, el).unwrap();
-}
-
-#[allow(dead_code)]
-pub(crate) fn bincode_serialize_to_file<T: serde::Serialize>(el: &T, filename: &str) {
-    let mut dst = std::fs::File::create(filename).unwrap();
-    bincode::serialize_into(&mut dst, el).unwrap();
 }

--- a/execution_utils/src/constants.rs
+++ b/execution_utils/src/constants.rs
@@ -4,4 +4,13 @@ pub const CAP_SIZE: usize = 64;
 pub const NUM_COSETS: usize = 2;
 
 use verifier_common::prover::definitions::MerkleTreeCap;
-include!("../../circuit_defs/setups/generated/all_delegation_circuits_params.rs");
+
+#[allow(dead_code)]
+mod all_delegation_circuits_params {
+    use super::MerkleTreeCap;
+
+    include!("../../circuit_defs/setups/generated/all_delegation_circuits_params.rs");
+}
+
+#[allow(unused_imports)]
+pub use all_delegation_circuits_params::*;

--- a/execution_utils/src/lib.rs
+++ b/execution_utils/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(allocator_api)]
 
 use clap::ValueEnum;
-use risc_v_simulator::abstractions::non_determinism::QuasiUARTSource;
 use risc_v_simulator::cycle::MachineConfig;
 use serde::{Deserialize, Serialize};
 use verifier_common::prover::definitions::MerkleTreeCap;

--- a/execution_utils/src/recursion.rs
+++ b/execution_utils/src/recursion.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)]
+
 use super::*;
 // use crate::verifier_binaries::{
 //     recursion_layer_verifier_vk, recursion_log_23_layer_verifier_vk,

--- a/execution_utils/src/recursion.rs
+++ b/execution_utils/src/recursion.rs
@@ -1,15 +1,8 @@
-#![allow(unused_imports)]
-
-use super::*;
 // use crate::verifier_binaries::{
 //     recursion_layer_verifier_vk, recursion_log_23_layer_verifier_vk,
 //     universal_circuit_log_23_verifier_vk, universal_circuit_verifier_vk, BASE_LAYER_VERIFIER,
 //     RECURSION_LAYER_VERIFIER, UNIVERSAL_CIRCUIT_VERIFIER,
 // };
-use crate::{Machine, RecursionStrategy};
-use std::alloc::Global;
-
-use verifier_common::blake2s_u32::BLAKE2S_DIGEST_SIZE_U32_WORDS;
 
 // pub fn generate_constants_for_binary(
 //     base_layer_bin: &[u8],

--- a/execution_utils/src/recursion_strategy.rs
+++ b/execution_utils/src/recursion_strategy.rs
@@ -1,7 +1,3 @@
-#![allow(unused_imports)]
-
-use crate::Machine;
-use crate::ProofMetadata;
 use clap::ValueEnum;
 
 /// We have two layers of recursion:

--- a/execution_utils/src/recursion_strategy.rs
+++ b/execution_utils/src/recursion_strategy.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)]
+
 use crate::Machine;
 use crate::ProofMetadata;
 use clap::ValueEnum;

--- a/execution_utils/src/unified_circuit.rs
+++ b/execution_utils/src/unified_circuit.rs
@@ -367,13 +367,12 @@ mod test {
     #[test]
     fn prove_unified_recursion() {
         use crate::setups::read_and_pad_binary;
-        use crate::setups::CompiledCircuitsSet;
         use crate::unified_circuit::flatten_proof_into_responses_for_unified_recursion;
         use crate::unrolled::*;
         use risc_v_simulator::abstractions::non_determinism::QuasiUARTSource;
         use risc_v_simulator::cycle::IWithoutByteAccessIsaConfigWithDelegation;
         use std::fs::File;
-        use std::{io::Read, path::Path};
+        use std::path::Path;
 
         let (binary, binary_u32) = read_and_pad_binary(Path::new(
             "../tools/verifier/recursion_in_unified_layer.bin",

--- a/execution_utils/src/unified_circuit.rs
+++ b/execution_utils/src/unified_circuit.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)]
+
 use riscv_transpiler::common_constants;
 use sha3::Digest;
 use std::collections::BTreeMap;

--- a/execution_utils/src/unified_circuit.rs
+++ b/execution_utils/src/unified_circuit.rs
@@ -1,7 +1,4 @@
-#![allow(unused_imports)]
-
 use riscv_transpiler::common_constants;
-use sha3::Digest;
 use std::collections::BTreeMap;
 use trace_and_split::prover;
 use trace_and_split::setups;
@@ -9,12 +6,8 @@ use trace_and_split::setups;
 use super::unrolled::{UnrolledProgramProof, UnrolledProgramSetup};
 use super::*;
 use prover::common_constants::TimestampScalar;
-use prover::cs::one_row_compiler::CompiledCircuitArtifact;
-use prover::cs::utils::split_timestamp;
-use prover::field::*;
 use prover::prover_stages::unrolled_prover::UnrolledModeProof;
 use prover::prover_stages::Proof;
-use prover::risc_v_simulator;
 use setups::CompiledCircuitsSet;
 use trace_and_split::FinalRegisterValue;
 
@@ -167,7 +160,7 @@ pub fn prove_unified_for_machine_configuration_into_program_proof<C: MachineConf
     ram_bound: usize,
     worker: &prover::worker::Worker,
 ) -> UnrolledProgramProof {
-    use riscv_transpiler::common_constants::{REDUCED_MACHINE_CIRCUIT_FAMILY_IDX, ROM_WORD_SIZE};
+    use riscv_transpiler::common_constants::ROM_WORD_SIZE;
 
     assert_eq!(binary_image.len(), ROM_WORD_SIZE);
     assert_eq!(text_section.len(), ROM_WORD_SIZE);

--- a/execution_utils/src/unrolled.rs
+++ b/execution_utils/src/unrolled.rs
@@ -1,5 +1,3 @@
-#![allow(unused_imports)]
-
 use riscv_transpiler::common_constants;
 use sha3::Digest;
 use std::collections::BTreeMap;
@@ -9,10 +7,8 @@ use trace_and_split::setups;
 use super::*;
 use prover::common_constants::TimestampScalar;
 use prover::cs::utils::split_timestamp;
-use prover::field::*;
 use prover::prover_stages::unrolled_prover::UnrolledModeProof;
 use prover::prover_stages::Proof;
-use prover::risc_v_simulator;
 use setups::CompiledCircuitsSet;
 use trace_and_split::FinalRegisterValue;
 

--- a/execution_utils/src/unrolled.rs
+++ b/execution_utils/src/unrolled.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)]
+
 use riscv_transpiler::common_constants;
 use sha3::Digest;
 use std::collections::BTreeMap;

--- a/fft/benches/bitreverse.rs
+++ b/fft/benches/bitreverse.rs
@@ -10,10 +10,10 @@ use worker::Worker;
 
 fn get_random_slice(len: usize) -> Vec<Mersenne31Field> {
     use rand::Rng;
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     (0..len)
-        .map(|_| Mersenne31Field::from_u64(rng.gen_range(0..(1 << 31) - 1)).unwrap())
+        .map(|_| Mersenne31Field::from_u64(rng.random_range(0..(1 << 31) - 1)).unwrap())
         .collect()
 }
 

--- a/fft/src/utils.rs
+++ b/fft/src/utils.rs
@@ -338,7 +338,7 @@ pub const fn bitreverse_index(index: usize, num_bits: u32) -> usize {
 }
 
 /// Allocate a vector of type T, but with extra restriction that it has an alignment
-/// of type U. Capacity should be divisible by size_of::<U>/size_of::<T>
+/// of type U. Capacity should be divisible by `size_of::<U>() / size_of::<T>()`.
 #[inline]
 pub fn allocate_in_with_alignment_of<T: Sized, U: Sized, A: GoodAllocator>(
     capacity: usize,

--- a/field/src/avx_512_impl.rs
+++ b/field/src/avx_512_impl.rs
@@ -33,7 +33,9 @@ use rand::Rng;
 impl Rand for Mersenne31FieldVectorized {
     fn random_element<R: Rng + ?Sized>(rng: &mut R) -> Mersenne31FieldVectorized {
         let t = [(); WIDTH].map(|_| {
-            Mersenne31Field::from_u64_unchecked(rng.gen_range(0..Mersenne31Field::CHARACTERISTICS))
+            Mersenne31Field::from_u64_unchecked(
+                rng.random_range(0..Mersenne31Field::CHARACTERISTICS),
+            )
         });
         Mersenne31FieldVectorized(t)
     }

--- a/field/src/ext_avx_512_impl.rs
+++ b/field/src/ext_avx_512_impl.rs
@@ -52,10 +52,14 @@ use rand::Rng;
 impl Rand for Mersenne31ComplexVectorized {
     fn random_element<R: Rng + ?Sized>(rng: &mut R) -> Mersenne31ComplexVectorized {
         let t_real = [(); WIDTH].map(|_| {
-            Mersenne31Field::from_u64_unchecked(rng.gen_range(0..Mersenne31Field::CHARACTERISTICS))
+            Mersenne31Field::from_u64_unchecked(
+                rng.random_range(0..Mersenne31Field::CHARACTERISTICS),
+            )
         });
         let t_imag = [(); WIDTH].map(|_| {
-            Mersenne31Field::from_u64_unchecked(rng.gen_range(0..Mersenne31Field::CHARACTERISTICS))
+            Mersenne31Field::from_u64_unchecked(
+                rng.random_range(0..Mersenne31Field::CHARACTERISTICS),
+            )
         });
         Mersenne31ComplexVectorized {
             c0: Mersenne31FieldVectorized(t_real),

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -6,7 +6,6 @@
 #![feature(associated_type_defaults)]
 #![feature(core_intrinsics)]
 #![feature(const_eval_select)]
-#![cfg_attr(target_feature = "avx512f", feature(stdarch_x86_avx512))]
 
 use core::fmt::Debug;
 use core::fmt::Display;

--- a/full_statement_verifier/src/lib.rs
+++ b/full_statement_verifier/src/lib.rs
@@ -3,9 +3,6 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
-#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
-use core::mem::MaybeUninit;
-
 pub use verifier_common;
 
 #[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
@@ -25,31 +22,29 @@ pub mod unrolled_proof_statement;
 pub mod statement_common;
 
 #[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
-use self::constants::*;
+mod verifier_imports {
+    pub(super) use super::constants::*;
+    pub(super) use core::mem::MaybeUninit;
+    pub(super) use verifier_common::blake2s_u32::{
+        BLAKE2S_BLOCK_SIZE_U32_WORDS, BLAKE2S_DIGEST_SIZE_U32_WORDS,
+    };
+    pub(super) use verifier_common::field::{
+        Field, Mersenne31Field, Mersenne31Quartic, PrimeField,
+    };
+    pub(super) use verifier_common::non_determinism_source::NonDeterminismSource;
+    pub(super) use verifier_common::prover::definitions::{ExternalChallenges, MerkleTreeCap};
+    pub(super) use verifier_common::transcript::Blake2sBufferingTranscript;
+    pub(super) use verifier_common::{ProofOutput, ProofPublicInputs, VerifierFunctionPointer};
+}
 
 #[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
-use verifier_common::blake2s_u32::{BLAKE2S_BLOCK_SIZE_U32_WORDS, BLAKE2S_DIGEST_SIZE_U32_WORDS};
+use self::verifier_imports::*;
+
 use verifier_common::cs::definitions::{
     NUM_EMPTY_BITS_FOR_RAM_TIMESTAMP, NUM_TIMESTAMP_COLUMNS_FOR_RAM, TIMESTAMP_COLUMNS_NUM_BITS,
 };
-#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
-use verifier_common::field::{Field, Mersenne31Field, Mersenne31Quartic, PrimeField};
-#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
-use verifier_common::non_determinism_source::NonDeterminismSource;
 use verifier_common::parse_field_els_as_u32_from_u16_limbs_checked;
 use verifier_common::prover;
-#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
-use verifier_common::prover::definitions::ExternalChallenges;
-#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
-use verifier_common::prover::definitions::MerkleTreeCap;
-#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
-use verifier_common::transcript::Blake2sBufferingTranscript;
-#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
-use verifier_common::ProofOutput;
-#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
-use verifier_common::ProofPublicInputs;
-#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
-use verifier_common::VerifierFunctionPointer;
 
 pub const MAX_CYCLES: u64 = const {
     let max_unique_timestamps =

--- a/full_statement_verifier/src/lib.rs
+++ b/full_statement_verifier/src/lib.rs
@@ -3,10 +3,12 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
+#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
 use core::mem::MaybeUninit;
 
 pub use verifier_common;
 
+#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
 mod constants;
 pub mod definitions;
 
@@ -22,20 +24,32 @@ pub mod unrolled_proof_statement;
 #[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
 pub mod statement_common;
 
+#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
 use self::constants::*;
 
+#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
 use verifier_common::blake2s_u32::{BLAKE2S_BLOCK_SIZE_U32_WORDS, BLAKE2S_DIGEST_SIZE_U32_WORDS};
 use verifier_common::cs::definitions::{
     NUM_EMPTY_BITS_FOR_RAM_TIMESTAMP, NUM_TIMESTAMP_COLUMNS_FOR_RAM, TIMESTAMP_COLUMNS_NUM_BITS,
 };
+#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
 use verifier_common::field::{Field, Mersenne31Field, Mersenne31Quartic, PrimeField};
+#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
 use verifier_common::non_determinism_source::NonDeterminismSource;
+use verifier_common::parse_field_els_as_u32_from_u16_limbs_checked;
+use verifier_common::prover;
+#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
 use verifier_common::prover::definitions::ExternalChallenges;
+#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
 use verifier_common::prover::definitions::MerkleTreeCap;
+#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
 use verifier_common::transcript::Blake2sBufferingTranscript;
+#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
+use verifier_common::ProofOutput;
+#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
+use verifier_common::ProofPublicInputs;
+#[cfg(any(feature = "verifiers", feature = "unified_verifier_only"))]
 use verifier_common::VerifierFunctionPointer;
-use verifier_common::{parse_field_els_as_u32_from_u16_limbs_checked, ProofPublicInputs};
-use verifier_common::{prover, ProofOutput};
 
 pub const MAX_CYCLES: u64 = const {
     let max_unique_timestamps =

--- a/gpu_prover_test/src/main.rs
+++ b/gpu_prover_test/src/main.rs
@@ -5,7 +5,7 @@ fn main() {}
 
 #[cfg(test)]
 mod tests {
-    #![allow(unused_variables)]
+    #![expect(unused_variables)] // TODO: Remove unused variables
 
     use execution_utils::setups::prover::prover_stages::unrolled_prover::UnrolledModeProof;
     use execution_utils::setups::prover::prover_stages::Proof;

--- a/gpu_prover_test/src/main.rs
+++ b/gpu_prover_test/src/main.rs
@@ -5,6 +5,8 @@ fn main() {}
 
 #[cfg(test)]
 mod tests {
+    #![allow(unused_variables)]
+
     use execution_utils::setups::prover::prover_stages::unrolled_prover::UnrolledModeProof;
     use execution_utils::setups::prover::prover_stages::Proof;
     use execution_utils::setups::prover::worker::Worker;

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -3,8 +3,8 @@
 //! The Poseidon2 permutation.
 //!
 //! This implementation was based upon the following resources:
-//! - https://github.com/HorizenLabs/poseidon2/blob/main/plain_implementations/src/poseidon2/poseidon2.rs
-//! - https://eprint.iacr.org/2023/323.pdf
-//! - https://github.com/Plonky3/Plonky3/blob/main/mersenne-31/src/poseidon2.rs for parameters
+//! - <https://github.com/HorizenLabs/poseidon2/blob/main/plain_implementations/src/poseidon2/poseidon2.rs>
+//! - <https://eprint.iacr.org/2023/323.pdf>
+//! - <https://github.com/Plonky3/Plonky3/blob/main/mersenne-31/src/poseidon2.rs> for parameters
 
 pub mod m31;

--- a/prover/src/definitions/leaf_inclusion_verifier/blake2s_for_everything.rs
+++ b/prover/src/definitions/leaf_inclusion_verifier/blake2s_for_everything.rs
@@ -15,7 +15,7 @@ impl LeafInclusionVerifier for Blake2sForEverythingVerifier {
     }
 
     #[unroll::unroll_for_loops]
-    #[allow(unreachable_code, unused_assignments, unused_variables)]
+    #[expect(unreachable_code, unused_assignments, unused_variables)]
     unsafe fn verify_leaf_inclusion<
         I: NonDeterminismSource,
         const CAP_SIZE: usize,

--- a/prover/src/definitions/leaf_inclusion_verifier/blake2s_for_everything.rs
+++ b/prover/src/definitions/leaf_inclusion_verifier/blake2s_for_everything.rs
@@ -15,6 +15,7 @@ impl LeafInclusionVerifier for Blake2sForEverythingVerifier {
     }
 
     #[unroll::unroll_for_loops]
+    #[allow(unreachable_code, unused_assignments, unused_variables)]
     unsafe fn verify_leaf_inclusion<
         I: NonDeterminismSource,
         const CAP_SIZE: usize,

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -4,10 +4,8 @@
 #![feature(allocator_api)]
 #![feature(iter_array_chunks)]
 #![feature(raw_slice_split)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![feature(vec_push_within_capacity)]
-#![feature(maybe_uninit_slice)]
 #![feature(lazy_type_alias)] // NECESSARY TO AVOID UGLY LIFETIME BOUND ISSUE
 
 #[cfg(feature = "debug_satisfiable")]

--- a/prover/src/prover_stages/stage2.rs
+++ b/prover/src/prover_stages/stage2.rs
@@ -23,7 +23,6 @@ use crate::prover_stages::stage2_utils::*;
 use cached_data::ProverCachedData;
 use cs::one_row_compiler::ColumnAddress;
 use fft::field_utils::batch_inverse_with_buffer;
-use transcript::pow;
 
 pub struct SecondStageOutput<const N: usize, A: GoodAllocator, T: MerkleTreeConstructor> {
     pub ldes: Vec<CosetBoundTracePart<N, A>>,

--- a/prover/src/prover_stages/stage2_utils.rs
+++ b/prover/src/prover_stages/stage2_utils.rs
@@ -204,6 +204,7 @@ pub(crate) unsafe fn stage_2_shuffle_ram_add_timestamp_contributions(
 }
 
 #[inline(always)]
+#[allow(dead_code)]
 pub(crate) unsafe fn stage_2_batched_ram_assemble_address_contribution(
     memory_trace_row: &[Mersenne31Field],
     mem_offset_high: ColumnSet<1>,
@@ -293,6 +294,7 @@ pub(crate) unsafe fn stage_2_delegation_ram_assemble_timestamp_contribution(
 }
 
 #[inline(always)]
+#[allow(dead_code)]
 pub(crate) unsafe fn stage_2_batched_ram_assemble_read_contribution(
     memory_trace_row: &[Mersenne31Field],
     read_value: ColumnSet<REGISTER_SIZE>,
@@ -345,6 +347,7 @@ pub(crate) unsafe fn stage_2_batched_ram_assemble_read_contribution(
 }
 
 #[inline(always)]
+#[allow(dead_code)]
 pub(crate) unsafe fn stage_2_batched_ram_assemble_write_contribution(
     memory_trace_row: &[Mersenne31Field],
     read_value: ColumnSet<REGISTER_SIZE>,

--- a/prover/src/prover_stages/stage2_utils.rs
+++ b/prover/src/prover_stages/stage2_utils.rs
@@ -204,7 +204,7 @@ pub(crate) unsafe fn stage_2_shuffle_ram_add_timestamp_contributions(
 }
 
 #[inline(always)]
-#[allow(dead_code)]
+// Kept as reference for the deprecated batched RAM flow and for possible reuse.
 pub(crate) unsafe fn stage_2_batched_ram_assemble_address_contribution(
     memory_trace_row: &[Mersenne31Field],
     mem_offset_high: ColumnSet<1>,
@@ -294,7 +294,8 @@ pub(crate) unsafe fn stage_2_delegation_ram_assemble_timestamp_contribution(
 }
 
 #[inline(always)]
-#[allow(dead_code)]
+// Kept as reference for the deprecated batched RAM flow and for possible reuse.
+#[expect(dead_code)]
 pub(crate) unsafe fn stage_2_batched_ram_assemble_read_contribution(
     memory_trace_row: &[Mersenne31Field],
     read_value: ColumnSet<REGISTER_SIZE>,
@@ -347,7 +348,8 @@ pub(crate) unsafe fn stage_2_batched_ram_assemble_read_contribution(
 }
 
 #[inline(always)]
-#[allow(dead_code)]
+// Kept as reference for the deprecated batched RAM flow and for possible reuse.
+#[expect(dead_code)]
 pub(crate) unsafe fn stage_2_batched_ram_assemble_write_contribution(
     memory_trace_row: &[Mersenne31Field],
     read_value: ColumnSet<REGISTER_SIZE>,

--- a/prover/src/prover_stages/unrolled_prover/stage2.rs
+++ b/prover/src/prover_stages/unrolled_prover/stage2.rs
@@ -5,7 +5,6 @@ use crate::prover_stages::unrolled_prover::stage_2_shared::*;
 use crate::prover_stages::SetupPrecomputations;
 use cs::one_row_compiler::ColumnAddress;
 use fft::field_utils::batch_inverse_with_buffer;
-use transcript::pow;
 
 pub fn prover_stage_2_for_unrolled_circuit<
     const N: usize,

--- a/prover/src/tests/delegation_test.rs
+++ b/prover/src/tests/delegation_test.rs
@@ -3,7 +3,6 @@ use super::*;
 use crate::prover_stages::ProofSecurityConfig;
 use crate::tracers::oracles::delegation_oracle::DelegationCircuitOracle;
 use cs::cs::{circuit::Circuit, cs_reference::BasicAssembly};
-use full_isa_with_delegation_no_exceptions::FullIsaMachineWithDelegationNoExceptionHandling;
 use risc_v_simulator::{
     cycle::IWithoutByteAccessIsaConfigWithDelegation, delegations::DelegationsCSRProcessor,
 };

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_variables)]
+
 use crate::definitions::*;
 use crate::merkle_trees::DefaultTreeConstructor;
 use crate::prover_stages::SetupPrecomputations;

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code, unused_variables)]
-
 use crate::definitions::*;
 use crate::merkle_trees::DefaultTreeConstructor;
 use crate::prover_stages::SetupPrecomputations;
@@ -519,12 +517,14 @@ fn serialize_to_file<T: serde::Serialize>(el: &T, filename: &str) {
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 fn deserialize_from_file<T: serde::de::DeserializeOwned>(filename: &str) -> T {
     let src = std::fs::File::open(filename).unwrap();
     serde_json::from_reader(src).unwrap()
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 fn fast_serialize_to_file<T: serde::Serialize>(el: &T, filename: &str) {
     let mut dst = std::fs::File::create(filename).unwrap();
     bincode::serialize_into(&mut dst, el).unwrap();
@@ -609,7 +609,7 @@ fn test_bigint_with_control_call() {
         }
 
         let register = Register(output_extended_state_vars.map(|el| Num::Var(el)));
-        let result_x12 = register.get_value_unsigned(&cs).unwrap();
+        let _result_x12 = register.get_value_unsigned(&cs).unwrap();
 
         // assert_eq!(expected_x12, result_x12, "x12 diverged for round {}", round);
 

--- a/prover/src/tests/unrolled/mod.rs
+++ b/prover/src/tests/unrolled/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_imports, unused_variables)]
+
 use super::*;
 
 use crate::tracers::unrolled::tracer::*;

--- a/prover/src/tests/unrolled/mod.rs
+++ b/prover/src/tests/unrolled/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code, unused_imports, unused_variables)]
-
 use super::*;
 
 use crate::tracers::unrolled::tracer::*;
@@ -7,7 +5,6 @@ use crate::unrolled::evaluate_witness_for_executor_family;
 use crate::unrolled::run_unrolled_machine_for_num_cycles;
 use crate::unrolled::MemoryCircuitOracle;
 use crate::unrolled::NonMemoryCircuitOracle;
-use common_constants::circuit_families::*;
 use common_constants::delegation_types::bigint_with_control::BIGINT_OPS_WITH_CONTROL_CSR_REGISTER;
 use common_constants::delegation_types::blake2s_with_control::BLAKE2S_DELEGATION_CSR_REGISTER;
 use common_constants::delegation_types::keccak_special5::KECCAK_SPECIAL5_CSR_REGISTER;
@@ -26,6 +23,7 @@ use crate::witness_evaluator::unrolled::evaluate_memory_witness_for_executor_fam
 mod reduced_machine;
 pub mod with_transpiler;
 
+#[allow(unused_imports)]
 pub mod add_sub_lui_auipc_mod {
     use crate::unrolled::NonMemoryCircuitOracle;
     use crate::witness_evaluator::SimpleWitnessProxy;
@@ -53,6 +51,7 @@ pub mod add_sub_lui_auipc_mod {
     }
 }
 
+#[allow(unused_imports)]
 pub mod jump_branch_slt {
     use crate::unrolled::NonMemoryCircuitOracle;
     use crate::witness_evaluator::SimpleWitnessProxy;
@@ -80,6 +79,7 @@ pub mod jump_branch_slt {
     }
 }
 
+#[allow(unused_imports)]
 pub mod shift_binop_csrrw {
     use crate::unrolled::NonMemoryCircuitOracle;
     use crate::witness_evaluator::SimpleWitnessProxy;
@@ -107,6 +107,7 @@ pub mod shift_binop_csrrw {
     }
 }
 
+#[allow(unused_imports)]
 pub mod mul_div {
     use crate::unrolled::NonMemoryCircuitOracle;
     use crate::witness_evaluator::SimpleWitnessProxy;
@@ -134,6 +135,7 @@ pub mod mul_div {
     }
 }
 
+#[allow(unused_imports)]
 pub mod mul_div_unsigned_only {
     use crate::unrolled::NonMemoryCircuitOracle;
     use crate::witness_evaluator::SimpleWitnessProxy;
@@ -161,6 +163,7 @@ pub mod mul_div_unsigned_only {
     }
 }
 
+#[allow(unused_imports)]
 pub mod load_store {
     use crate::unrolled::MemoryCircuitOracle;
     use crate::witness_evaluator::SimpleWitnessProxy;
@@ -186,6 +189,7 @@ pub mod load_store {
     }
 }
 
+#[allow(unused_imports)]
 pub mod word_load_store {
     use crate::unrolled::MemoryCircuitOracle;
     use crate::witness_evaluator::SimpleWitnessProxy;
@@ -211,6 +215,7 @@ pub mod word_load_store {
     }
 }
 
+#[allow(unused_imports)]
 pub mod subword_load_store {
     use crate::unrolled::MemoryCircuitOracle;
     use crate::witness_evaluator::SimpleWitnessProxy;
@@ -483,7 +488,7 @@ pub(crate) unsafe fn parse_delegation_ram_accesses(
         {
             // register
             {
-                let reg_idx = access.register_access.get_register_index();
+                let _reg_idx = access.register_access.get_register_index();
                 let read_ts = read_timestamp(
                     trace_row,
                     access.register_access.get_read_timestamp_columns(),
@@ -617,7 +622,7 @@ fn run_basic_unrolled_test() {
 }
 
 pub fn run_basic_unrolled_test_impl(
-    maybe_gpu_comparison_hook: Option<Box<dyn Fn(&GpuComparisonArgs)>>,
+    _maybe_gpu_comparison_hook: Option<Box<dyn Fn(&GpuComparisonArgs)>>,
 ) {
     // NOTE: these constants must match with ones used in CS crate to produce
     // layout and SSA forms, otherwise derived witness-gen functions may write into
@@ -707,9 +712,9 @@ pub fn run_basic_unrolled_test_impl(
         final_pc,
         family_circuits,
         mem_circuits,
-        delegation_circuits,
+        _delegation_circuits,
         register_final_state,
-        shuffle_ram_touched_addresses,
+        _shuffle_ram_touched_addresses,
     ) = if SUPPORT_SIGNED {
         let mut non_determinism = QuasiUARTSource::new_with_reads(vec![15, 1]); // 1000 steps of fibonacci, and 1 round of hashing
         run_unrolled_machine_for_num_cycles::<_, IMStandardIsaConfig, Global>(
@@ -903,7 +908,7 @@ pub fn run_basic_unrolled_test_impl(
         //     family_data[0].data[4].opcode_data.opcode
         // );
 
-        let memory_trace = evaluate_memory_witness_for_executor_family::<_, Global>(
+        let _memory_trace = evaluate_memory_witness_for_executor_family::<_, Global>(
             &add_sub_circuit,
             NUM_CYCLES_PER_CHUNK,
             &oracle,
@@ -951,7 +956,7 @@ pub fn run_basic_unrolled_test_impl(
         println!("Trying to prove");
 
         let now = std::time::Instant::now();
-        let (prover_data, proof) = prove_configured_for_unrolled_circuits::<
+        let (_prover_data, _proof) = prove_configured_for_unrolled_circuits::<
             DEFAULT_TRACE_PADDING_MULTIPLE,
             _,
             DefaultTreeConstructor,
@@ -1007,7 +1012,7 @@ pub fn run_basic_unrolled_test_impl(
         //     family_data[0].data[4].opcode_data.opcode
         // );
 
-        let memory_trace = evaluate_memory_witness_for_executor_family::<_, Global>(
+        let _memory_trace = evaluate_memory_witness_for_executor_family::<_, Global>(
             &jump_branch_circuit,
             NUM_CYCLES_PER_CHUNK,
             &oracle,
@@ -1055,7 +1060,7 @@ pub fn run_basic_unrolled_test_impl(
         println!("Trying to prove");
 
         let now = std::time::Instant::now();
-        let (prover_data, proof) = prove_configured_for_unrolled_circuits::<
+        let (_prover_data, _proof) = prove_configured_for_unrolled_circuits::<
             DEFAULT_TRACE_PADDING_MULTIPLE,
             _,
             DefaultTreeConstructor,
@@ -1127,7 +1132,7 @@ pub fn run_basic_unrolled_test_impl(
         //     family_data[0].data[26].opcode_data.opcode
         // );
 
-        let memory_trace = evaluate_memory_witness_for_executor_family::<_, Global>(
+        let _memory_trace = evaluate_memory_witness_for_executor_family::<_, Global>(
             &shift_binop_csrrw_circuit,
             NUM_CYCLES_PER_CHUNK,
             &oracle,
@@ -1175,7 +1180,7 @@ pub fn run_basic_unrolled_test_impl(
         println!("Trying to prove");
 
         let now = std::time::Instant::now();
-        let (prover_data, proof) = prove_configured_for_unrolled_circuits::<
+        let (_prover_data, _proof) = prove_configured_for_unrolled_circuits::<
             DEFAULT_TRACE_PADDING_MULTIPLE,
             _,
             DefaultTreeConstructor,
@@ -1239,7 +1244,7 @@ pub fn run_basic_unrolled_test_impl(
         //     family_data[0].data[26].opcode_data.opcode
         // );
 
-        let memory_trace = evaluate_memory_witness_for_executor_family::<_, Global>(
+        let _memory_trace = evaluate_memory_witness_for_executor_family::<_, Global>(
             &mul_div_circuit,
             NUM_CYCLES_PER_CHUNK,
             &oracle,
@@ -1287,7 +1292,7 @@ pub fn run_basic_unrolled_test_impl(
         println!("Trying to prove");
 
         let now = std::time::Instant::now();
-        let (prover_data, proof) = prove_configured_for_unrolled_circuits::<
+        let (_prover_data, _proof) = prove_configured_for_unrolled_circuits::<
             DEFAULT_TRACE_PADDING_MULTIPLE,
             _,
             DefaultTreeConstructor,
@@ -1352,7 +1357,7 @@ pub fn run_basic_unrolled_test_impl(
         //     family_data[0].data[29].opcode_data.opcode
         // );
 
-        let memory_trace = evaluate_memory_witness_for_executor_family::<_, Global>(
+        let _memory_trace = evaluate_memory_witness_for_executor_family::<_, Global>(
             &load_store_circuit,
             NUM_CYCLES_PER_CHUNK,
             &oracle,
@@ -1400,7 +1405,7 @@ pub fn run_basic_unrolled_test_impl(
         println!("Trying to prove");
 
         let now = std::time::Instant::now();
-        let (prover_data, proof) = prove_configured_for_unrolled_circuits::<
+        let (_prover_data, _proof) = prove_configured_for_unrolled_circuits::<
             DEFAULT_TRACE_PADDING_MULTIPLE,
             _,
             DefaultTreeConstructor,
@@ -1572,7 +1577,6 @@ fn test_single_non_mem_circuit() {
     use crate::cs::cs::cs_reference::BasicAssembly;
     use cs::cs::circuit::Circuit;
     use cs::machine::ops::unrolled::add_sub_lui_auipc_mop::*;
-    use cs::machine::ops::unrolled::shift_binary_csr::*;
     use std::path::Path;
 
     let family_idx = ADD_SUB_LUI_AUIPC_MOP_CIRCUIT_FAMILY_IDX;
@@ -1689,7 +1693,7 @@ fn test_bigint_with_replayer_oracle() {
         }
 
         let register = Register(output_extended_state_vars.map(|el| Num::Var(el)));
-        let result_x12 = register.get_value_unsigned(&cs).unwrap();
+        let _result_x12 = register.get_value_unsigned(&cs).unwrap();
 
         // assert_eq!(expected_x12, result_x12, "x12 diverged for round {}", round);
 

--- a/prover/src/tests/unrolled/mod.rs
+++ b/prover/src/tests/unrolled/mod.rs
@@ -13,6 +13,7 @@ use cs::machine::ops::unrolled::*;
 use cs::machine::NON_DETERMINISM_CSR;
 use risc_v_simulator::abstractions::non_determinism::QuasiUARTSource;
 use risc_v_simulator::{cycle::*, delegations::DelegationsCSRProcessor};
+#[cfg(test)]
 use riscv_transpiler::witness::delegation::bigint::BigintDelegationWitness;
 use std::alloc::Allocator;
 use std::collections::BTreeSet;
@@ -621,6 +622,13 @@ fn run_basic_unrolled_test() {
     run_basic_unrolled_test_impl(None);
 }
 
+#[cfg_attr(
+    all(feature = "test", not(test)),
+    expect(
+        dead_code,
+        reason = "feature=test compiles helper, but it is called only by #[test] wrapper"
+    )
+)]
 pub fn run_basic_unrolled_test_impl(
     _maybe_gpu_comparison_hook: Option<Box<dyn Fn(&GpuComparisonArgs)>>,
 ) {

--- a/prover/src/tests/unrolled/reduced_machine.rs
+++ b/prover/src/tests/unrolled/reduced_machine.rs
@@ -1,22 +1,18 @@
-#![allow(dead_code, unused_imports, unused_variables)]
-
 use super::*;
 
 use crate::unrolled::evaluate_witness_for_unified_executor;
 use crate::unrolled::UnifiedRiscvCircuitOracle;
-use common_constants::circuit_families::*;
 use common_constants::delegation_types::blake2s_with_control::BLAKE2S_DELEGATION_CSR_REGISTER;
 use cs::cs::circuit::Circuit;
-use cs::machine::ops::unrolled::*;
 use cs::machine::NON_DETERMINISM_CSR;
 use risc_v_simulator::abstractions::non_determinism::QuasiUARTSource;
 use risc_v_simulator::machine_mode_only_unrolled::UnifiedOpcodeTracingDataWithTimestamp;
-use risc_v_simulator::{cycle::*, delegations::DelegationsCSRProcessor};
 use riscv_transpiler::witness::UnifiedDestinationHolder;
 
 use crate::prover_stages::unrolled_prover::prove_configured_for_unrolled_circuits;
 use crate::witness_evaluator::unrolled::evaluate_memory_witness_for_unified_executor;
 
+#[allow(unused_imports)]
 pub mod reduced_machine {
     use crate::unrolled::UnifiedRiscvCircuitOracle;
     use crate::witness_evaluator::SimpleWitnessProxy;
@@ -50,7 +46,7 @@ fn run_unrolled_reduced_test() {
 }
 
 pub fn run_unrolled_reduced_test_impl(
-    maybe_gpu_comparison_hook: Option<Box<dyn Fn(&GpuComparisonArgs)>>,
+    _maybe_gpu_comparison_hook: Option<Box<dyn Fn(&GpuComparisonArgs)>>,
 ) {
     use riscv_transpiler::ir::*;
     use riscv_transpiler::replayer::*;
@@ -125,14 +121,14 @@ pub fn run_unrolled_reduced_test_impl(
 
     dbg!(state.counters);
 
-    let total_snapshots = snapshotter.snapshots.len();
-    let cycles_upper_bound = cycles_bound;
+    let _total_snapshots = snapshotter.snapshots.len();
+    let _cycles_upper_bound = cycles_bound;
 
     let exact_cycles_passed = (state.timestamp - INITIAL_TIMESTAMP) / TIMESTAMP_STEP;
 
     println!("Passed exactly {} cycles", exact_cycles_passed);
 
-    let counters = snapshotter.snapshots.last().unwrap().state.counters;
+    let _counters = snapshotter.snapshots.last().unwrap().state.counters;
 
     let shuffle_ram_touched_addresses = ram.collect_inits_and_teardowns(&worker, Global);
 
@@ -464,7 +460,7 @@ pub fn run_unrolled_reduced_test_impl(
         println!("Trying to prove");
 
         let now = std::time::Instant::now();
-        let (prover_data, proof) = prove_configured_for_unrolled_circuits::<
+        let (_prover_data, proof) = prove_configured_for_unrolled_circuits::<
             DEFAULT_TRACE_PADDING_MULTIPLE,
             _,
             DefaultTreeConstructor,
@@ -502,21 +498,21 @@ pub fn run_unrolled_reduced_test_impl(
         // assert_eq!(expected_init_set.len(), flattened_inits_and_teardowns.len());
 
         if flattened_inits_and_teardowns.len() != expected_init_set.len() {
-            for (idx, (address, (teardown_ts, teardown_value))) in
+            for (_idx, (address, (teardown_ts, teardown_value))) in
                 flattened_inits_and_teardowns.iter().enumerate()
             {
                 let mut init_set_el = None;
-                for (i, (is_reg, addr, ts, init_value)) in expected_init_set.iter().enumerate() {
+                for (_i, (is_reg, addr, ts, init_value)) in expected_init_set.iter().enumerate() {
                     if *addr == *address {
                         init_set_el = Some((*is_reg, *addr, *ts, *init_value));
                     }
                 }
-                let Some(init_set_el) = init_set_el else {
+                let Some(_init_set_el) = init_set_el else {
                     panic!("No expected init set element for address {} of flattened inits or teardowns", *address);
                 };
 
                 let mut teardown_set_el = None;
-                for (i, (is_reg, addr, ts, teardown_value)) in
+                for (_i, (is_reg, addr, ts, teardown_value)) in
                     expected_teardown_set.iter().enumerate()
                 {
                     if *addr == *address {

--- a/prover/src/tests/unrolled/reduced_machine.rs
+++ b/prover/src/tests/unrolled/reduced_machine.rs
@@ -45,6 +45,13 @@ fn run_unrolled_reduced_test() {
     run_unrolled_reduced_test_impl(None);
 }
 
+#[cfg_attr(
+    all(feature = "test", not(test)),
+    expect(
+        dead_code,
+        reason = "feature=test compiles helper, but it is called only by #[test] wrapper"
+    )
+)]
 pub fn run_unrolled_reduced_test_impl(
     _maybe_gpu_comparison_hook: Option<Box<dyn Fn(&GpuComparisonArgs)>>,
 ) {

--- a/prover/src/tests/unrolled/reduced_machine.rs
+++ b/prover/src/tests/unrolled/reduced_machine.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_imports, unused_variables)]
+
 use super::*;
 
 use crate::unrolled::evaluate_witness_for_unified_executor;

--- a/prover/src/tests/unrolled/with_transpiler.rs
+++ b/prover/src/tests/unrolled/with_transpiler.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code, unused_imports, unused_variables)]
-
 use super::*;
 use riscv_transpiler::replayer::*;
 use std::collections::BTreeSet;
@@ -121,7 +119,7 @@ pub fn run_basic_unrolled_test_in_transpiler_with_word_specialization_impl(
 
     dbg!(state.counters);
 
-    let total_snapshots = snapshotter.snapshots.len();
+    let _total_snapshots = snapshotter.snapshots.len();
 
     let exact_cycles_passed = (state.timestamp - INITIAL_TIMESTAMP) / TIMESTAMP_STEP;
 
@@ -1532,7 +1530,7 @@ pub fn run_basic_unrolled_test_in_transpiler_with_word_specialization_impl(
 
         let inits_data = &inits_and_teardowns[0];
 
-        let memory_trace = evaluate_init_and_teardown_memory_witness::<Global>(
+        let _memory_trace = evaluate_init_and_teardown_memory_witness::<Global>(
             &inits_and_teardowns_circuit,
             NUM_CYCLES_PER_CHUNK,
             &inits_data.lazy_init_data,
@@ -1709,7 +1707,7 @@ pub fn run_basic_unrolled_test_in_transpiler_with_word_specialization_impl(
             "Evaluating memory-only witness for delegation circuit {}",
             delegation_type
         );
-        let mem_only_witness = evaluate_delegation_memory_witness(
+        let _mem_only_witness = evaluate_delegation_memory_witness(
             &circuit,
             NUM_DELEGATION_CYCLES,
             &oracle,
@@ -1889,7 +1887,7 @@ pub fn run_basic_unrolled_test_in_transpiler_with_word_specialization_impl(
             "Evaluating memory-only witness for delegation circuit {}",
             delegation_type
         );
-        let mem_only_witness = evaluate_delegation_memory_witness(
+        let _mem_only_witness = evaluate_delegation_memory_witness(
             &circuit,
             NUM_DELEGATION_CYCLES,
             &oracle,
@@ -2016,21 +2014,21 @@ pub fn run_basic_unrolled_test_in_transpiler_with_word_specialization_impl(
         // assert_eq!(expected_init_set.len(), flattened_inits_and_teardowns.len());
 
         if flattened_inits_and_teardowns.len() != expected_init_set.len() {
-            for (idx, (address, (teardown_ts, teardown_value))) in
+            for (_idx, (address, (teardown_ts, teardown_value))) in
                 flattened_inits_and_teardowns.iter().enumerate()
             {
                 let mut init_set_el = None;
-                for (i, (is_reg, addr, ts, init_value)) in expected_init_set.iter().enumerate() {
+                for (_i, (is_reg, addr, ts, init_value)) in expected_init_set.iter().enumerate() {
                     if *addr == *address {
                         init_set_el = Some((*is_reg, *addr, *ts, *init_value));
                     }
                 }
-                let Some(init_set_el) = init_set_el else {
+                let Some(_init_set_el) = init_set_el else {
                     panic!("No expected init set element for address {} of flattened inits or teardowns", *address);
                 };
 
                 let mut teardown_set_el = None;
-                for (i, (is_reg, addr, ts, teardown_value)) in
+                for (_i, (is_reg, addr, ts, teardown_value)) in
                     expected_teardown_set.iter().enumerate()
                 {
                     if *addr == *address {

--- a/prover/src/tests/unrolled/with_transpiler.rs
+++ b/prover/src/tests/unrolled/with_transpiler.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_imports, unused_variables)]
+
 use super::*;
 use riscv_transpiler::replayer::*;
 use std::collections::BTreeSet;

--- a/prover/src/tracer.rs
+++ b/prover/src/tracer.rs
@@ -2,8 +2,6 @@ use crate::definitions::LazyInitAndTeardown;
 use cs::definitions::TimestampScalar;
 use fft::GoodAllocator;
 pub use risc_v_simulator::abstractions::memory::VectorMemoryImplWithRom;
-use risc_v_simulator::abstractions::memory::*;
-use risc_v_simulator::cycle::status_registers::*;
 use std::alloc::Global;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/prover/src/tracers/delegation.rs
+++ b/prover/src/tracers/delegation.rs
@@ -57,6 +57,7 @@ impl<A: GoodAllocator> DelegationWitness<A> {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn skip_n(&mut self, n: usize) {
         self.write_timestamp = self.write_timestamp[n..].to_vec_in(A::default());
         self.register_accesses = self.register_accesses

--- a/prover/src/tracers/oracles/transpiler_oracles/mod.rs
+++ b/prover/src/tracers/oracles/transpiler_oracles/mod.rs
@@ -1,5 +1,3 @@
-use super::*;
-
 // Oracles for mem and non-mem families are just the same as in the baseline
 // case of unrolled cirucits, so we need to only handle the case of delegaitons,
 // and of unified cycle

--- a/prover/src/tracers/unrolled/tracer.rs
+++ b/prover/src/tracers/unrolled/tracer.rs
@@ -106,7 +106,10 @@ pub struct UnrolledGPUFriendlyTracer<
     pub _marker: core::marker::PhantomData<C>,
 }
 
-#[allow(deprecated)]
+#[expect(
+    deprecated,
+    reason = "uses deprecated machine/tracer APIs during migration"
+)]
 impl<
         C: MachineConfig,
         A: GoodAllocator,
@@ -217,7 +220,10 @@ impl<
     }
 }
 
-#[allow(deprecated)]
+#[expect(
+    deprecated,
+    reason = "implements deprecated tracing trait for compatibility"
+)]
 impl<
         C: MachineConfig,
         A: GoodAllocator,

--- a/prover/src/tracers/unrolled/tracer.rs
+++ b/prover/src/tracers/unrolled/tracer.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated, dead_code, unused_mut, unused_variables)]
-
 use crate::fft::GoodAllocator;
 use risc_v_simulator::abstractions::tracer::RegisterOrIndirectReadData;
 use risc_v_simulator::abstractions::tracer::RegisterOrIndirectReadWriteData;
@@ -15,11 +13,16 @@ use risc_v_simulator::machine_mode_only_unrolled::*;
 
 pub(crate) const NUM_OPCODE_FAMILIES_NO_RAM: usize = 4;
 
+#[allow(dead_code)]
 pub(crate) const RS1_ACCESS_IDX: TimestampScalar = 0;
+#[allow(dead_code)]
 pub(crate) const RS2_ACCESS_IDX: TimestampScalar = 1;
+#[allow(dead_code)]
 pub(crate) const RD_ACCESS_IDX: TimestampScalar = 2;
 pub(crate) const DELEGATION_ACCESS_IDX: TimestampScalar = 3;
+#[allow(dead_code)]
 pub(crate) const RAM_READ_ACCESS_IDX: TimestampScalar = RS2_ACCESS_IDX;
+#[allow(dead_code)]
 pub(crate) const RAM_WRITE_ACCESS_IDX: TimestampScalar = RD_ACCESS_IDX;
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -103,6 +106,7 @@ pub struct UnrolledGPUFriendlyTracer<
     pub _marker: core::marker::PhantomData<C>,
 }
 
+#[allow(deprecated)]
 impl<
         C: MachineConfig,
         A: GoodAllocator,
@@ -165,6 +169,7 @@ impl<
     }
 
     #[inline]
+    #[allow(dead_code)]
     fn update_reg_access_timestamp<const ACCESS_IDX: u64>(
         &mut self,
         reg_idx: u8,
@@ -182,6 +187,7 @@ impl<
     }
 
     #[inline]
+    #[allow(dead_code)]
     fn update_ram_access_timestmap<const ACCESS_IDX: u64>(
         &mut self,
         phys_address: u64,
@@ -211,6 +217,7 @@ impl<
     }
 }
 
+#[allow(deprecated)]
 impl<
         C: MachineConfig,
         A: GoodAllocator,
@@ -239,7 +246,7 @@ impl<
     }
 
     #[inline]
-    fn trace_non_mem_step(&mut self, family: u8, mut data: NonMemoryOpcodeTracingData) {
+    fn trace_non_mem_step(&mut self, _family: u8, _data: NonMemoryOpcodeTracingData) {
         panic!("deprecated");
         // let mut rs1_read_timestamp = TimestampData::EMPTY;
         // let mut rs2_read_timestamp = TimestampData::EMPTY;
@@ -276,7 +283,7 @@ impl<
     }
 
     #[inline]
-    fn trace_mem_load_step(&mut self, data: LoadOpcodeTracingData) {
+    fn trace_mem_load_step(&mut self, _data: LoadOpcodeTracingData) {
         panic!("deprecated");
         // let mut rs1_read_timestamp = TimestampData::EMPTY;
         // let mut rs2_or_ram_read_timestamp = TimestampData::EMPTY;
@@ -313,7 +320,7 @@ impl<
         // }
     }
 
-    fn trace_mem_store_step(&mut self, data: StoreOpcodeTracingData) {
+    fn trace_mem_store_step(&mut self, _data: StoreOpcodeTracingData) {
         panic!("deprecated");
         // let mut rs1_read_timestamp = TimestampData::EMPTY;
         // let mut rs2_or_ram_read_timestamp = TimestampData::EMPTY;

--- a/prover/src/tracers/unrolled/tracer.rs
+++ b/prover/src/tracers/unrolled/tracer.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated, dead_code, unused_mut, unused_variables)]
+
 use crate::fft::GoodAllocator;
 use risc_v_simulator::abstractions::tracer::RegisterOrIndirectReadData;
 use risc_v_simulator::abstractions::tracer::RegisterOrIndirectReadWriteData;

--- a/prover/src/witness_evaluator/unrolled/mod.rs
+++ b/prover/src/witness_evaluator/unrolled/mod.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated, unused_imports, unused_variables)]
+
 use core::mem::MaybeUninit;
 
 use super::*;

--- a/prover/src/witness_evaluator/unrolled/mod.rs
+++ b/prover/src/witness_evaluator/unrolled/mod.rs
@@ -1,20 +1,12 @@
-#![allow(deprecated, unused_imports, unused_variables)]
-
 use core::mem::MaybeUninit;
 
 use super::*;
 use crate::tracers::delegation::DelegationWitness;
 use crate::tracers::unrolled::tracer::*;
 // use crate::tracers::unrolled::word_specialized_tracer::WordSpecializedTracer;
-use cs::machine::machine_configurations::full_isa_with_delegation_no_exceptions::FullIsaMachineWithDelegationNoExceptionHandling;
-use cs::machine::machine_configurations::full_isa_with_delegation_no_exceptions_no_signed_mul_div::FullIsaMachineWithDelegationNoExceptionHandlingNoSignedMulDiv;
-use cs::machine::machine_configurations::minimal_no_exceptions_with_delegation::MinimalMachineNoExceptionHandlingWithDelegation;
 use risc_v_simulator::cycle::MachineConfig;
+use risc_v_simulator::machine_mode_only_unrolled::DelegationCSRProcessor;
 use risc_v_simulator::machine_mode_only_unrolled::UnifiedOpcodeTracingDataWithTimestamp;
-use risc_v_simulator::machine_mode_only_unrolled::{
-    DelegationCSRProcessor, RiscV32StateForUnrolledProver,
-};
-use riscv_transpiler::ir::preprocess_bytecode;
 use riscv_transpiler::witness::delegation::bigint::BigintDelegationWitness;
 use riscv_transpiler::witness::delegation::blake2_round_function::Blake2sRoundFunctionDelegationWitness;
 use riscv_transpiler::witness::delegation::keccak_special5::KeccakSpecial5DelegationWitness;
@@ -23,6 +15,7 @@ mod family_circuits;
 
 pub use self::family_circuits::*;
 
+#[allow(deprecated)]
 pub fn run_unrolled_machine_for_num_cycles<
     CSR: DelegationCSRProcessor,
     C: MachineConfig,
@@ -58,7 +51,10 @@ pub fn run_unrolled_machine_for_num_cycles<
 
     let now = std::time::Instant::now();
 
-    let mut state = RiscV32StateForUnrolledProver::<C>::initial(initial_pc);
+    let mut state =
+        risc_v_simulator::machine_mode_only_unrolled::RiscV32StateForUnrolledProver::<C>::initial(
+            initial_pc,
+        );
 
     let ram_tracer =
         RamTracingData::<true>::new_for_ram_size_and_rom_bound(ram_bound, rom_address_space_bound);
@@ -465,16 +461,16 @@ pub fn run_unrolled_machine<
     let preprocessed_bytecode: Vec<_> = if core::any::TypeId::of::<C>()
         == core::any::TypeId::of::<risc_v_simulator::cycle::IMStandardIsaConfig>()
     {
-        preprocess_bytecode::<FullMachineDecoderConfig>(text_section)
+        riscv_transpiler::ir::preprocess_bytecode::<FullMachineDecoderConfig>(text_section)
     } else if core::any::TypeId::of::<C>()
         == core::any::TypeId::of::<risc_v_simulator::cycle::IMStandardIsaConfigWithUnsignedMulDiv>()
     {
-        preprocess_bytecode::<FullUnsignedMachineDecoderConfig>(text_section)
+        riscv_transpiler::ir::preprocess_bytecode::<FullUnsignedMachineDecoderConfig>(text_section)
     } else if core::any::TypeId::of::<C>()
         == core::any::TypeId::of::<risc_v_simulator::cycle::IWithoutByteAccessIsaConfigWithDelegation>(
         )
     {
-        preprocess_bytecode::<ReducedMachineDecoderConfig>(text_section)
+        riscv_transpiler::ir::preprocess_bytecode::<ReducedMachineDecoderConfig>(text_section)
     } else {
         panic!("Unknown machine config {}", core::any::type_name::<C>());
     };
@@ -790,16 +786,16 @@ pub fn run_unified_machine<
     let preprocessed_bytecode: Vec<_> = if core::any::TypeId::of::<C>()
         == core::any::TypeId::of::<risc_v_simulator::cycle::IMStandardIsaConfig>()
     {
-        preprocess_bytecode::<FullMachineDecoderConfig>(text_section)
+        riscv_transpiler::ir::preprocess_bytecode::<FullMachineDecoderConfig>(text_section)
     } else if core::any::TypeId::of::<C>()
         == core::any::TypeId::of::<risc_v_simulator::cycle::IMStandardIsaConfigWithUnsignedMulDiv>()
     {
-        preprocess_bytecode::<FullUnsignedMachineDecoderConfig>(text_section)
+        riscv_transpiler::ir::preprocess_bytecode::<FullUnsignedMachineDecoderConfig>(text_section)
     } else if core::any::TypeId::of::<C>()
         == core::any::TypeId::of::<risc_v_simulator::cycle::IWithoutByteAccessIsaConfigWithDelegation>(
         )
     {
-        preprocess_bytecode::<ReducedMachineDecoderConfig>(text_section)
+        riscv_transpiler::ir::preprocess_bytecode::<ReducedMachineDecoderConfig>(text_section)
     } else {
         panic!("Unknown machine config {}", core::any::type_name::<C>());
     };
@@ -836,7 +832,7 @@ pub fn run_unified_machine<
         last_access_timestamp: el.timestamp,
     });
 
-    let total_snapshots = snapshotter.snapshots.len();
+    let _total_snapshots = snapshotter.snapshots.len();
     let exact_cycles_passed = (state.timestamp - INITIAL_TIMESTAMP) / TIMESTAMP_STEP;
     let final_pc = state.pc;
     let final_timestamp = state.timestamp;
@@ -854,7 +850,7 @@ pub fn run_unified_machine<
         == core::any::TypeId::of::<
             risc_v_simulator::cycle::IWithoutByteAccessIsaConfigWithDelegation,
         >();
-    let replay_mul_circuits = core::any::TypeId::of::<C>()
+    let _replay_mul_circuits = core::any::TypeId::of::<C>()
         != core::any::TypeId::of::<
             risc_v_simulator::cycle::IWithoutByteAccessIsaConfigWithDelegation,
         >();
@@ -1476,10 +1472,6 @@ pub(crate) fn replay_generic_work<
     work_type_idx: usize,
     worker: &Worker,
 ) -> Vec<Vec<D::Element, A>> {
-    use risc_v_simulator::machine_mode_only_unrolled::*;
-    use riscv_transpiler::vm::Counters;
-    use riscv_transpiler::witness::DestinationHolderConstructor;
-
     let counters = snapshotter
         .snapshots
         .last()
@@ -1605,7 +1597,6 @@ pub(crate) fn replay_generic_work<
 
             use riscv_transpiler::replayer::*;
             use riscv_transpiler::vm::ReplayBuffer;
-            use riscv_transpiler::witness::*;
 
             let tape_ref = tape;
             let snapshotter_ref = &snapshotter;

--- a/prover/src/witness_evaluator/unrolled/mod.rs
+++ b/prover/src/witness_evaluator/unrolled/mod.rs
@@ -15,7 +15,10 @@ mod family_circuits;
 
 pub use self::family_circuits::*;
 
-#[allow(deprecated)]
+#[expect(
+    deprecated,
+    reason = "delegation CSR path still depends on deprecated unrolled machine APIs"
+)]
 pub fn run_unrolled_machine_for_num_cycles<
     CSR: DelegationCSRProcessor,
     C: MachineConfig,

--- a/riscv_transpiler/src/lib.rs
+++ b/riscv_transpiler/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(vec_push_within_capacity)]
 #![feature(allocator_api)]
 #![feature(widening_mul)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(maybe_uninit_array_assume_init)]
 #![feature(likely_unlikely)]
 #![feature(pointer_is_aligned_to)]

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -407,11 +407,12 @@ fn main() {
         } => flatten_two(first_metadata, second_metadata, output_file),
         Commands::GenerateConstants {
             bin,
-            universal_verifier,
-            recompute,
-            mode,
+            universal_verifier: _,
+            recompute: _,
+            mode: _,
         } => {
-            let base_layer_bin = std::fs::read(bin).expect("Failed to read base layer binary file");
+            let _base_layer_bin =
+                std::fs::read(bin).expect("Failed to read base layer binary file");
             todo!()
             // let (end_params, aux_values) = generate_constants_for_binary(
             //     &base_layer_bin,

--- a/tools/cli/src/prover_utils.rs
+++ b/tools/cli/src/prover_utils.rs
@@ -54,7 +54,7 @@ pub fn u32_from_hex_string(hex_string: &str) -> Vec<u32> {
 }
 
 #[cfg(feature = "gpu")]
-pub fn multi_prove(bin_path: &String, input_files: Vec<Vec<u32>>) {
+pub fn multi_prove(_bin_path: &String, _input_files: Vec<Vec<u32>>) {
     todo!();
     /*
     let binary = load_binary_from_path(bin_path);
@@ -259,11 +259,13 @@ pub struct GpuSharedState {
 
 #[cfg(feature = "gpu")]
 impl GpuSharedState {
+    #[expect(dead_code, reason = "reserved key for pending GPU implementation")]
     const MAIN_BINARY_KEY: usize = 0;
+    #[expect(dead_code, reason = "reserved key for pending GPU implementation")]
     const RECURSION_BINARY_KEY: usize = 1;
 
     #[cfg(feature = "gpu")]
-    pub fn new(binary: &Vec<u32>) -> Self {
+    pub fn new(_binary: &Vec<u32>) -> Self {
         todo!()
         // use execution_utils::verifier_binaries::UNIVERSAL_CIRCUIT_VERIFIER;
         // use gpu_prover::execution::prover::ExecutionProver;
@@ -304,7 +306,7 @@ pub fn create_proofs_internal(
     num_instances: usize,
     prev_end_params_output: Option<([u32; 8], Option<[u32; 16]>)>,
     gpu_shared_state: &mut Option<&mut GpuSharedState>,
-    total_proof_time: &mut Option<f64>,
+    _total_proof_time: &mut Option<f64>,
 ) -> (ProofList, ProofMetadata) {
     let worker = worker::Worker::new();
 
@@ -320,11 +322,11 @@ pub fn create_proofs_internal(
                 panic!("Are you sure that you want to pass --prev-metadata to basic proof?");
             }
             let (basic_proofs, delegation_proofs, register_values, pow_challenge) =
-                if let Some(gpu_shared_state) = gpu_shared_state {
+                if let Some(_gpu_shared_state) = gpu_shared_state {
                     #[cfg(feature = "gpu")]
                     {
                         println!("**** proving using GPU ****");
-                        let timer = std::time::Instant::now();
+                        let _timer = std::time::Instant::now();
                         /*let (final_register_values, basic_proofs, delegation_proofs) =
                             gpu_shared_state.prover.commit_memory_and_prove(
                                 0,
@@ -344,8 +346,6 @@ pub fn create_proofs_internal(
                     }
                     #[cfg(not(feature = "gpu"))]
                     {
-                        let _ = gpu_shared_state;
-                        let _ = total_proof_time;
                         panic!("GPU not enabled - please compile with --features gpu flag.")
                     }
                 } else {
@@ -377,11 +377,11 @@ pub fn create_proofs_internal(
         }
         Machine::Reduced => {
             let (reduced_proofs, delegation_proofs, register_values, pow_challenge) =
-                if let Some(gpu_shared_state) = gpu_shared_state {
+                if let Some(_gpu_shared_state) = gpu_shared_state {
                     #[cfg(feature = "gpu")]
                     {
                         println!("**** proving using GPU ****");
-                        let timer = std::time::Instant::now();
+                        let _timer = std::time::Instant::now();
                         /*let (final_register_values, basic_proofs, delegation_proofs) =
                             gpu_shared_state.prover.commit_memory_and_prove(
                                 0,
@@ -401,8 +401,6 @@ pub fn create_proofs_internal(
                     }
                     #[cfg(not(feature = "gpu"))]
                     {
-                        let _ = gpu_shared_state;
-                        let _ = total_proof_time;
                         panic!("GPU not enabled - please compile with --features gpu flag.")
                     }
                 } else {
@@ -434,11 +432,11 @@ pub fn create_proofs_internal(
         }
         Machine::ReducedLog23 => {
             let (reduced_log_23_proofs, delegation_proofs, register_values, pow_challenge) =
-                if let Some(gpu_shared_state) = gpu_shared_state {
+                if let Some(_gpu_shared_state) = gpu_shared_state {
                     #[cfg(feature = "gpu")]
                     {
                         println!("**** proving using GPU ****");
-                        let timer = std::time::Instant::now();
+                        let _timer = std::time::Instant::now();
                         /*let (final_register_values, basic_proofs, delegation_proofs) =
                             gpu_shared_state.prover.commit_memory_and_prove(
                                 0,
@@ -458,8 +456,6 @@ pub fn create_proofs_internal(
                     }
                     #[cfg(not(feature = "gpu"))]
                     {
-                        let _ = gpu_shared_state;
-                        let _ = total_proof_time;
                         panic!("GPU not enabled - please compile with --features gpu flag.")
                     }
                 } else {

--- a/tools/cli/src/prover_utils.rs
+++ b/tools/cli/src/prover_utils.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unreachable_code, unused_variables)]
+
 use clap::ValueEnum;
 pub use execution_utils::{
     generate_oracle_data_for_universal_verifier, generate_oracle_data_from_metadata_and_proof_list,

--- a/tools/cli/src/prover_utils.rs
+++ b/tools/cli/src/prover_utils.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code, unreachable_code, unused_variables)]
-
 use clap::ValueEnum;
 pub use execution_utils::{
     generate_oracle_data_for_universal_verifier, generate_oracle_data_from_metadata_and_proof_list,
@@ -316,7 +314,7 @@ pub fn create_proofs_internal(
         non_determinism_source.oracle.push_back(entry);
     }
 
-    let (proof_list, register_values) = match machine {
+    let (proof_list, register_values, pow_challenge) = match machine {
         Machine::Standard => {
             if prev_end_params_output.is_some() {
                 panic!("Are you sure that you want to pass --prev-metadata to basic proof?");
@@ -374,6 +372,7 @@ pub fn create_proofs_internal(
                     delegation_proofs,
                 },
                 register_values,
+                pow_challenge,
             )
         }
         Machine::Reduced => {
@@ -430,6 +429,7 @@ pub fn create_proofs_internal(
                     delegation_proofs,
                 },
                 register_values,
+                pow_challenge,
             )
         }
         Machine::ReducedLog23 => {
@@ -489,6 +489,7 @@ pub fn create_proofs_internal(
                     delegation_proofs,
                 },
                 register_values,
+                pow_challenge,
             )
         }
     };
@@ -531,19 +532,19 @@ pub fn create_proofs_internal(
         end_params,
         prev_end_params_output_hash,
         prev_end_params_output,
-        pow_challenge: todo!(),
+        pow_challenge,
     };
 
     (proof_list, proof_metadata)
 }
 
 pub fn create_recursion_proofs(
-    proof_list: ProofList,
-    proof_metadata: ProofMetadata,
-    recursion_mode: RecursionStrategy,
-    tmp_dir: &Option<String>,
-    gpu_shared_state: &mut Option<&mut GpuSharedState>,
-    total_proof_time: &mut Option<f64>,
+    _proof_list: ProofList,
+    _proof_metadata: ProofMetadata,
+    _recursion_mode: RecursionStrategy,
+    _tmp_dir: &Option<String>,
+    _gpu_shared_state: &mut Option<&mut GpuSharedState>,
+    _total_proof_time: &mut Option<f64>,
 ) -> (ProofList, ProofMetadata) {
     todo!()
     // assert!(
@@ -643,12 +644,12 @@ pub fn create_final_proofs_from_program_proof(
 }
 
 pub fn create_final_proofs(
-    proof_list: ProofList,
-    proof_metadata: ProofMetadata,
-    recursion_mode: RecursionStrategy,
-    tmp_dir: &Option<String>,
-    gpu_shared_state: &mut Option<&mut GpuSharedState>,
-    total_proof_time: &mut Option<f64>,
+    _proof_list: ProofList,
+    _proof_metadata: ProofMetadata,
+    _recursion_mode: RecursionStrategy,
+    _tmp_dir: &Option<String>,
+    _gpu_shared_state: &mut Option<&mut GpuSharedState>,
+    _total_proof_time: &mut Option<f64>,
 ) -> ProgramProof {
     todo!()
     // let binary = recursion_mode.get_second_layer_binary();

--- a/tools/cli/src/vk.rs
+++ b/tools/cli/src/vk.rs
@@ -1,8 +1,7 @@
 use execution_utils::Machine;
 // use execution_utils::verifier_binaries::VerificationKey;
-use sha3::{Digest, Keccak256};
 
-pub fn generate_vk(bin_path: &String, machine: &Option<Machine>, output: &Option<String>) {
+pub fn generate_vk(_bin_path: &String, _machine: &Option<Machine>, _output: &Option<String>) {
     todo!();
 
     // let binary = std::fs::read(bin_path).expect("Failed to read binary file");

--- a/tools/pow_config_generator/src/main.rs
+++ b/tools/pow_config_generator/src/main.rs
@@ -4,8 +4,7 @@ use std::{
     process::{Command, Stdio},
 };
 
-use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt, quote};
+use quote::quote;
 
 fn main() {
     println!("Running PoW Config Generator");
@@ -519,6 +518,7 @@ fn pow_bits_for_folding_round(
     }
 }
 
+#[allow(dead_code)]
 fn pow_bits_for_queries(security_bits: usize, num_queries: usize, lde_factor_log2: usize) -> usize {
     // We should add extra 20% of queries
     let queries_contribution = 5 * num_queries / 6;

--- a/transcript/src/lib.rs
+++ b/transcript/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "pow"), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 
 use blake2s_u32::*;
 

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![cfg_attr(not(any(test, feature = "proof_utils")), feature(allocator_api))]
 #![allow(incomplete_features)]

--- a/verifier_common/src/lib.rs
+++ b/verifier_common/src/lib.rs
@@ -1,12 +1,11 @@
 #![cfg_attr(not(any(test, feature = "replace_csr")), no_std)]
 #![cfg_attr(any(test, feature = "proof_utils"), feature(allocator_api))]
-#![feature(ptr_as_ref_unchecked)]
 #![feature(slice_from_ptr_range)]
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
-#[cfg(any(all(feature = "security_80", feature = "security_100"),))]
-compile_error!("multiple security levels selected same time");
+#[cfg(all(feature = "security_80", feature = "security_100"))]
+compile_error!("multiple security levels selected at the same time");
 
 pub const MERSENNE31QUARTIC_SIZE_LOG2: usize = 124;
 pub const POW_BITS_FOR_80_SECURITY_BITS: usize = 28;
@@ -16,7 +15,7 @@ pub const POW_BITS_FOR_100_SECURITY_BITS: usize = 28;
 pub const SECURITY_BITS: usize = 80;
 #[cfg(all(feature = "security_80", not(feature = "worst_case_config_generation")))]
 pub const MEMORY_DELEGATION_POW_BITS: usize =
-    POW_BITS_FOR_MEMORY_AND_DELEGATION_FOR_80_SECURITY_BITS;
+    pow_config_worst_constants::MEMORY_DELEGATION_POW_BITS_80;
 
 #[cfg(feature = "security_100")]
 pub const SECURITY_BITS: usize = 100;
@@ -25,7 +24,7 @@ pub const SECURITY_BITS: usize = 100;
     not(feature = "worst_case_config_generation")
 ))]
 pub const MEMORY_DELEGATION_POW_BITS: usize =
-    POW_BITS_FOR_MEMORY_AND_DELEGATION_FOR_100_SECURITY_BITS;
+    pow_config_worst_constants::MEMORY_DELEGATION_POW_BITS_100;
 
 #[cfg(feature = "worst_case_config_generation")]
 pub const MEMORY_DELEGATION_POW_BITS: usize = 0;
@@ -60,7 +59,17 @@ impl<const NUM_FOLDINGS: usize> SizedProofSecurityConfig<NUM_FOLDINGS> {
 
 // The file should be generated with tools/pow_config_generator
 #[cfg(not(feature = "worst_case_config_generation"))]
-include!("pow_config_worst_constants.rs");
+#[allow(dead_code)]
+mod pow_config_worst_constants {
+    use super::SizedProofSecurityConfig;
+
+    include!("pow_config_worst_constants.rs");
+
+    pub(super) const MEMORY_DELEGATION_POW_BITS_80: usize =
+        POW_BITS_FOR_MEMORY_AND_DELEGATION_FOR_80_SECURITY_BITS;
+    pub(super) const MEMORY_DELEGATION_POW_BITS_100: usize =
+        POW_BITS_FOR_MEMORY_AND_DELEGATION_FOR_100_SECURITY_BITS;
+}
 
 #[cfg(feature = "worst_case_config_generation")]
 impl<const NUM_FOLDINGS: usize> SizedProofSecurityConfig<NUM_FOLDINGS> {


### PR DESCRIPTION
## What

This PR delivers a workspace-wide warning/lint hygiene cleanup, with no intended runtime behavior change.

- Warning noise is reduced across touched crates (`cs`, `field`, `fft`, `prover`, `execution_utils`, `verifier_common`, `tools/cli`, and circuit/verifier crates).
- Broad crate-level suppressions for `unused_imports` / `unused_variables` are not present in the touched modules; lint handling is localized (item/cfg-scoped).
- `timing_logs` timer usage in `circuit_defs/prover_examples` is consistent with actual logging paths.
- Deprecated `rand` usage in affected paths is updated to current APIs (`rng`, `random_range`).
- Obsolete feature-gate usage that is no longer needed is removed (including AVX-512 stdarch gating in `field`).
- Generated unrolled setup modules are warning-clean across `witness_eval_fn` cfg permutations.
- Intentional deprecated compatibility paths are explicitly marked with `#[expect(deprecated, reason = "...")]`.
- Additional targeted import/visibility/lint cleanups are applied across verifier/CLI/supporting modules.

## Why

- Keep strict linting useful and actionable.
- Reduce CI warning noise while keeping legacy/test/generated paths intact.

## Breaking change
- [ ] Yes
- [x] No

## Validation

- Ran strict lint-deny checks across `prover_examples`, `execution_utils`, `prover`, and `cli` (including feature combinations).
- Ran targeted `-Dwarnings` checks for `execution_utils` tests, `setups`, and `field`.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.
