### PR TITLE
fix: support RISC-V CSR 0xC00 (cycle counter) in simulator

### DIFF
--- a/risc_v_simulator/src/cycle/state.rs
+++ b/risc_v_simulator/src/cycle/state.rs
@@ -1192,6 +1192,11 @@ impl<Config: MachineConfig> RiscV32State<Config> {
                                 MARKER_CSR => {
                                   // Do nothing here, we do the work in the write case
                                 }
+                                0xc00 => {
+                                    // RISC-V cycle counter (read-only). Returns 0 since
+                                    // the cycle count has no meaningful value in the zkVM.
+                                    ret_val = 0;
+                                }
                                 csr => {
                                     assert!(Config::ALLOWED_DELEGATION_CSRS.contains(&csr), "Machine {:?} is not configured to support CSR number {} at pc 0x{:08x}", Config::default(), csr, pc);
                                     // println!("Custom CSR = 0x{:04x} READ at cycle {}", csr_number, proc_cycle);
@@ -1246,6 +1251,9 @@ impl<Config: MachineConfig> RiscV32State<Config> {
                                 MARKER_CSR => {
                                   self.add_marker()
                                 }
+                                0xc00 => {
+                                    // cycle counter is read-only — ignore writes
+                                }
                                 csr => {
                                     assert!(Config::ALLOWED_DELEGATION_CSRS.contains(&csr), "Machine {:?} is not configured to support CSR number {}", Config::default(), csr);
                                     Self::add_delegation(csr);
@@ -1276,7 +1284,7 @@ impl<Config: MachineConfig> RiscV32State<Config> {
                                 0x342 => ret_val = self.machine_mode_trap_data.handling.cause, // mcause
                                 0x343 => ret_val = self.machine_mode_trap_data.handling.tval, // mtval
                                 0x344 => ret_val = self.machine_mode_trap_data.state.ip, // mip
-                                //0xc00 => ret_val = self.cycle_counter as u32, // cycle
+                                0xc00 => ret_val = 0, // cycle counter — not meaningful in zkVM
                                 //0xf11 => ret_val = 0, // vendor ID, will come up later on,
                                 NON_DETERMINISM_CSR => {
                                     // to improve oracle usability we can try to avoid read
@@ -1353,6 +1361,7 @@ impl<Config: MachineConfig> RiscV32State<Config> {
                                 0x342 => self.machine_mode_trap_data.handling.cause = write_val, // mcause
                                 0x343 => self.machine_mode_trap_data.handling.tval = write_val, // mtval
                                 0x344 => self.machine_mode_trap_data.state.ip = write_val, // mip
+                                0xc00 => {} // cycle counter is read-only — ignore writes
                                 NON_DETERMINISM_CSR => {
                                     if ND::SHOULD_IGNORE_WRITES_AFTER_READS {
                                         // if we have rs1 == 0 then we should ignore write into CSR,

--- a/risc_v_simulator/src/cycle/state_new.rs
+++ b/risc_v_simulator/src/cycle/state_new.rs
@@ -94,6 +94,9 @@ impl DelegationCSRProcessor for crate::delegations::DelegationsCSRProcessor {
             U256_OPS_WITH_CONTROL_ACCESS_ID => {
                 u256_ops_with_control_impl_over_unrolled_state(state, memory_source, tracer);
             }
+            0xc00 => {
+                // RISC-V cycle counter — no-op in zkVM proving context
+            }
             csr => {
                 panic!("Unsupported CSR = 0x{:04x}", csr);
             }


### PR DESCRIPTION
The RISC-V cycle counter CSR (0xC00) is part of the base ISA and may be read by on-chain contracts. The simulator currently panics when this CSR is accessed because it is not in ALLOWED_DELEGATION_CSRS.

This adds explicit handling for CSR 0xC00 in all CSR access paths:
- Read: returns 0 (cycle count has no meaningful value in the zkVM)
- Write: no-op (the cycle counter is read-only per the RISC-V spec)

Affected code paths:
- state.rs: SUPPORT_STANDARD_CSRS=false read/write (used by prover input generation)
- state.rs: SUPPORT_STANDARD_CSRS=true read/write (used when standard CSRs enabled)
- state_new.rs: delegation CSR processor (used by GPU prover witness generation)

Without this fix, any contract that reads the cycle counter causes the server's prover input generator and the FRI prover to panic, blocking the entire proving pipeline.

## What ❔

  This PR adds support for RISC-V CSR 0xC00 (the standard cycle counter register) in the RISC-V simulator. When a program reads this CSR, the simulator now returns 0 instead of
   panicking. Writes are ignored since the cycle counter is read-only per the RISC-V spec.

  Changes are in `risc_v_simulator/src/cycle/state.rs` (4 code paths: read/write for both `SUPPORT_STANDARD_CSRS=true` and `false`) and `state_new.rs` (delegation CSR processor
   used by GPU prover witness generation).

## Why ❔

  On-chain contracts can read CSR 0xC00 (the cycle counter), which is part of the base RISC-V ISA. When this happens, both the zksync-os-server's prover input generator and the
   FRI prover panic with:

  Machine IMStandardIsaConfig is not configured to support CSR number 3072 at pc 0x000e5248

  (FRI prover variant: `Unsupported CSR = 0x0c00`)

  This blocks the entire proving pipeline no batches can be proven, verified, or executed on L1. The chain continues to produce L2 blocks but L1 settlement stalls completely.

  Returning 0 is safe because the cycle count has no meaningful value in the zkVM execution context. It is not part of the state transition and does not affect proof
  correctness.

  ## Is this a breaking change?
  - [ ] Yes
  - [x] No

  ## Checklist

  - [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
  - [ ] Tests for the changes have been added / updated.
  - [x] Documentation comments have been added / updated.
  - [x] Code has been formatted.