### PR TITLE
fix: reset cycle markers for fresh simulator states

### DIFF
--- a/risc_v_simulator/src/cycle/state.rs
+++ b/risc_v_simulator/src/cycle/state.rs
@@ -222,6 +222,11 @@ thread_local! {
 }
 
 #[cfg(feature = "cycle_marker")]
+pub(crate) fn reset_cycle_marker() {
+    CYCLE_MARKER.with_borrow_mut(|cm| *cm = CycleMarker::new());
+}
+
+#[cfg(feature = "cycle_marker")]
 pub fn take_cycle_marker() -> CycleMarker {
     CYCLE_MARKER.with(|cm| std::mem::take(&mut *cm.borrow_mut()))
 }
@@ -406,6 +411,8 @@ impl<Config: MachineConfig> RiscV32State<Config> {
 
         #[cfg(feature = "opcode_stats")]
         OPCODES_COUNTER.with_borrow_mut(|el| el.clear());
+        #[cfg(feature = "cycle_marker")]
+        reset_cycle_marker();
 
         Self {
             observable: RiscV32ObservableState { registers, pc },
@@ -420,6 +427,9 @@ impl<Config: MachineConfig> RiscV32State<Config> {
 
     pub fn new_random(initial_pc: u32, is_user_mode: bool, is_halted: bool) -> Self {
         let mut rng = rand::thread_rng();
+
+        #[cfg(feature = "cycle_marker")]
+        reset_cycle_marker();
 
         let mut extra_flags = ExtraFlags(0u32);
         extra_flags.set_mode(if is_user_mode {

--- a/risc_v_simulator/src/cycle/state_new.rs
+++ b/risc_v_simulator/src/cycle/state_new.rs
@@ -22,7 +22,7 @@ use crate::cycle::state::NUM_REGISTERS;
 #[cfg(feature = "opcode_stats")]
 use crate::cycle::state::OPCODES_COUNTER;
 #[cfg(feature = "cycle_marker")]
-use crate::cycle::state::{CycleMarker, Mark, CYCLE_MARKER};
+use crate::cycle::state::{reset_cycle_marker, CYCLE_MARKER};
 use crate::cycle::status_registers::TrapReason;
 use crate::cycle::IMStandardIsaConfig;
 use crate::cycle::MachineConfig;
@@ -214,6 +214,8 @@ impl<Config: MachineConfig> RiscV32StateForUnrolledProver<Config> {
 
         #[cfg(feature = "opcode_stats")]
         OPCODES_COUNTER.with_borrow_mut(|el| el.clear());
+        #[cfg(feature = "cycle_marker")]
+        reset_cycle_marker();
 
         Self {
             observable: RiscV32ObservableState { registers, pc },

--- a/risc_v_simulator/src/tests/mod.rs
+++ b/risc_v_simulator/src/tests/mod.rs
@@ -1,4 +1,6 @@
 use crate::abstractions::csr_processor::NoExtraCSRs;
+#[cfg(feature = "cycle_marker")]
+use crate::cycle::state::take_cycle_marker;
 use crate::cycle::state_new::RiscV32StateForUnrolledProver;
 use crate::cycle::IMStandardIsaConfig;
 use crate::{
@@ -20,6 +22,24 @@ mod sltu;
 mod sra;
 
 const INITIAL_PC: u32 = 0;
+#[cfg(feature = "cycle_marker")]
+const MARKER_OPCODE: u32 = 0x7ff01073; // csrrw x0, 2047, x0
+#[cfg(feature = "cycle_marker")]
+const ADDI_OPCODE: u32 = 0x00100093; // addi x1, x0, 1
+
+#[cfg(feature = "cycle_marker")]
+fn memory_for_opcodes(opcodes: &[u32]) -> VectorMemoryImpl {
+    let mut memory =
+        VectorMemoryImpl::new_for_byte_size((opcodes.len() * core::mem::size_of::<u32>()).max(4));
+    for (idx, opcode) in opcodes.iter().enumerate() {
+        memory.populate(
+            INITIAL_PC + idx as u32 * (core::mem::size_of::<u32>() as u32),
+            *opcode,
+        );
+    }
+
+    memory
+}
 
 fn test_reg_reg_op(op_name: &str, expected: u32, op1: u32, op2: u32) {
     {
@@ -184,4 +204,56 @@ fn test_reg_reg_op_64(op_name: &str, expected: u64, op1: u64, op2: u64) {
 fn test_reg_imm_op_64(op_name: &str, expected: u64, op1: u64, imm: u16) {
     // truncate
     test_reg_imm_op(op_name, expected as u32, op1 as u32, imm)
+}
+
+#[cfg(feature = "cycle_marker")]
+#[test]
+fn cycle_markers_reset_for_fresh_state() {
+    {
+        let _ = take_cycle_marker();
+
+        let mut warmup_state = RiscV32State::<IMStandardIsaConfig>::initial(INITIAL_PC);
+        let mut warmup_memory = memory_for_opcodes(&[ADDI_OPCODE]);
+        let mut mmu = NoMMU::default();
+        warmup_state.cycle(&mut warmup_memory, &mut (), &mut mmu, &mut ZeroedSource);
+
+        let mut measured_state = RiscV32State::<IMStandardIsaConfig>::initial(INITIAL_PC);
+        let mut measured_memory = memory_for_opcodes(&[MARKER_OPCODE]);
+        let mut mmu = NoMMU::default();
+        measured_state.cycle(&mut measured_memory, &mut (), &mut mmu, &mut ZeroedSource);
+
+        let marker = take_cycle_marker();
+        assert_eq!(marker.markers.len(), 1);
+        assert_eq!(marker.markers[0].cycles, 0);
+    }
+
+    {
+        let _ = take_cycle_marker();
+
+        let mut warmup_state =
+            RiscV32StateForUnrolledProver::<IMStandardIsaConfig>::initial(INITIAL_PC);
+        let mut warmup_memory = memory_for_opcodes(&[ADDI_OPCODE]);
+        let _ = warmup_state.run_cycles(
+            &mut warmup_memory,
+            &mut (),
+            &mut ZeroedSource,
+            &mut NoExtraCSRs,
+            1,
+        );
+
+        let mut measured_state =
+            RiscV32StateForUnrolledProver::<IMStandardIsaConfig>::initial(INITIAL_PC);
+        let mut measured_memory = memory_for_opcodes(&[MARKER_OPCODE]);
+        let _ = measured_state.run_cycles(
+            &mut measured_memory,
+            &mut (),
+            &mut ZeroedSource,
+            &mut NoExtraCSRs,
+            1,
+        );
+
+        let marker = take_cycle_marker();
+        assert_eq!(marker.markers.len(), 1);
+        assert_eq!(marker.markers[0].cycles, 0);
+    }
 }


### PR DESCRIPTION
## Summary
- reset the thread-local cycle marker collector whenever a fresh simulator state is created
- apply the reset in both the baseline simulator and the unrolled prover state so marker counts do not leak across runs
- add a regression test covering the one-cycle carry-over case for both simulator implementations

## Why
Cycle marker state lives in thread-local storage. Creating a fresh simulator state did not clear that storage, so a previous run could shift the next run's first marker by one or more cycles. Resetting the collector on fresh state creation makes marker counts scoped to the current execution.

## Testing
- cargo test -p risc_v_simulator
- cargo test -p risc_v_simulator --features cycle_marker
