### PR TITLE
feat: Implement support for cycle markers in transpiler

### DIFF
--- a/common_constants/src/lib.rs
+++ b/common_constants/src/lib.rs
@@ -5,6 +5,17 @@ pub mod delegation_types;
 pub mod rom;
 pub mod timestamps;
 
+pub mod dev {
+    /// Development-only CSR recognized by the transpiler-side cycle marker hooks.
+    ///
+    /// This is intended for local transpiler profiling only.
+    ///
+    /// The proving path rejects this CSR during replay/witness generation, so a
+    /// program that contains it should be treated as a development artifact and
+    /// must not be proved.
+    pub const TRANSPILER_MARKER_CSR: u32 = 0x7ff;
+}
+
 pub use self::circuit_families::*;
 pub use self::delegation_types::*;
 pub use self::rom::*;

--- a/common_constants/src/lib.rs
+++ b/common_constants/src/lib.rs
@@ -5,7 +5,9 @@ pub mod delegation_types;
 pub mod rom;
 pub mod timestamps;
 
-pub mod dev {
+/// This module is meant to contain extensions that are outside of the proving path,
+/// e.g. for development.
+pub mod internal_features {
     /// Development-only CSR recognized by the transpiler-side cycle marker hooks.
     ///
     /// This is intended for local transpiler profiling only.

--- a/prover/src/tests/unrolled/mod.rs
+++ b/prover/src/tests/unrolled/mod.rs
@@ -764,7 +764,7 @@ fn test_reference_block_exec() {
     let mut snapshotter = SimpleSnapshotter::new_with_cycle_limit(cycles_bound, state);
 
     let now = std::time::Instant::now();
-    VM::run_basic_unrolled::<_, _, _>(
+    VM::<DelegationsAndFamiliesCounters>::run_basic_unrolled::<_, _, _>(
         &mut state,
         &mut ram,
         &mut snapshotter,

--- a/riscv_transpiler/src/cycle/markers.rs
+++ b/riscv_transpiler/src/cycle/markers.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use crate::vm::{Counters, ExecutionObserver, State};
 use common_constants::{
-    dev::TRANSPILER_MARKER_CSR, TimestampScalar, INITIAL_TIMESTAMP, TIMESTAMP_STEP,
+    internal_features::TRANSPILER_MARKER_CSR, TimestampScalar, INITIAL_TIMESTAMP, TIMESTAMP_STEP,
 };
 
 /// An execution observer which collects the cycle markers and delegation counts

--- a/riscv_transpiler/src/cycle/markers.rs
+++ b/riscv_transpiler/src/cycle/markers.rs
@@ -1,0 +1,169 @@
+//! Cycle markers record anonymous cycle snapshots together with cumulative
+//! delegation counts for one profiled execution scope.
+//!
+//! This module is meant for profiling of the RISC-V program runs.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::vm::{Counters, ExecutionObserver, State};
+use common_constants::{
+    dev::TRANSPILER_MARKER_CSR, TimestampScalar, INITIAL_TIMESTAMP, TIMESTAMP_STEP,
+};
+
+/// An execution observer which collects the cycle markers and delegation counts
+/// for the profiled execution scope.
+///
+/// This intended use is to specify it as a generic parameter for `Vm` and call
+/// from within `CycleMarkerHooks::with(...)` scope to collect the cycle marker
+/// data for the profiled execution run.
+pub struct CycleMarkerHooks;
+
+impl CycleMarkerHooks {
+    /// Collect cycle markers and delegation counts that happen while `f` runs.
+    ///
+    /// This method enables the cycle marker data collection for the duration of `f`,
+    /// so it is expected that `with` will only be used for a single profiled execution
+    /// run at a time.
+    pub fn with<T>(f: impl FnOnce() -> T) -> (T, CycleMarker) {
+        let guard = ActiveCycleMarkerGuard::install();
+        let result = f();
+        let marker = guard.take();
+
+        (result, marker)
+    }
+}
+
+impl<C: Counters> ExecutionObserver<C> for CycleMarkerHooks {
+    fn on_marker(state: &State<C>) {
+        let cycles = {
+            debug_assert!(state.timestamp >= INITIAL_TIMESTAMP);
+            debug_assert_eq!(state.timestamp % TIMESTAMP_STEP, 0);
+            (state.timestamp - INITIAL_TIMESTAMP) / TIMESTAMP_STEP
+        };
+        with_active_cycle_marker_mut(|collector| {
+            collector.set_cycle_counter(cycles);
+            collector.add_marker();
+        });
+    }
+
+    fn on_delegation(_state: &State<C>, id: u32, by: u64) {
+        debug_assert_ne!(id, TRANSPILER_MARKER_CSR);
+        with_active_cycle_marker_mut(|collector| collector.add_delegation_count(id, by));
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Mark {
+    pub cycles: u64,
+    pub delegations: HashMap<u32, u64>,
+}
+
+impl Mark {
+    pub fn diff(&self, before: &Self) -> Self {
+        let cycles = self.cycles - before.cycles;
+        let mut delegations = HashMap::new();
+        for (id, current_count) in self.delegations.iter() {
+            match before.delegations.get(id) {
+                Some(previous_count) => {
+                    let diff = current_count - previous_count;
+                    if diff != 0 {
+                        delegations.insert(*id, diff);
+                    }
+                }
+                None => {
+                    delegations.insert(*id, *current_count);
+                }
+            }
+        }
+
+        Self {
+            cycles,
+            delegations,
+        }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct CycleMarker {
+    cycle_counter: u64,
+    pub markers: Vec<Mark>,
+    pub delegation_counter: HashMap<u32, u64>,
+}
+
+impl CycleMarker {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    #[inline(always)]
+    fn add_marker(&mut self) {
+        self.markers.push(Mark {
+            cycles: self.cycle_counter,
+            delegations: self.delegation_counter.clone(),
+        });
+    }
+
+    #[inline(always)]
+    fn set_cycle_counter(&mut self, cycles: u64) {
+        self.cycle_counter = cycles;
+    }
+
+    #[inline(always)]
+    fn add_delegation_count(&mut self, id: u32, by: u64) {
+        self.delegation_counter
+            .entry(id)
+            .and_modify(|count| *count += by)
+            .or_insert(by);
+    }
+}
+
+std::thread_local! {
+  static ACTIVE_CYCLE_MARKER: RefCell<Option<CycleMarker>> = const { RefCell::new(None) };
+}
+
+fn with_active_cycle_marker_mut<T>(f: impl FnOnce(&mut CycleMarker) -> T) -> T {
+    ACTIVE_CYCLE_MARKER.with(|collector| {
+        let mut collector = collector.borrow_mut();
+        let collector = collector.as_mut().unwrap_or_else(|| {
+            panic!("CycleMarkerHooks was used outside CycleMarkerHooks::with(...)")
+        });
+
+        f(collector)
+    })
+}
+
+/// This guard ensures that the thread-local storage remains in a consistent state
+/// even if `CycleMarkerHooks::with(...)` panics.
+struct ActiveCycleMarkerGuard;
+
+impl ActiveCycleMarkerGuard {
+    fn install() -> Self {
+        ACTIVE_CYCLE_MARKER.with(|collector| {
+            let mut collector = collector.borrow_mut();
+            assert!(
+                collector.is_none(),
+                "CycleMarkerHooks::with(...) does not support nested collection scopes",
+            );
+            *collector = Some(CycleMarker::new());
+        });
+
+        Self
+    }
+
+    fn take(self) -> CycleMarker {
+        ACTIVE_CYCLE_MARKER.with(|collector| {
+            collector.borrow_mut().take().expect(
+                "CycleMarkerHooks::with(...) collector unexpectedly disappeared before the scope finished",
+            )
+        })
+    }
+}
+
+impl Drop for ActiveCycleMarkerGuard {
+    fn drop(&mut self) {
+        ACTIVE_CYCLE_MARKER.with(|collector| {
+            *collector.borrow_mut() = None;
+        });
+    }
+}

--- a/riscv_transpiler/src/cycle/mod.rs
+++ b/riscv_transpiler/src/cycle/mod.rs
@@ -1,10 +1,7 @@
 use std::hash::Hash;
 
-// These machine profiles remain here because the rest of the workspace still
-// keys decoder selection, setup generation, and recursion layout on them.
-//
-// The old simulator state machines are gone, but the marker types still define
-// the supported ISA surface for the active proving path.
+// Machine profiles tie together the ISA features used by preprocessing, setup
+// generation, and recursion layout.
 pub trait MachineConfig:
     'static
     + Clone
@@ -34,13 +31,13 @@ pub trait MachineConfig:
     const ALLOWED_DELEGATION_CSRS: &'static [u32];
 }
 
-// The active witnesses still use the architectural register count through the
-// historical `cycle::state::NUM_REGISTERS` path, so we preserve that path as a
-// tiny compatibility shim instead of touching unrelated consumers.
+mod markers;
+
 pub mod state {
     pub const NUM_REGISTERS: usize = 32;
 }
 
+pub use self::markers::{CycleMarker, CycleMarkerHooks, Mark};
 pub use state::NUM_REGISTERS;
 
 #[derive(

--- a/riscv_transpiler/src/ir/mod.rs
+++ b/riscv_transpiler/src/ir/mod.rs
@@ -648,10 +648,11 @@ pub fn preprocess_bytecode<OPT: DecodingOptions>(bytecode: &[u32]) -> Vec<Instru
                             // short-cut
                             continue;
                         }
-                        common_constants::dev::TRANSPILER_MARKER_CSR => {
+                        common_constants::internal_features::TRANSPILER_MARKER_CSR => {
                             // We only support the write-only marker form
-                            // `csrrw x0, 0x7ff, xN`; the source register is ignored.
+                            // `csrrw x0, 0x7ff, x0`.
                             assert_eq!(rd, 0);
+                            assert_eq!(formal_rs1, 0);
                             Instruction::from_imm(
                                 InstructionName::ZicsrMarkerCsr,
                                 formal_rs1,

--- a/riscv_transpiler/src/ir/mod.rs
+++ b/riscv_transpiler/src/ir/mod.rs
@@ -648,6 +648,18 @@ pub fn preprocess_bytecode<OPT: DecodingOptions>(bytecode: &[u32]) -> Vec<Instru
                             // short-cut
                             continue;
                         }
+                        common_constants::dev::TRANSPILER_MARKER_CSR => {
+                            // We only support the write-only marker form
+                            // `csrrw x0, 0x7ff, xN`; the source register is ignored.
+                            assert_eq!(rd, 0);
+                            Instruction::from_imm(
+                                InstructionName::ZicsrMarkerCsr,
+                                formal_rs1,
+                                0,
+                                0,
+                                0,
+                            )
+                        }
                         CYCLE_CSR_INDEX => {
                             // It is canonical CSR to encode UNIMP instruction
                             illegal_instr

--- a/riscv_transpiler/src/jit/tests.rs
+++ b/riscv_transpiler/src/jit/tests.rs
@@ -95,7 +95,7 @@ fn test_ensure_proof_correctness() {
     let mut state = State::initial_with_counters(DelegationsAndFamiliesCounters::default());
 
     let now = std::time::Instant::now();
-    VM::run_basic_unrolled::<_, _, _>(
+    VM::<DelegationsAndFamiliesCounters>::run_basic_unrolled::<_, _, _>(
         &mut state,
         &mut ram,
         &mut (),
@@ -190,7 +190,7 @@ fn run_reference_for_num_cycles(
 
     let mut state = State::initial_with_counters(DelegationsAndFamiliesCounters::default());
 
-    VM::run_by_timestamp_bound::<_, _, _>(
+    VM::<DelegationsAndFamiliesCounters>::run_by_timestamp_bound::<_, _, _>(
         &mut state,
         &mut ram,
         &mut (),
@@ -233,7 +233,7 @@ fn run_reference_for_num_cycles_with_snapshots(
     let mut state = State::initial_with_counters(DelegationsAndFamiliesCounters::default());
     let mut snapshotter = SimpleSnapshotter::<_, {common_constants::rom::ROM_SECOND_WORD_BITS }>::new_with_cycle_limit(1 << 31, state);
 
-    VM::run_by_timestamp_bound::<_, _, _>(
+    VM::<DelegationsAndFamiliesCounters>::run_by_timestamp_bound::<_, _, _>(
         &mut state,
         &mut ram,
         &mut snapshotter,
@@ -279,7 +279,7 @@ fn test_reference_block_exec() {
     let mut snapshotter = SimpleSnapshotter::<_, { common_constants::rom::ROM_SECOND_WORD_BITS }>::new_with_cycle_limit(cycles_bound, state);
 
     let now = std::time::Instant::now();
-    VM::run_basic_unrolled::<_, _, _>(
+    VM::<DelegationsAndFamiliesCounters>::run_basic_unrolled::<_, _, _>(
         &mut state,
         &mut ram,
         &mut snapshotter,

--- a/riscv_transpiler/src/replayer/mod.rs
+++ b/riscv_transpiler/src/replayer/mod.rs
@@ -207,6 +207,9 @@ impl<C: Counters> ReplayerVM<C> {
                     InstructionName::ZicsrNonDeterminismWrite => {
                         zicsr::nd_write::<C, R>(state, ram, instr, tracer)
                     }
+                    InstructionName::ZicsrMarkerCsr => panic!(
+                        "detected transpiler marker CSR during replay; programs containing development cycle markers must not be proved"
+                    ),
                     InstructionName::ZicsrDelegation => {
                         zicsr::call_delegation::<C, R>(state, ram, instr, tracer)
                     }

--- a/riscv_transpiler/src/tests/test_vector/csrrw.rs
+++ b/riscv_transpiler/src/tests/test_vector/csrrw.rs
@@ -32,7 +32,7 @@ fn test_vector_csrrw() {
     expected = "detected transpiler marker CSR during replay; programs containing development cycle markers must not be proved"
 )]
 fn test_vector_marker_csr_is_rejected_by_replayer() {
-    const CSRRW_MARKER_OPCODE: u32 = 0x7ff11073; // csrrw x0, 2047, x2
+    const CSRRW_MARKER_OPCODE: u32 = 0x7ff01073; // csrrw x0, 2047, x0
 
     execute_case::<FullUnsignedMachineDecoderConfig>(
         &[CSRRW_MARKER_OPCODE],

--- a/riscv_transpiler/src/tests/test_vector/csrrw.rs
+++ b/riscv_transpiler/src/tests/test_vector/csrrw.rs
@@ -1,4 +1,5 @@
-use super::run_test_vector_opcode;
+use super::{execute_case, run_test_vector_opcode, ExpectedOutcome};
+use crate::ir::FullUnsignedMachineDecoderConfig;
 
 #[test]
 fn test_vector_csrrw() {
@@ -23,5 +24,23 @@ fn test_vector_csrrw() {
         Some(CSRRW_U256BIGINTOPS_OPCODE),
         [0; 32],
         None,
+    );
+}
+
+#[test]
+#[should_panic(
+    expected = "detected transpiler marker CSR during replay; programs containing development cycle markers must not be proved"
+)]
+fn test_vector_marker_csr_is_rejected_by_replayer() {
+    const CSRRW_MARKER_OPCODE: u32 = 0x7ff11073; // csrrw x0, 2047, x2
+
+    execute_case::<FullUnsignedMachineDecoderConfig>(
+        &[CSRRW_MARKER_OPCODE],
+        [0; 32],
+        &ExpectedOutcome {
+            final_pc: 4,
+            register_checks: vec![],
+            memory_checks: vec![],
+        },
     );
 }

--- a/riscv_transpiler/src/vm/delegations/bigint.rs
+++ b/riscv_transpiler/src/vm/delegations/bigint.rs
@@ -66,7 +66,7 @@ fn write_back_u256<C: Counters, S: Snapshotter<C>, R: RAM>(
 }
 
 #[inline(never)]
-pub(crate) fn bigint_call<C: Counters, S: Snapshotter<C>, R: RAM>(
+pub(crate) fn bigint_call<C: Counters, S: Snapshotter<C>, R: RAM, E: ExecutionObserver<C>>(
     state: &mut State<C>,
     ram: &mut R,
     snapshotter: &mut S,
@@ -106,6 +106,7 @@ pub(crate) fn bigint_call<C: Counters, S: Snapshotter<C>, R: RAM>(
     snapshotter.append_arbitrary_value(of_for_bookkepping);
 
     state.counters.bump_bigint(1);
+    E::on_delegation(state, BIGINT_OPS_WITH_CONTROL_CSR_REGISTER, 1);
     default_increase_pc::<C>(state);
     increment_family_counter::<C, SHIFT_BINARY_CSR_CIRCUIT_FAMILY_IDX>(state);
 }

--- a/riscv_transpiler/src/vm/delegations/blake2_round_function.rs
+++ b/riscv_transpiler/src/vm/delegations/blake2_round_function.rs
@@ -59,7 +59,12 @@ fn write_back_words<C: Counters, S: Snapshotter<C>, R: RAM, const N: usize>(
 }
 
 #[inline(never)]
-pub(crate) fn blake2_round_function_call<C: Counters, S: Snapshotter<C>, R: RAM>(
+pub(crate) fn blake2_round_function_call<
+    C: Counters,
+    S: Snapshotter<C>,
+    R: RAM,
+    E: ExecutionObserver<C>,
+>(
     state: &mut State<C>,
     ram: &mut R,
     snapshotter: &mut S,
@@ -250,6 +255,7 @@ pub(crate) fn blake2_round_function_call<C: Counters, S: Snapshotter<C>, R: RAM>
     // But timestamp needs 1 less bump
     state.timestamp += ((num_rounds - 1) as TimestampScalar) * TIMESTAMP_STEP;
     state.counters.bump_blake2_round_function(num_rounds);
+    E::on_delegation(state, BLAKE2S_DELEGATION_CSR_REGISTER, num_rounds as u64);
     state.pc = state
         .pc
         .wrapping_add((core::mem::size_of::<u32>() * num_rounds) as u32);
@@ -259,7 +265,7 @@ pub(crate) fn blake2_round_function_call<C: Counters, S: Snapshotter<C>, R: RAM>
 }
 
 // #[inline(never)]
-// pub(crate) fn blake2_round_function_call<C: Counters, S: Snapshotter<C>, R: RAM>(
+// pub(crate) fn blake2_round_function_call<C: Counters, S: Snapshotter<C>, R: RAM, E: ExecutionObserver<C>>(
 //     state: &mut State<C>,
 //     ram: &mut R,
 //     snapshotter: &mut S,

--- a/riscv_transpiler/src/vm/delegations/keccak_special5.rs
+++ b/riscv_transpiler/src/vm/delegations/keccak_special5.rs
@@ -11,7 +11,12 @@ const PRECOMPILE_CHI1: u32 = 5;
 const PRECOMPILE_CHI2: u32 = 6;
 
 #[inline(never)]
-pub(crate) fn keccak_special5_call<C: Counters, S: Snapshotter<C>, R: RAM>(
+pub(crate) fn keccak_special5_call<
+    C: Counters,
+    S: Snapshotter<C>,
+    R: RAM,
+    E: ExecutionObserver<C>,
+>(
     state: &mut State<C>,
     ram: &mut R,
     snapshotter: &mut S,
@@ -92,6 +97,11 @@ pub(crate) fn keccak_special5_call<C: Counters, S: Snapshotter<C>, R: RAM>(
     state
         .counters
         .bump_keccak_special5(common_constants::NUM_DELEGATION_CALLS_FOR_KECCAK_F1600);
+    E::on_delegation(
+        state,
+        KECCAK_SPECIAL5_CSR_REGISTER,
+        common_constants::NUM_DELEGATION_CALLS_FOR_KECCAK_F1600 as u64,
+    );
     state.pc = state.pc.wrapping_add(
         (core::mem::size_of::<u32>() * common_constants::NUM_DELEGATION_CALLS_FOR_KECCAK_F1600)
             as u32,

--- a/riscv_transpiler/src/vm/execution_observer.rs
+++ b/riscv_transpiler/src/vm/execution_observer.rs
@@ -1,0 +1,16 @@
+use super::{Counters, State};
+
+/// ExecutionObserver lets a VM publish optional instrumentation without turning
+/// it into semantic machine state.
+///
+/// Methods are receiver-free so the default `()` observer compiles away, while
+/// specialized observers can source their storage from a scoped context.
+pub trait ExecutionObserver<C: Counters>: 'static {
+    #[inline(always)]
+    fn on_marker(_state: &State<C>) {}
+
+    #[inline(always)]
+    fn on_delegation(_state: &State<C>, _csr: u32, _by: u64) {}
+}
+
+impl<C: Counters> ExecutionObserver<C> for () {}

--- a/riscv_transpiler/src/vm/instructions/zicsr/mod.rs
+++ b/riscv_transpiler/src/vm/instructions/zicsr/mod.rs
@@ -1,6 +1,25 @@
 use super::*;
 
 #[inline(always)]
+pub(crate) fn marker<C: Counters, S: Snapshotter<C>, R: RAM, E: ExecutionObserver<C>>(
+    state: &mut State<C>,
+    ram: &mut R,
+    snapshotter: &mut S,
+    instr: Instruction,
+) {
+    let _rs1_value = read_register::<C, 0>(state, instr.rs1);
+    touch_x0::<C, 1>(state);
+    write_register::<C, 2>(state, instr.rd, &mut 0);
+
+    // Emit the observation before the instruction advances the cycle-family
+    // counters or the outer execution loop bumps the timestamp.
+    E::on_marker(state);
+
+    default_increase_pc::<C>(state);
+    increment_family_counter::<C, SHIFT_BINARY_CSR_CIRCUIT_FAMILY_IDX>(state);
+}
+
+#[inline(always)]
 pub(crate) fn nd_read<C: Counters, S: Snapshotter<C>, R: RAM, ND: NonDeterminismCSRSource>(
     state: &mut State<C>,
     ram: &mut R,
@@ -36,7 +55,7 @@ pub(crate) fn nd_write<C: Counters, S: Snapshotter<C>, R: RAM, ND: NonDeterminis
 }
 
 #[inline(always)]
-pub(crate) fn call_delegation<C: Counters, S: Snapshotter<C>, R: RAM>(
+pub(crate) fn call_delegation<C: Counters, S: Snapshotter<C>, R: RAM, E: ExecutionObserver<C>>(
     state: &mut State<C>,
     ram: &mut R,
     snapshotter: &mut S,
@@ -50,13 +69,21 @@ pub(crate) fn call_delegation<C: Counters, S: Snapshotter<C>, R: RAM>(
     // especially in case of multiple delegation calls batched together
     match instr.imm {
         a if a == DelegationType::BigInt as u32 => {
-            delegations::bigint::bigint_call(state, ram, snapshotter)
+            delegations::bigint::bigint_call::<C, S, R, E>(state, ram, snapshotter)
         }
         a if a == DelegationType::Blake as u32 => {
-            delegations::blake2_round_function::blake2_round_function_call(state, ram, snapshotter)
+            delegations::blake2_round_function::blake2_round_function_call::<C, S, R, E>(
+                state,
+                ram,
+                snapshotter,
+            )
         }
         a if a == DelegationType::Keccak as u32 => {
-            delegations::keccak_special5::keccak_special5_call(state, ram, snapshotter)
+            delegations::keccak_special5::keccak_special5_call::<C, S, R, E>(
+                state,
+                ram,
+                snapshotter,
+            )
         }
         _ => unsafe { core::hint::unreachable_unchecked() },
     }

--- a/riscv_transpiler/src/vm/mod.rs
+++ b/riscv_transpiler/src/vm/mod.rs
@@ -5,7 +5,9 @@ use crate::jit::{MachineState, MAX_NUM_COUNTERS};
 use common_constants::circuit_families::*;
 use common_constants::{TimestampScalar, INITIAL_TIMESTAMP, TIMESTAMP_STEP};
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
+mod execution_observer;
 #[cfg(feature = "flamegraph")]
 mod flamegraph;
 mod instructions;
@@ -15,6 +17,7 @@ mod simple_tape;
 
 pub(crate) mod delegations;
 
+pub use self::execution_observer::ExecutionObserver;
 #[cfg(feature = "flamegraph")]
 pub use self::flamegraph::*;
 pub use self::ram_with_rom_region::RamWithRomRegion;
@@ -200,11 +203,12 @@ impl NonDeterminismCSRSource for crate::abstractions::non_determinism::QuasiUART
     }
 }
 
-pub struct VM<C: Counters> {
+pub struct VM<C: Counters, E: ExecutionObserver<C> = ()> {
     pub state: State<C>,
+    pub(crate) observer: PhantomData<E>,
 }
 
-impl<C: Counters> VM<C> {
+impl<C: Counters, E: ExecutionObserver<C>> VM<C, E> {
     pub fn run_basic_unrolled<S: Snapshotter<C>, R: RAM, ND: NonDeterminismCSRSource>(
         state: &mut State<C>,
         ram: &mut R,
@@ -448,8 +452,11 @@ impl<C: Counters> VM<C> {
                 InstructionName::ZicsrNonDeterminismWrite => {
                     zicsr::nd_write::<C, S, R, ND>(state, ram, snapshotter, instr, nd)
                 }
+                InstructionName::ZicsrMarkerCsr => {
+                    zicsr::marker::<C, S, R, E>(state, ram, snapshotter, instr)
+                }
                 InstructionName::ZicsrDelegation => {
-                    zicsr::call_delegation::<C, S, R>(state, ram, snapshotter, instr)
+                    zicsr::call_delegation::<C, S, R, E>(state, ram, snapshotter, instr)
                 }
                 a @ _ => {
                     panic!("Unknown instruction {:?}", a);
@@ -502,6 +509,40 @@ pub(crate) mod test {
         }
 
         (buffer, binary)
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_cycle_markers_follow_vm_execution() {
+        const MARKER_OPCODE: u32 = 0x7ff09073; // csrrw x0, 2047, x1
+        const ADDI_OPCODE: u32 = 0x00100093; // addi x1, x0, 1
+
+        let program = vec![MARKER_OPCODE, ADDI_OPCODE, MARKER_OPCODE];
+        let instructions: Vec<Instruction> =
+            preprocess_bytecode::<FullUnsignedMachineDecoderConfig>(&program);
+        let tape = SimpleTape::new(&instructions);
+        let mut ram = RamWithRomRegion::<5>::from_rom_content(&program, 1 << 22);
+        let mut state = State::initial_with_counters(DelegationsCounters::default());
+
+        let (finished, marker_state) =
+            crate::cycle::CycleMarkerHooks::with(|| {
+                VM::<DelegationsCounters, crate::cycle::CycleMarkerHooks>::run_basic_unrolled::<
+                    _,
+                    _,
+                    _,
+                >(&mut state, &mut ram, &mut (), &tape, program.len(), &mut ())
+            });
+
+        assert!(!finished);
+        assert_eq!(state.pc, 12);
+        assert_eq!(state.registers[1].value, 1);
+
+        assert_eq!(marker_state.markers.len(), 2);
+        assert!(marker_state.delegation_counter.is_empty());
+
+        let diff = marker_state.markers[1].diff(&marker_state.markers[0]);
+        assert_eq!(diff.cycles, 2);
+        assert!(diff.delegations.is_empty());
     }
 
     #[test]

--- a/riscv_transpiler/src/vm/mod.rs
+++ b/riscv_transpiler/src/vm/mod.rs
@@ -514,7 +514,7 @@ pub(crate) mod test {
     #[test]
     #[serial_test::serial]
     fn test_cycle_markers_follow_vm_execution() {
-        const MARKER_OPCODE: u32 = 0x7ff09073; // csrrw x0, 2047, x1
+        const MARKER_OPCODE: u32 = 0x7ff01073; // csrrw x0, 2047, x0
         const ADDI_OPCODE: u32 = 0x00100093; // addi x1, x0, 1
 
         let program = vec![MARKER_OPCODE, ADDI_OPCODE, MARKER_OPCODE];


### PR DESCRIPTION
This PR implements cycle marker API that previously was available for the simulator.

For that, we extend VM with one more generic parameter -- `ExecutionObserver` -- which is meant to do any general-purpose (not proving-related) observations. It is done in a non-dyn-friendly way, but this way we have efficiently 0 footprint for the proving path.

The API can be used as follows:

```rust
let (_finished, cycle_markers) = CycleMarkerHooks::with(|| {
    VM::<DelegationsCounters, CycleMarkerHooks>::run_basic_unrolled::<_, _, _>(
        &mut state,
        &mut ram,
        &mut (),
        &tape,
        program.len(),
        &mut (),
    )
});
```