### PR TITLE
fix: Fix rustdoc builds

### DIFF
--- a/prover/src/merkle_trees/blake2s_for_everything_tree.rs
+++ b/prover/src/merkle_trees/blake2s_for_everything_tree.rs
@@ -77,10 +77,7 @@ impl<B: GoodAllocator> MerkleTreeConstructor for Blake2sU32MerkleTreeWithCap<B> 
     fn get_proof<C: GoodAllocator>(
         &self,
         idx: usize,
-    ) -> (
-        [u32; DIGEST_SIZE_U32_WORDS],
-        Vec<[u32; DIGEST_SIZE_U32_WORDS], C>,
-    ) {
+    ) -> (MerkleTreeDigest, Vec<MerkleTreeDigest, C>) {
         let depth = self.node_hashes_enumerated_from_leafs.len(); // we do not need the element of the cap
         let mut result = Vec::with_capacity_in(depth, C::default());
         let mut idx = idx;

--- a/prover/src/merkle_trees/mod.rs
+++ b/prover/src/merkle_trees/mod.rs
@@ -13,6 +13,12 @@ use worker::Worker;
 pub mod blake2s_for_everything_tree;
 pub mod blake2s_hash_leafs;
 
+// Rustdoc currently struggles to normalize the inline `[u32; DIGEST_SIZE_U32_WORDS]`
+// return type of `MerkleTreeConstructor::get_proof` when another crate documents APIs
+// that depend on this trait. Giving the digest a stable alias keeps the public API the
+// same while avoiding the problematic method-local const normalization path.
+pub type MerkleTreeDigest = [u32; DIGEST_SIZE_U32_WORDS];
+
 pub type DefaultTreeConstructor =
     crate::merkle_trees::blake2s_for_everything_tree::Blake2sU32MerkleTreeWithCap<
         std::alloc::Global,
@@ -71,10 +77,7 @@ pub trait MerkleTreeConstructor: Sized + Send + Sync {
     fn get_proof<C: GoodAllocator>(
         &self,
         idx: usize,
-    ) -> (
-        [u32; DIGEST_SIZE_U32_WORDS],
-        Vec<[u32; DIGEST_SIZE_U32_WORDS], C>,
-    );
+    ) -> (MerkleTreeDigest, Vec<MerkleTreeDigest, C>);
 
     // pub fn verify_proof_over_cap(
     //     _proof: &[[u32; BLAKE2S_DIGEST_SIZE_U32_WORDS]],

--- a/riscv_transpiler/src/jit/impls.rs
+++ b/riscv_transpiler/src/jit/impls.rs
@@ -2007,7 +2007,7 @@ impl<I: ContextImpl> Context<I> {
         self.implementation.read_nondeterminism()
     }
 
-    extern "sysv64" fn write_nondeterminism(&mut self, value: u32, memory: &[u32; RAM_SIZE]) {
+    extern "sysv64" fn write_nondeterminism(&mut self, value: u32, memory: &RamImage) {
         self.implementation.write_nondeterminism(value, memory)
     }
 

--- a/riscv_transpiler/src/jit/minimal_tracer/mod.rs
+++ b/riscv_transpiler/src/jit/minimal_tracer/mod.rs
@@ -73,7 +73,7 @@ impl<'a, const N: usize, A: Allocator> ContextImpl for PreallocatedSnapshots<'a,
         self.non_determinism.read()
     }
     #[inline(always)]
-    fn write_nondeterminism(&mut self, value: u32, memory: &[u32; RAM_SIZE]) {
+    fn write_nondeterminism(&mut self, value: u32, memory: &RamImage) {
         self.non_determinism
             .write_with_memory_access_dyn(memory, value);
     }

--- a/riscv_transpiler/src/jit/mod.rs
+++ b/riscv_transpiler/src/jit/mod.rs
@@ -31,6 +31,10 @@ const MAX_RAM_SIZE: usize = 1 << 30; // 1 Gb, as we want to avoid having separat
 pub const RAM_SIZE: usize = 1 << 30;
 const NUM_RAM_WORDS: usize = RAM_SIZE / core::mem::size_of::<u32>();
 
+// Keep the RAM backing store type named so rustdoc does not have to normalize the
+// large inline `[u32; RAM_SIZE]` array at every public trait boundary.
+pub type RamImage = [u32; RAM_SIZE];
+
 // We will measure trace chunk in a number of memory accesses and not in a almost fixed number of cycles that did pass between them.
 // At most we extend a chunk by the number of accesses in delegation
 pub const TRACE_CHUNK_LEN: usize = 1 << 20;
@@ -42,6 +46,11 @@ pub const MAX_TRACE_CHUNK_LEN: usize = const {
 };
 
 pub const MAX_NUM_COUNTERS: usize = 16;
+
+// Rustdoc can hit query cycles when downstream crates expose inline `[u64; MAX_NUM_COUNTERS]`
+// bounds in their public APIs. Naming the counter payload keeps the machine layout intact
+// while letting those APIs depend on a stable type alias instead of a method-local const.
+pub type MachineCounters = [u64; MAX_NUM_COUNTERS];
 
 #[repr(u8)]
 pub enum CounterType {
@@ -66,7 +75,7 @@ const _: () = const {
 pub struct MachineState {
     pub registers: [u32; 32], // aligned at 16, so we can write XMMs directly into the stack
     pub register_timestamps: [TimestampScalar; 32],
-    pub counters: [u64; MAX_NUM_COUNTERS],
+    pub counters: MachineCounters,
     pub pc: u32,
     pub timestamp: TimestampScalar,
     pub(crate) context_ptr: *mut (),
@@ -135,7 +144,7 @@ pub struct TraceChunk {
 pub trait ContextImpl {
     fn read_nondeterminism(&mut self) -> u32;
 
-    fn write_nondeterminism(&mut self, value: u32, memory: &[u32; RAM_SIZE]);
+    fn write_nondeterminism(&mut self, value: u32, memory: &RamImage);
 
     fn receive_trace(
         &mut self,

--- a/riscv_transpiler/src/jit/structs.rs
+++ b/riscv_transpiler/src/jit/structs.rs
@@ -238,7 +238,7 @@ impl<'a, N: NonDeterminismCSRSource> ContextImpl for DefaultContextImpl<'a, N> {
         self.non_determinism_source.read()
     }
 
-    fn write_nondeterminism(&mut self, value: u32, memory: &[u32; RAM_SIZE]) {
+    fn write_nondeterminism(&mut self, value: u32, memory: &RamImage) {
         self.non_determinism_source
             .write_with_memory_access(memory, value);
     }

--- a/riscv_transpiler/src/vm/mod.rs
+++ b/riscv_transpiler/src/vm/mod.rs
@@ -1,7 +1,7 @@
 use crate::ir::DelegationType;
 use crate::ir::Instruction;
 use crate::ir::InstructionName;
-use crate::jit::{MachineState, MAX_NUM_COUNTERS};
+use crate::jit::{MachineCounters, MachineState};
 use common_constants::circuit_families::*;
 use common_constants::{TimestampScalar, INITIAL_TIMESTAMP, TIMESTAMP_STEP};
 use std::fmt::Debug;
@@ -66,7 +66,7 @@ impl<C: Counters> State<C> {
     }
 }
 
-impl<C: Counters + From<[u64; MAX_NUM_COUNTERS]>> From<MachineState> for State<C> {
+impl<C: Counters + From<MachineCounters>> From<MachineState> for State<C> {
     fn from(state: MachineState) -> Self {
         Self {
             registers: std::array::from_fn(|i| Register {

--- a/riscv_transpiler/src/vm/replay_snapshotter.rs
+++ b/riscv_transpiler/src/vm/replay_snapshotter.rs
@@ -1,6 +1,6 @@
 use std::alloc::Allocator;
 
-use crate::jit::{CounterType, MAX_NUM_COUNTERS, MAX_TRACE_CHUNK_LEN};
+use crate::jit::{CounterType, MachineCounters, MAX_NUM_COUNTERS, MAX_TRACE_CHUNK_LEN};
 
 use super::*;
 
@@ -119,8 +119,8 @@ impl Counters for DelegationsAndFamiliesCounters {
     }
 }
 
-impl From<[u64; MAX_NUM_COUNTERS]> for DelegationsAndFamiliesCounters {
-    fn from(counters: [u64; MAX_NUM_COUNTERS]) -> Self {
+impl From<MachineCounters> for DelegationsAndFamiliesCounters {
+    fn from(counters: MachineCounters) -> Self {
         Self {
             add_sub_family: counters[CounterType::AddSubLui as u8 as usize] as usize,
             slt_branch_family: counters[CounterType::BranchSlt as u8 as usize] as usize,
@@ -204,8 +204,8 @@ impl Counters for DelegationsAndUnifiedCounters {
     }
 }
 
-impl From<[u64; MAX_NUM_COUNTERS]> for DelegationsAndUnifiedCounters {
-    fn from(counters: [u64; MAX_NUM_COUNTERS]) -> Self {
+impl From<MachineCounters> for DelegationsAndUnifiedCounters {
+    fn from(counters: MachineCounters) -> Self {
         let add_sub_family = counters[CounterType::AddSubLui as u8 as usize] as usize;
         let slt_branch_family = counters[CounterType::BranchSlt as u8 as usize] as usize;
         let binary_shift_csr_family = counters[CounterType::ShiftBinaryCsr as u8 as usize] as usize;


### PR DESCRIPTION
For some reason, rustdoc currently fails when it meets array types in signatures. Adding type aliases fixes this problem.

I want to generate docs for airbender-platform, so this is a blocker for that.