### PR TITLE
feat: add deterministic PoW mode

### DIFF
--- a/gpu_prover/Cargo.toml
+++ b/gpu_prover/Cargo.toml
@@ -40,6 +40,7 @@ type-map = "0.5"
 
 [features]
 default = ["security_80"]
+deterministic_pow = ["prover/deterministic_pow"]
 log_gpu_mem_usage = []
 log_gpu_stages_timings = []
 security_80 = ["verifier_common/security_80"]

--- a/gpu_prover/benches/blake2s.rs
+++ b/gpu_prover/benches/blake2s.rs
@@ -134,10 +134,11 @@ fn pow(c: &mut Criterion<CudaMeasurement>) {
         group.throughput(Throughput::Elements(max_nonce));
         group.bench_function(BenchmarkId::from_parameter(bits_count), |b| {
             b.iter(|| {
-                blake2s_pow(&d_seed, 32, max_nonce, &mut d_result[0], &stream).unwrap();
+                blake2s_pow(&d_seed, bits_count, max_nonce, &mut d_result[0], &stream).unwrap();
             })
         });
     }
+
     group.finish();
 }
 

--- a/gpu_prover/build/main.rs
+++ b/gpu_prover/build/main.rs
@@ -4,6 +4,7 @@ use era_cudart_sys::{get_cuda_lib_path, get_cuda_version, is_no_cuda, no_cuda_me
 
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(no_cuda)");
+    let deterministic_pow = std::env::var_os("CARGO_FEATURE_DETERMINISTIC_POW").is_some();
     if is_no_cuda() {
         println!("cargo::warning={}", no_cuda_message!());
         println!("cargo::rustc-cfg=no_cuda");
@@ -15,10 +16,13 @@ fn main() {
             println!("cargo::warning=CUDA Toolkit version {cuda_version} detected. This crate is only tested with CUDA Toolkit versions 12.* and 13.*.");
         }
         let cudaarchs = var("CUDAARCHS").unwrap_or("native".to_string());
-        let dst = cmake::Config::new("native")
-            .profile("Release")
-            .define("CMAKE_CUDA_ARCHITECTURES", cudaarchs)
-            .build();
+        let mut config = cmake::Config::new("native");
+        config.profile("Release");
+        config.define("CMAKE_CUDA_ARCHITECTURES", cudaarchs);
+        if deterministic_pow {
+            config.define("AB_DETERMINISTIC_POW", "ON");
+        }
+        let dst = config.build();
         let gpu_prover_native_path = dst.to_str().unwrap();
         println!("cargo:rustc-link-search=native={gpu_prover_native_path}");
         println!("cargo:rustc-link-lib=static=gpu_prover_native");

--- a/gpu_prover/native/CMakeLists.txt
+++ b/gpu_prover/native/CMakeLists.txt
@@ -5,6 +5,7 @@ enable_language(CUDA)
 if ((NOT DEFINED CMAKE_CUDA_ARCHITECTURES) OR (CMAKE_CUDA_ARCHITECTURES STREQUAL ""))
     set(CMAKE_CUDA_ARCHITECTURES native)
 endif ()
+option(AB_DETERMINISTIC_POW "Enable deterministic PoW search" OFF)
 add_library(gpu_prover_native STATIC
         arg_utils.cuh
         barycentric.cu
@@ -74,6 +75,9 @@ add_library(gpu_prover_native STATIC
 set_target_properties(gpu_prover_native PROPERTIES CUDA_STANDARD 20)
 set_target_properties(gpu_prover_native PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 set_target_properties(gpu_prover_native PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+if (AB_DETERMINISTIC_POW)
+    target_compile_definitions(gpu_prover_native PRIVATE AB_DETERMINISTIC_POW=1)
+endif ()
 target_compile_options(gpu_prover_native PRIVATE --expt-relaxed-constexpr)
 target_compile_options(gpu_prover_native PRIVATE --ptxas-options=-v)
 #target_compile_options(gpu_prover_native PRIVATE -lineinfo)

--- a/gpu_prover/native/blake2s.cu
+++ b/gpu_prover/native/blake2s.cu
@@ -248,24 +248,35 @@ EXTERN __global__ void ab_gather_rows_and_merkle_paths_kernel(const unsigned *in
 }
 
 EXTERN __global__ void ab_blake2s_pow_kernel(const u64 *seed, const u32 bits_count, const u64 max_nonce, volatile u64 *result) {
-  const uint32_t digest_mask = 0xffffffff << 32 - bits_count;
+  const u32 digest_mask = 0xffffffff << 32 - bits_count;
+  const auto result_ptr = reinterpret_cast<unsigned long long *>(const_cast<u64 *>(result));
   __align__(8) u32 m_u32[BLOCK_SIZE] = {};
   auto m_u64 = reinterpret_cast<u64 *>(m_u32);
 #pragma unroll
   for (unsigned i = 0; i < 4; i++)
     m_u64[i] = seed[i];
   const unsigned stride = blockDim.x * gridDim.x;
-  for (uint64_t nonce = threadIdx.x + blockIdx.x * blockDim.x; nonce < max_nonce; nonce += stride) {
+  for (u64 nonce = threadIdx.x + blockIdx.x * blockDim.x; nonce < max_nonce; nonce += stride) {
     m_u64[STATE_SIZE / 2] = nonce;
     u32 state[STATE_SIZE];
     initialize(state);
     u32 t = 0;
     compress<true>(state, t, m_u32, STATE_SIZE + 2);
     if (!(state[0] & digest_mask)) {
-      atomicCAS(reinterpret_cast<unsigned long long *>(const_cast<u64 *>(result)), UINT64_MAX, nonce);
+#ifdef AB_DETERMINISTIC_POW
+      atomicMin(result_ptr, static_cast<unsigned long long>(nonce));
+#else
+      atomicCAS(result_ptr, UINT64_MAX, nonce);
+#endif
       __threadfence();
     }
-    if (*result != UINT64_MAX)
+    if (*result
+#ifdef AB_DETERMINISTIC_POW
+        <= nonce
+#else
+        != UINT64_MAX
+#endif
+    )
       return;
   }
 }

--- a/gpu_prover/src/blake2s.rs
+++ b/gpu_prover/src/blake2s.rs
@@ -642,5 +642,19 @@ mod tests {
         let mut digest = Digest::default();
         state.absorb_final_block::<true>(&block, STATE_SIZE + 2, &mut digest);
         assert!(digest[0].leading_zeros() >= BITS_COUNT);
+
+        #[cfg(feature = "deterministic_pow")]
+        {
+            use prover::transcript::{Blake2sTranscript, Seed};
+            use worker::Worker;
+
+            let expected_worker = Worker::new_with_num_threads(1);
+            let expected =
+                Blake2sTranscript::search_pow(&Seed(h_seed), BITS_COUNT, &expected_worker);
+            let worker = Worker::new_with_num_threads(4);
+            let actual = Blake2sTranscript::search_pow(&Seed(h_seed), BITS_COUNT, &worker);
+            assert_eq!(actual, expected);
+            assert_eq!(h_result[0], expected.1);
+        }
     }
 }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -47,6 +47,7 @@ harness = false
 
 [features]
 prover = ["trace_holder", "worker", "seq-macro", "fft", "cs/compiler", "transcript/pow",  "risc_v_simulator", "riscv_transpiler", "proc-macro2", "quote", "serde_json", "itertools"]
+deterministic_pow = ["transcript/deterministic_pow"]
 definitions_only = ["cs/definitions_only"]
 # Print logs related to timings only.
 timing_logs = []

--- a/transcript/Cargo.toml
+++ b/transcript/Cargo.toml
@@ -16,6 +16,7 @@ worker = { workspace = true, optional = true }
 
 [features]
 pow = ["worker"]
+deterministic_pow = []
 blake2_with_compression = ["blake2s_u32/blake2_with_compression"]
 
 default = []

--- a/transcript/src/pow.rs
+++ b/transcript/src/pow.rs
@@ -11,15 +11,16 @@ impl Blake2sTranscript {
         let (initial_state, base_input) = Self::prepare_pow_search(seed);
 
         if pow_bits <= BLAKE2S_ROUNDS_PER_INVOCAITON.trailing_zeros() {
-            return Self::search_pow_serial_from_prepared(
-                seed,
-                pow_bits,
-                initial_state,
-                base_input,
-            );
+            return Self::search_pow_serial_from_prepared(seed, pow_bits, initial_state, base_input);
         }
 
-        Self::search_pow_parallel_from_prepared(seed, pow_bits, worker, initial_state, base_input)
+        Self::search_pow_parallel_from_prepared(
+            seed,
+            pow_bits,
+            worker,
+            initial_state,
+            base_input,
+        )
     }
 
     fn prepare_pow_search(
@@ -59,9 +60,10 @@ impl Blake2sTranscript {
         initial_state: [u32; BLAKE2S_BLOCK_SIZE_U32_WORDS],
         base_input: [u32; BLAKE2S_BLOCK_SIZE_U32_WORDS],
     ) -> (Seed, u64) {
+        let threshold = u32::MAX.checked_shr(pow_bits).unwrap_or(0);
         let mut input = base_input;
         for challenge in 0u64..(BLAKE2S_NO_RESULT - 1) {
-            if Self::pow_challenge_matches(&mut input, &initial_state, challenge, pow_bits) {
+            if Self::pow_challenge_matches(&mut input, &initial_state, challenge, threshold) {
                 return Self::finalize_pow_result(seed, challenge, pow_bits);
             }
         }
@@ -80,6 +82,7 @@ impl Blake2sTranscript {
         use std::sync::atomic::Ordering;
 
         let result = std::sync::Arc::new(AtomicU64::new(BLAKE2S_NO_RESULT));
+        let threshold = u32::MAX.checked_shr(pow_bits).unwrap_or(0);
         let pow_rounds_per_invocation = BLAKE2S_ROUNDS_PER_INVOCAITON as u64;
         let num_workers = worker.num_cores as u64;
 
@@ -88,19 +91,14 @@ impl Blake2sTranscript {
                 let mut input = base_input;
                 let result = std::sync::Arc::clone(&result);
                 Worker::smart_spawn(scope, worker_idx == num_workers - 1, move |_| {
-                    let mut round_idx = 0u64;
-                    loop {
-                        let Some(base) = Self::pow_round_base(
-                            worker_idx,
-                            round_idx,
-                            num_workers,
-                            pow_rounds_per_invocation,
-                        ) else {
-                            break;
-                        };
+                    for round_idx in
+                        0..((BLAKE2S_NO_RESULT - 1) / num_workers / pow_rounds_per_invocation)
+                    {
+                        let base =
+                            (worker_idx + round_idx * num_workers) * pow_rounds_per_invocation;
 
                         #[cfg(feature = "deterministic_pow")]
-                        if result.load(Ordering::Acquire) <= base {
+                        if result.load(Ordering::Relaxed) <= base {
                             break;
                         }
                         #[cfg(not(feature = "deterministic_pow"))]
@@ -116,59 +114,35 @@ impl Blake2sTranscript {
                                 &mut input,
                                 &initial_state,
                                 challenge_u64,
-                                pow_bits,
+                                threshold,
                             ) {
                                 #[cfg(feature = "deterministic_pow")]
-                                result.fetch_min(challenge_u64, Ordering::AcqRel);
+                                result.fetch_min(challenge_u64, Ordering::Relaxed);
                                 #[cfg(not(feature = "deterministic_pow"))]
-                                {
-                                    let _ = result.compare_exchange(
-                                        BLAKE2S_NO_RESULT,
-                                        challenge_u64,
-                                        Ordering::Acquire,
-                                        Ordering::Relaxed,
-                                    );
-                                    return;
-                                }
-                            }
-
-                            #[cfg(feature = "deterministic_pow")]
-                            if result.load(Ordering::Acquire) <= challenge_u64 {
+                                let _ = result.compare_exchange(
+                                    BLAKE2S_NO_RESULT,
+                                    challenge_u64,
+                                    Ordering::Relaxed,
+                                    Ordering::Relaxed,
+                                );
                                 return;
                             }
                         }
-                        round_idx += 1;
                     }
                 })
             }
         });
 
-        let challenge_u64 = result.load(Ordering::SeqCst);
+        let challenge_u64 = result.load(Ordering::Relaxed);
         Self::finalize_pow_result(seed, challenge_u64, pow_bits)
     }
 
-    fn pow_round_base(
-        worker_idx: u64,
-        round_idx: u64,
-        num_workers: u64,
-        pow_rounds_per_invocation: u64,
-    ) -> Option<u64> {
-        let schedule_slot = round_idx
-            .checked_mul(num_workers)?
-            .checked_add(worker_idx)?;
-        let base = schedule_slot.checked_mul(pow_rounds_per_invocation)?;
-        if base >= BLAKE2S_NO_RESULT - 1 {
-            None
-        } else {
-            Some(base)
-        }
-    }
-
+    #[inline(always)]
     fn pow_challenge_matches(
         input: &mut [u32; BLAKE2S_BLOCK_SIZE_U32_WORDS],
         initial_state: &[u32; BLAKE2S_BLOCK_SIZE_U32_WORDS],
         challenge_u64: u64,
-        pow_bits: u32,
+        threshold: u32,
     ) -> bool {
         input[BLAKE2S_DIGEST_SIZE_U32_WORDS] = challenge_u64 as u32;
         input[BLAKE2S_DIGEST_SIZE_U32_WORDS + 1] = (challenge_u64 >> 32) as u32;
@@ -180,7 +154,7 @@ impl Blake2sTranscript {
         }
 
         let word_to_test = CONFIGURED_IV[0] ^ state[0] ^ state[8];
-        word_to_test <= (0xffffffff >> pow_bits)
+        word_to_test <= threshold
     }
 
     fn finalize_pow_result(seed: &Seed, challenge_u64: u64, pow_bits: u32) -> (Seed, u64) {

--- a/transcript/src/pow.rs
+++ b/transcript/src/pow.rs
@@ -8,6 +8,26 @@ impl Blake2sTranscript {
     pub fn search_pow(seed: &Seed, pow_bits: u32, worker: &Worker) -> (Seed, u64) {
         assert!(pow_bits <= 32);
 
+        let (initial_state, base_input) = Self::prepare_pow_search(seed);
+
+        if pow_bits <= BLAKE2S_ROUNDS_PER_INVOCAITON.trailing_zeros() {
+            return Self::search_pow_serial_from_prepared(
+                seed,
+                pow_bits,
+                initial_state,
+                base_input,
+            );
+        }
+
+        Self::search_pow_parallel_from_prepared(seed, pow_bits, worker, initial_state, base_input)
+    }
+
+    fn prepare_pow_search(
+        seed: &Seed,
+    ) -> (
+        [u32; BLAKE2S_BLOCK_SIZE_U32_WORDS],
+        [u32; BLAKE2S_BLOCK_SIZE_U32_WORDS],
+    ) {
         let initial_state = [
             CONFIGURED_IV[0],
             CONFIGURED_IV[1],
@@ -30,93 +50,200 @@ impl Blake2sTranscript {
         let mut base_input = [0u32; BLAKE2S_BLOCK_SIZE_U32_WORDS];
         base_input[..BLAKE2S_DIGEST_SIZE_U32_WORDS].copy_from_slice(&seed.0);
 
-        if pow_bits <= BLAKE2S_ROUNDS_PER_INVOCAITON.trailing_zeros() {
-            // serial case
-            let mut input = base_input;
-            for challenge in 0u64..(BLAKE2S_NO_RESULT - 1) {
-                // we expect somewhat "good" hash distribution
+        (initial_state, base_input)
+    }
 
-                // write LE
-                input[BLAKE2S_DIGEST_SIZE_U32_WORDS] = challenge as u32;
-                input[BLAKE2S_DIGEST_SIZE_U32_WORDS + 1] = (challenge >> 32) as u32;
-                let mut state = initial_state;
-                if USE_REDUCED_BLAKE2_ROUNDS {
-                    round_function_reduced_rounds(&mut state, &input);
-                } else {
-                    round_function_full_rounds(&mut state, &input);
-                }
-                let word_to_test = CONFIGURED_IV[0] ^ state[0] ^ state[8];
-
-                if word_to_test <= (0xffffffff >> pow_bits) {
-                    let mut output = CONFIGURED_IV;
-
-                    for i in 0..8 {
-                        output[i] ^= state[i];
-                        output[i] ^= state[i + 8];
-                    }
-
-                    return (Seed(output), challenge);
-                }
+    fn search_pow_serial_from_prepared(
+        seed: &Seed,
+        pow_bits: u32,
+        initial_state: [u32; BLAKE2S_BLOCK_SIZE_U32_WORDS],
+        base_input: [u32; BLAKE2S_BLOCK_SIZE_U32_WORDS],
+    ) -> (Seed, u64) {
+        let mut input = base_input;
+        for challenge in 0u64..(BLAKE2S_NO_RESULT - 1) {
+            if Self::pow_challenge_matches(&mut input, &initial_state, challenge, pow_bits) {
+                return Self::finalize_pow_result(seed, challenge, pow_bits);
             }
         }
 
+        unreachable!("PoW search exhausted the nonce space without a result");
+    }
+
+    fn search_pow_parallel_from_prepared(
+        seed: &Seed,
+        pow_bits: u32,
+        worker: &Worker,
+        initial_state: [u32; BLAKE2S_BLOCK_SIZE_U32_WORDS],
+        base_input: [u32; BLAKE2S_BLOCK_SIZE_U32_WORDS],
+    ) -> (Seed, u64) {
         use std::sync::atomic::AtomicU64;
         use std::sync::atomic::Ordering;
 
         let result = std::sync::Arc::new(AtomicU64::new(BLAKE2S_NO_RESULT));
-
         let pow_rounds_per_invocation = BLAKE2S_ROUNDS_PER_INVOCAITON as u64;
-        // it's good to parallelize
         let num_workers = worker.num_cores as u64;
+
         worker.scope(usize::MAX, |scope, _| {
             for worker_idx in 0..num_workers {
                 let mut input = base_input;
                 let result = std::sync::Arc::clone(&result);
                 Worker::smart_spawn(scope, worker_idx == num_workers - 1, move |_| {
-                    for i in 0..((BLAKE2S_NO_RESULT - 1) / num_workers / pow_rounds_per_invocation)
-                    {
-                        let base = (worker_idx + i * num_workers) * pow_rounds_per_invocation;
-                        let current_flag = result.load(Ordering::Relaxed);
-                        if current_flag == BLAKE2S_NO_RESULT {
-                            for j in 0..pow_rounds_per_invocation {
-                                let challenge_u64 = base + j;
-                                // write LE
-                                input[BLAKE2S_DIGEST_SIZE_U32_WORDS] = challenge_u64 as u32;
-                                input[BLAKE2S_DIGEST_SIZE_U32_WORDS + 1] =
-                                    (challenge_u64 >> 32) as u32;
-                                let mut state = initial_state;
-                                if USE_REDUCED_BLAKE2_ROUNDS {
-                                    round_function_reduced_rounds(&mut state, &input);
-                                } else {
-                                    round_function_full_rounds(&mut state, &input);
-                                }
-                                let word_to_test = CONFIGURED_IV[0] ^ state[0] ^ state[8];
+                    let mut round_idx = 0u64;
+                    loop {
+                        let Some(base) = Self::pow_round_base(
+                            worker_idx,
+                            round_idx,
+                            num_workers,
+                            pow_rounds_per_invocation,
+                        ) else {
+                            break;
+                        };
 
-                                if word_to_test <= (0xffffffff >> pow_bits) {
+                        #[cfg(feature = "deterministic_pow")]
+                        if result.load(Ordering::Acquire) <= base {
+                            break;
+                        }
+                        #[cfg(not(feature = "deterministic_pow"))]
+                        if result.load(Ordering::Relaxed) != BLAKE2S_NO_RESULT {
+                            break;
+                        }
+
+                        let rounds_this_invocation =
+                            pow_rounds_per_invocation.min((BLAKE2S_NO_RESULT - 1) - base);
+                        for j in 0..rounds_this_invocation {
+                            let challenge_u64 = base + j;
+                            if Self::pow_challenge_matches(
+                                &mut input,
+                                &initial_state,
+                                challenge_u64,
+                                pow_bits,
+                            ) {
+                                #[cfg(feature = "deterministic_pow")]
+                                result.fetch_min(challenge_u64, Ordering::AcqRel);
+                                #[cfg(not(feature = "deterministic_pow"))]
+                                {
                                     let _ = result.compare_exchange(
                                         BLAKE2S_NO_RESULT,
                                         challenge_u64,
                                         Ordering::Acquire,
                                         Ordering::Relaxed,
                                     );
-
-                                    break;
+                                    return;
                                 }
                             }
-                        } else {
-                            break;
+
+                            #[cfg(feature = "deterministic_pow")]
+                            if result.load(Ordering::Acquire) <= challenge_u64 {
+                                return;
+                            }
                         }
+                        round_idx += 1;
                     }
                 })
             }
         });
 
         let challenge_u64 = result.load(Ordering::SeqCst);
+        Self::finalize_pow_result(seed, challenge_u64, pow_bits)
+    }
 
-        // we should just recompute
+    fn pow_round_base(
+        worker_idx: u64,
+        round_idx: u64,
+        num_workers: u64,
+        pow_rounds_per_invocation: u64,
+    ) -> Option<u64> {
+        let schedule_slot = round_idx
+            .checked_mul(num_workers)?
+            .checked_add(worker_idx)?;
+        let base = schedule_slot.checked_mul(pow_rounds_per_invocation)?;
+        if base >= BLAKE2S_NO_RESULT - 1 {
+            None
+        } else {
+            Some(base)
+        }
+    }
+
+    fn pow_challenge_matches(
+        input: &mut [u32; BLAKE2S_BLOCK_SIZE_U32_WORDS],
+        initial_state: &[u32; BLAKE2S_BLOCK_SIZE_U32_WORDS],
+        challenge_u64: u64,
+        pow_bits: u32,
+    ) -> bool {
+        input[BLAKE2S_DIGEST_SIZE_U32_WORDS] = challenge_u64 as u32;
+        input[BLAKE2S_DIGEST_SIZE_U32_WORDS + 1] = (challenge_u64 >> 32) as u32;
+        let mut state = *initial_state;
+        if USE_REDUCED_BLAKE2_ROUNDS {
+            round_function_reduced_rounds(&mut state, input);
+        } else {
+            round_function_full_rounds(&mut state, input);
+        }
+
+        let word_to_test = CONFIGURED_IV[0] ^ state[0] ^ state[8];
+        word_to_test <= (0xffffffff >> pow_bits)
+    }
+
+    fn finalize_pow_result(seed: &Seed, challenge_u64: u64, pow_bits: u32) -> (Seed, u64) {
         let mut new_seed = *seed;
         Self::verify_pow(&mut new_seed, challenge_u64, pow_bits);
-
         (new_seed, challenge_u64)
+    }
+}
+
+#[cfg(all(test, feature = "deterministic_pow"))]
+mod tests {
+    use super::*;
+
+    fn test_seeds() -> [Seed; 3] {
+        [
+            Seed([0, 1, 2, 3, 4, 5, 6, 7]),
+            Seed([42, 42, 42, 42, 42, 42, 42, 42]),
+            Seed([
+                0x01234567, 0x89abcdef, 0xfedcba98, 0x76543210, 0x0f0f0f0f, 0xf0f0f0f0, 0x13579bdf,
+                0x2468ace0,
+            ]),
+        ]
+    }
+
+    #[test]
+    fn deterministic_parallel_matches_serial_baseline() {
+        for seed in test_seeds() {
+            for pow_bits in [17, 18, 20] {
+                let (initial_state, base_input) = Blake2sTranscript::prepare_pow_search(&seed);
+                let expected = Blake2sTranscript::search_pow_serial_from_prepared(
+                    &seed,
+                    pow_bits,
+                    initial_state,
+                    base_input,
+                );
+                for threads in [1, 2, 4] {
+                    let worker = Worker::new_with_num_threads(threads);
+                    let actual = Blake2sTranscript::search_pow(&seed, pow_bits, &worker);
+                    assert_eq!(
+                        actual, expected,
+                        "seed={seed:?}, pow_bits={pow_bits}, threads={threads}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn deterministic_parallel_result_is_invariant_across_worker_counts() {
+        let seed = Seed([0xdeadbeef; 8]);
+        let pow_bits = 19;
+        let (initial_state, base_input) = Blake2sTranscript::prepare_pow_search(&seed);
+        let expected = Blake2sTranscript::search_pow_serial_from_prepared(
+            &seed,
+            pow_bits,
+            initial_state,
+            base_input,
+        );
+
+        for threads in [1, 2, 4, 8] {
+            let worker = Worker::new_with_num_threads(threads);
+            let actual = Blake2sTranscript::search_pow(&seed, pow_bits, &worker);
+            assert_eq!(actual, expected, "threads={threads}");
+        }
     }
 }

--- a/transcript/src/pow.rs
+++ b/transcript/src/pow.rs
@@ -11,16 +11,15 @@ impl Blake2sTranscript {
         let (initial_state, base_input) = Self::prepare_pow_search(seed);
 
         if pow_bits <= BLAKE2S_ROUNDS_PER_INVOCAITON.trailing_zeros() {
-            return Self::search_pow_serial_from_prepared(seed, pow_bits, initial_state, base_input);
+            return Self::search_pow_serial_from_prepared(
+                seed,
+                pow_bits,
+                initial_state,
+                base_input,
+            );
         }
 
-        Self::search_pow_parallel_from_prepared(
-            seed,
-            pow_bits,
-            worker,
-            initial_state,
-            base_input,
-        )
+        Self::search_pow_parallel_from_prepared(seed, pow_bits, worker, initial_state, base_input)
     }
 
     fn prepare_pow_search(


### PR DESCRIPTION
## What ❔

Adds an opt-in `deterministic_pow` mode to `transcript`, `prover`, and `gpu_prover` so PoW search returns the smallest valid nonce independent of scheduling.

## Why ❔

This makes PoW outputs reproducible across runs while keeping the current non-deterministic behavior as the default.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.
