### PR TITLE
fix: Allow unsupported instructions in JIT by turning them into runtime panic

### DIFF
--- a/riscv_transpiler/src/jit/impls.rs
+++ b/riscv_transpiler/src/jit/impls.rs
@@ -801,7 +801,9 @@ impl<I: ContextImpl> JittedCode<I> {
                 continue;
             };
 
-            // Pure instructions
+            // Pure instructions that are fully modeled by the unsigned RV32 JIT.
+            // Signed-M instructions such as `mulh` and `div` are intentionally
+            // excluded here so `rd = x0` can not silently turn them into NOPs.
             if matches!(
                 instruction,
                 Instruction::Addi(_)
@@ -831,12 +833,8 @@ impl<I: ContextImpl> JittedCode<I> {
                     | Instruction::Lhu(_)
                     | Instruction::Lw(_)
                     | Instruction::Mul(_)
-                    | Instruction::Mulh(_)
                     | Instruction::Mulhu(_)
-                    | Instruction::Mulhsu(_)
-                    | Instruction::Div(_)
                     | Instruction::Divu(_)
-                    | Instruction::Rem(_)
                     | Instruction::Remu(_)
             ) {
                 let rd = (raw_instruction >> 7) & 0x1F;
@@ -1197,23 +1195,6 @@ impl<I: ContextImpl> JittedCode<I> {
                         );
                         record_circuit_type(&mut ops, CounterType::MulDiv, 1);
                     }
-                    Instruction::Mulh(parts) => {
-                        emit_runtime_error!(ops);
-                        // unimplemented!("unsupported by default");
-                        // touch_register_and_increment_timestamp!(ops, parts.rs1());
-                        // touch_register_and_increment_timestamp!(ops, parts.rs2());
-                        // load_into(&mut ops, parts.rs1(), x64::Rq::RAX as u8);
-                        // let other = load(&mut ops, parts.rs2());
-                        // dynasm!(ops
-                        //     ; imul Rd(other)
-                        // );
-                        // if out != x64::Rq::RDX as u8 {
-                        //     dynasm!(ops
-                        //         ; mov Rd(out), edx
-                        //     );
-                        // }
-                        // record_circuit_type(&mut ops, CounterType::MulDiv, 1);
-                    }
                     Instruction::Mulhu(parts) => {
                         touch_register_and_increment_timestamp!(ops, parts.rs1());
                         touch_register_and_increment_timestamp!(ops, parts.rs2());
@@ -1228,22 +1209,6 @@ impl<I: ContextImpl> JittedCode<I> {
                             );
                         }
                         record_circuit_type(&mut ops, CounterType::MulDiv, 1);
-                    }
-                    Instruction::Mulhsu(parts) => {
-                        unimplemented!("unsupported by default");
-                        // touch_register_and_increment_timestamp!(ops, parts.rs1());
-                        // touch_register_and_increment_timestamp!(ops, parts.rs2());
-                        // load_into(&mut ops, parts.rs2(), SCRATCH_REGISTER);
-                        // load_into(&mut ops, parts.rs1(), out);
-                        // dynasm!(ops
-                        //     ; movsx Rq(out), Rd(out)
-                        //     ; imul Rq(out), Rq(SCRATCH_REGISTER)
-                        //     ; shr Rq(out), 32
-                        // );
-                        // record_circuit_type(&mut ops, CounterType::MulDiv, 1);
-                    }
-                    Instruction::Div(parts) => {
-                        unimplemented!("unsupported by default");
                     }
                     Instruction::Divu(parts) => {
                         // TODO: handle exception cases
@@ -1263,9 +1228,6 @@ impl<I: ContextImpl> JittedCode<I> {
                         }
                         record_circuit_type(&mut ops, CounterType::MulDiv, 1);
                     }
-                    Instruction::Rem(parts) => {
-                        unimplemented!("unsupported by default");
-                    }
                     Instruction::Remu(parts) => {
                         // TODO: handle exception cases
                         touch_register_and_increment_timestamp!(ops, parts.rs1());
@@ -1284,9 +1246,7 @@ impl<I: ContextImpl> JittedCode<I> {
                         }
                         record_circuit_type(&mut ops, CounterType::MulDiv, 1);
                     }
-                    a @ _ => {
-                        panic!("Opcode {:?} is not supported", a);
-                    }
+                    _ => unreachable!(),
                 }
 
                 touch_register_and_bump_timestamp!(ops, rd, 2);
@@ -1729,10 +1689,15 @@ impl<I: ContextImpl> JittedCode<I> {
                         }
                     }
                 }
-                opcode @ _ => {
-                    panic!("Unknown opcode {:?}", opcode);
-                    // emit_runtime_error!(ops);
-                    // i += 1;
+                _ => {
+                    // We only JIT the opcode subset mirrored by the unsigned RV32
+                    // transpiler VM and proving circuits. Everything else, including
+                    // decoded-but-unsupported instructions such as fence-family ops,
+                    // still gets compiled so dead code does not block proving setup,
+                    // but any reachable unsupported opcode aborts at runtime.
+                    emit_execution_panic!(ops, pc);
+                    i += 1;
+                    continue;
                 }
             }
 

--- a/riscv_transpiler/src/jit/tests.rs
+++ b/riscv_transpiler/src/jit/tests.rs
@@ -11,6 +11,75 @@ use std::{alloc::Global, io::Read, path::Path};
 #[cfg(test)]
 use test_utils::skip_if_ci;
 
+fn assemble_single_instruction(instruction: &str) -> u32 {
+    let mut labels = std::collections::HashMap::new();
+    lib_rv32_asm::assemble_ir(instruction, &mut labels, 0)
+        .expect("single-instruction assembly should succeed")
+        .expect("single-instruction assembly should emit one opcode")
+}
+
+fn run_jit_program(program: &[u32]) {
+    JittedCode::<_>::run_alternative_simulator(program, &mut (), &[], None);
+}
+
+/// Assert that a JIT-triggered runtime panic occurs by re-running the current
+/// test in a subprocess.
+///
+/// We can not use `#[should_panic]` or `catch_unwind` here because the panic is
+/// raised from an `extern "sysv64"` callback reached from JIT-generated code.
+/// Rust treats that path as non-unwinding, so the process aborts instead of
+/// producing a catchable unwind.
+fn assert_jit_runtime_panic(test_name: &str, fixture_env_var: &str, instruction: &str) {
+    let output = std::process::Command::new(
+        std::env::current_exe().expect("test binary path should be available"),
+    )
+    .env(fixture_env_var, instruction)
+    .arg("--exact")
+    .arg(test_name)
+    .arg("--nocapture")
+    .output()
+    .expect("subprocess should launch");
+
+    assert!(
+        !output.status.success(),
+        "expected subprocess for `{instruction}` to abort, but it exited successfully",
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined_output = format!("{stdout}\n{stderr}");
+    assert!(
+        combined_output.contains("Runtime explicitly panicked"),
+        "expected runtime panic output for `{instruction}`, got:\n{combined_output}",
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn test_jit_unsupported_instructions_trap_at_runtime() {
+    let fixture_env_var = "RISCV_TRANSPILER_UNSUPPORTED_INSTRUCTION_FIXTURE";
+    let unsupported_instructions = [
+        "mulhsu x0, x1, x2",
+        "div x0, x1, x2",
+        "rem x0, x1, x2",
+        "ecall",
+        "ebreak",
+        "fence",
+    ];
+
+    if let Ok(instruction) = std::env::var(fixture_env_var) {
+        run_jit_program(&[assemble_single_instruction(&instruction)]);
+    } else {
+        for instruction in unsupported_instructions {
+            assert_jit_runtime_panic(
+                "jit::tests::test_jit_unsupported_instructions_trap_at_runtime",
+                fixture_env_var,
+                instruction,
+            );
+        }
+    }
+}
+
 #[test]
 #[serial_test::serial]
 fn test_jit_simple_fibonacci() {


### PR DESCRIPTION
Sometimes compiler would inject the dead code with unsupported instructions (e.g. `pause` in my case) -- these are never executed, but right now JIT compiler discards them fully preventing me from proving such programs.

Turning these into runtime panics would increase the subset of provable programs.