### PR TITLE
fix: correct cycle marker accounting

### DIFF
--- a/riscv_transpiler/src/cycle/markers.rs
+++ b/riscv_transpiler/src/cycle/markers.rs
@@ -98,8 +98,11 @@ impl CycleMarker {
 
     #[inline(always)]
     fn add_marker(&mut self) {
+        // Marker instructions are profiling boundaries, not profiled work. Normalize
+        // the raw VM cycle counter so `Mark::diff` reports only non-marker cycles.
+        let cycles = self.cycle_counter - self.markers.len() as u64;
         self.markers.push(Mark {
-            cycles: self.cycle_counter,
+            cycles,
             delegations: self.delegation_counter.clone(),
         });
     }

--- a/riscv_transpiler/src/vm/mod.rs
+++ b/riscv_transpiler/src/vm/mod.rs
@@ -539,9 +539,11 @@ pub(crate) mod test {
 
         assert_eq!(marker_state.markers.len(), 2);
         assert!(marker_state.delegation_counter.is_empty());
+        assert_eq!(marker_state.markers[0].cycles, 0);
+        assert_eq!(marker_state.markers[1].cycles, 1);
 
         let diff = marker_state.markers[1].diff(&marker_state.markers[0]);
-        assert_eq!(diff.cycles, 2);
+        assert_eq!(diff.cycles, 1);
         assert!(diff.delegations.is_empty());
     }
 


### PR DESCRIPTION
## Summary
- normalize stored marker cycle counts so marker instructions themselves are excluded from `Mark::diff`
- update the existing VM regression test for the reported `marker -> opcode -> marker` case

## Testing
- `cargo nextest run -p riscv_transpiler test_cycle_markers_follow_vm_execution`
- `cargo fmt --check`

## Notes
- `cargo nextest run -p riscv_transpiler` still hits an unrelated pre-existing stack overflow in `jit::tests::test_replayer_over_jit`