### PR TITLE
fix: make copy gates explicit over base/extension field 

### DIFF
--- a/cs/compiled_circuits/add_sub_lui_auipc_mop_preprocessed_layout_gkr.json
+++ b/cs/compiled_circuits/add_sub_lui_auipc_mop_preprocessed_layout_gkr.json
@@ -725,7 +725,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 17
               },
@@ -939,7 +939,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 23
               },
@@ -1089,7 +1089,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "Cached": {
                   "layer": 0,
@@ -2735,7 +2735,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2992,7 +2992,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3011,7 +3011,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3030,7 +3030,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3049,7 +3049,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3227,7 +3227,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3246,7 +3246,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3265,7 +3265,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3284,7 +3284,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3359,7 +3359,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3378,7 +3378,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3397,7 +3397,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3416,7 +3416,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3435,7 +3435,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3454,7 +3454,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,

--- a/cs/compiled_circuits/add_sub_lui_auipc_mop_preprocessed_layout_no_caches_gkr.json
+++ b/cs/compiled_circuits/add_sub_lui_auipc_mop_preprocessed_layout_no_caches_gkr.json
@@ -61,7 +61,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 17
               },
@@ -441,7 +441,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 23
               },
@@ -2521,7 +2521,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2778,7 +2778,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2797,7 +2797,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2816,7 +2816,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2835,7 +2835,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3013,7 +3013,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3032,7 +3032,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3051,7 +3051,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3070,7 +3070,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3145,7 +3145,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3164,7 +3164,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3183,7 +3183,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3202,7 +3202,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3221,7 +3221,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3240,7 +3240,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,

--- a/cs/compiled_circuits/bigint_with_extended_control_layout_gkr.json
+++ b/cs/compiled_circuits/bigint_with_extended_control_layout_gkr.json
@@ -5448,7 +5448,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 94
               },
@@ -7989,7 +7989,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 135
               },
@@ -8005,7 +8005,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 136
               },
@@ -8256,7 +8256,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 103
               },
@@ -8966,7 +8966,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "Cached": {
                   "layer": 0,
@@ -33585,7 +33585,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -34348,7 +34348,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -34367,7 +34367,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -34886,7 +34886,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -34905,7 +34905,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -35689,7 +35689,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -35708,7 +35708,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -35808,7 +35808,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -35881,7 +35881,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -35954,7 +35954,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -36279,7 +36279,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -36298,7 +36298,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -36572,7 +36572,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -36591,7 +36591,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -37025,7 +37025,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -37071,7 +37071,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -37117,7 +37117,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -37289,7 +37289,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -37308,7 +37308,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -37691,7 +37691,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -37917,7 +37917,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -37936,7 +37936,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,

--- a/cs/compiled_circuits/bigint_with_extended_control_layout_no_caches_gkr.json
+++ b/cs/compiled_circuits/bigint_with_extended_control_layout_no_caches_gkr.json
@@ -61,7 +61,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 94
               },
@@ -3347,7 +3347,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 135
               },
@@ -3363,7 +3363,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 136
               },
@@ -3775,7 +3775,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 103
               },
@@ -31422,7 +31422,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -32369,7 +32369,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -32388,7 +32388,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -32907,7 +32907,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -32926,7 +32926,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -33710,7 +33710,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -33729,7 +33729,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -33829,7 +33829,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -33902,7 +33902,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -33975,7 +33975,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -34300,7 +34300,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -34319,7 +34319,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -34593,7 +34593,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -34612,7 +34612,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -35046,7 +35046,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -35092,7 +35092,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -35138,7 +35138,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -35310,7 +35310,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -35329,7 +35329,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -35712,7 +35712,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -35938,7 +35938,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -35957,7 +35957,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -54063,37 +54063,37 @@
     "160": "Variable at cs/src/gkr_circuits/delegation/bigint_with_control/mod.rs::558",
     "161": "Variable at cs/src/gkr_circuits/delegation/bigint_with_control/mod.rs::558",
     "162": "Variable at cs/src/gkr_circuits/delegation/bigint_with_control/mod.rs::558",
-    "163": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "164": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "165": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "166": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "167": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "168": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "169": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "170": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "171": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "172": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "173": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "174": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "175": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "176": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "177": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "178": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "179": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "180": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "181": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "182": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "183": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "184": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "185": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "186": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "187": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "188": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "189": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "190": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "191": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "192": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "193": "Variable at cs/src/cs/circuit_trait.rs::241",
+    "163": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "164": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "165": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "166": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "167": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "168": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "169": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "170": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "171": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "172": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "173": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "174": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "175": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "176": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "177": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "178": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "179": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "180": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "181": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "182": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "183": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "184": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "185": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "186": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "187": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "188": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "189": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "190": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "191": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "192": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "193": "Variable at cs/src/cs/circuit_trait.rs::239",
     "194": "range check selection for limb 0",
     "195": "range check selection for limb 1",
     "196": "range check selection for limb 2",
@@ -54115,8 +54115,8 @@
     "212": "Variable at cs/src/gkr_circuits/delegation/bigint_with_control/mod.rs::788",
     "213": "inv var for zero check copy",
     "214": "is zero var for zero check copy",
-    "215": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "216": "Variable at cs/src/cs/circuit_trait.rs::241",
+    "215": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "216": "Variable at cs/src/cs/circuit_trait.rs::239",
     "217": "ram or indirect query 0, register read_ts[0]",
     "218": "ram or indirect query 0, register read_ts[1]",
     "219": "indirect access query 0, register acccess interm ts borrow",

--- a/cs/compiled_circuits/blake2_with_extended_control_layout_gkr.json
+++ b/cs/compiled_circuits/blake2_with_extended_control_layout_gkr.json
@@ -24895,7 +24895,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 222
               },
@@ -27633,7 +27633,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "Cached": {
                   "layer": 0,
@@ -50497,7 +50497,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -52222,7 +52222,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -52241,7 +52241,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -54902,7 +54902,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -54921,7 +54921,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -54947,7 +54947,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -55101,7 +55101,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -55255,7 +55255,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -55835,7 +55835,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -55854,7 +55854,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -57199,7 +57199,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -57218,7 +57218,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -57244,7 +57244,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -58394,7 +58394,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -58413,7 +58413,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -58439,7 +58439,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -58485,7 +58485,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -58531,7 +58531,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -59067,7 +59067,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -59191,7 +59191,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -59210,7 +59210,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -59382,7 +59382,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -59401,7 +59401,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -59686,7 +59686,7 @@
         {
           "output_layer": 8,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 7,
@@ -59705,7 +59705,7 @@
         {
           "output_layer": 8,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 7,
@@ -59724,7 +59724,7 @@
         {
           "output_layer": 8,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 7,
@@ -59743,7 +59743,7 @@
         {
           "output_layer": 8,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 7,

--- a/cs/compiled_circuits/blake2_with_extended_control_layout_no_caches_gkr.json
+++ b/cs/compiled_circuits/blake2_with_extended_control_layout_no_caches_gkr.json
@@ -61,7 +61,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 222
               },
@@ -44181,7 +44181,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -45906,7 +45906,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -45925,7 +45925,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -48586,7 +48586,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -48605,7 +48605,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -48631,7 +48631,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -48785,7 +48785,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -48939,7 +48939,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -49519,7 +49519,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -49538,7 +49538,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -50883,7 +50883,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -50902,7 +50902,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -50928,7 +50928,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -52078,7 +52078,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -52097,7 +52097,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -52123,7 +52123,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -52169,7 +52169,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -52215,7 +52215,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -52751,7 +52751,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -52875,7 +52875,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -52894,7 +52894,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -53066,7 +53066,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -53085,7 +53085,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -53370,7 +53370,7 @@
         {
           "output_layer": 8,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 7,
@@ -53389,7 +53389,7 @@
         {
           "output_layer": 8,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 7,
@@ -53408,7 +53408,7 @@
         {
           "output_layer": 8,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 7,
@@ -53427,7 +53427,7 @@
         {
           "output_layer": 8,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 7,
@@ -85665,7 +85665,7 @@
     "150": "Variable at cs/src/types.rs::145",
     "151": "Variable at cs/src/types.rs::145",
     "152": "perform final xor flag",
-    "153": "Variable at cs/src/cs/circuit_trait.rs::241",
+    "153": "Variable at cs/src/cs/circuit_trait.rs::239",
     "154": "Variable at cs/src/gkr_circuits/delegation/blake2_round_with_extended_control/mod.rs::324",
     "155": "Variable at cs/src/gkr_circuits/delegation/blake2_round_with_extended_control/mod.rs::333",
     "156": "Variable at cs/src/gkr_circuits/delegation/blake2_round_with_extended_control/mod.rs::324",
@@ -85698,88 +85698,88 @@
     "183": "Variable at cs/src/gkr_circuits/delegation/blake2_round_with_extended_control/mod.rs::333",
     "184": "Variable at cs/src/gkr_circuits/delegation/blake2_round_with_extended_control/mod.rs::324",
     "185": "Variable at cs/src/gkr_circuits/delegation/blake2_round_with_extended_control/mod.rs::333",
-    "186": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "187": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "188": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "189": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "190": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "191": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "192": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "193": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "194": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "195": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "196": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "197": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "198": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "199": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "200": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "201": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "202": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "203": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "204": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "205": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "206": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "207": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "208": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "209": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "210": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "211": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "212": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "213": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "214": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "215": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "216": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "217": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "218": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "219": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "220": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "221": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "222": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "223": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "224": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "225": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "226": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "227": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "228": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "229": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "230": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "231": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "232": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "233": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "234": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "235": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "236": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "237": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "238": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "239": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "240": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "241": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "242": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "243": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "244": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "245": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "246": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "247": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "248": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "249": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "250": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "251": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "252": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "253": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "254": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "255": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "256": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "257": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "258": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "259": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "260": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "261": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "262": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "263": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "264": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "265": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "266": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "267": "Variable at cs/src/cs/circuit_trait.rs::241",
+    "186": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "187": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "188": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "189": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "190": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "191": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "192": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "193": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "194": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "195": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "196": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "197": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "198": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "199": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "200": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "201": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "202": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "203": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "204": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "205": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "206": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "207": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "208": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "209": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "210": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "211": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "212": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "213": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "214": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "215": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "216": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "217": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "218": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "219": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "220": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "221": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "222": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "223": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "224": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "225": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "226": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "227": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "228": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "229": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "230": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "231": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "232": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "233": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "234": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "235": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "236": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "237": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "238": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "239": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "240": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "241": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "242": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "243": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "244": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "245": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "246": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "247": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "248": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "249": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "250": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "251": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "252": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "253": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "254": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "255": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "256": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "257": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "258": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "259": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "260": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "261": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "262": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "263": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "264": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "265": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "266": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "267": "Variable at cs/src/cs/circuit_trait.rs::239",
     "268": "Variable at cs/src/gkr_circuits/delegation/blake2_round_with_extended_control/g_function.rs::32",
     "269": "Variable at cs/src/gkr_circuits/delegation/blake2_round_with_extended_control/g_function.rs::32",
     "270": "Variable at cs/src/gkr_circuits/delegation/blake2_round_with_extended_control/g_function.rs::34",

--- a/cs/compiled_circuits/jump_branch_slt_preprocessed_layout_gkr.json
+++ b/cs/compiled_circuits/jump_branch_slt_preprocessed_layout_gkr.json
@@ -1041,7 +1041,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 17
               },
@@ -1226,7 +1226,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 10
               },
@@ -1376,7 +1376,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "Cached": {
                   "layer": 0,
@@ -2939,7 +2939,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3053,7 +3053,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3072,7 +3072,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3183,7 +3183,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3202,7 +3202,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3272,7 +3272,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3291,7 +3291,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3469,7 +3469,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3488,7 +3488,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3614,7 +3614,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3633,7 +3633,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3652,7 +3652,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3671,7 +3671,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3690,7 +3690,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3709,7 +3709,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,

--- a/cs/compiled_circuits/jump_branch_slt_preprocessed_layout_no_caches_gkr.json
+++ b/cs/compiled_circuits/jump_branch_slt_preprocessed_layout_no_caches_gkr.json
@@ -61,7 +61,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 17
               },
@@ -389,7 +389,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 10
               },
@@ -2638,7 +2638,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2752,7 +2752,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2771,7 +2771,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2882,7 +2882,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2901,7 +2901,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2971,7 +2971,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2990,7 +2990,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3168,7 +3168,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3187,7 +3187,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3313,7 +3313,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3332,7 +3332,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3351,7 +3351,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3370,7 +3370,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3389,7 +3389,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3408,7 +3408,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,

--- a/cs/compiled_circuits/keccak_special5_layout_gkr.json
+++ b/cs/compiled_circuits/keccak_special5_layout_gkr.json
@@ -6839,7 +6839,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 88
               },
@@ -7233,7 +7233,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "Cached": {
                   "layer": 0,
@@ -7252,7 +7252,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "Cached": {
                   "layer": 0,
@@ -7790,7 +7790,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "Cached": {
                   "layer": 0,
@@ -30352,7 +30352,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -31495,7 +31495,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -31514,7 +31514,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -31540,7 +31540,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -32126,7 +32126,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -32145,7 +32145,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -32171,7 +32171,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -32658,7 +32658,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -32677,7 +32677,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -32752,7 +32752,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -32771,7 +32771,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -32790,7 +32790,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -32809,7 +32809,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,

--- a/cs/compiled_circuits/keccak_special5_layout_gkr.json
+++ b/cs/compiled_circuits/keccak_special5_layout_gkr.json
@@ -7233,7 +7233,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "CopyInBaseField": {
+            "CopyInExtensionField": {
               "input": {
                 "Cached": {
                   "layer": 0,
@@ -7252,7 +7252,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "CopyInBaseField": {
+            "CopyInExtensionField": {
               "input": {
                 "Cached": {
                   "layer": 0,

--- a/cs/compiled_circuits/keccak_special5_layout_no_caches_gkr.json
+++ b/cs/compiled_circuits/keccak_special5_layout_no_caches_gkr.json
@@ -61,7 +61,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 88
               },
@@ -28693,7 +28693,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -29836,7 +29836,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -29855,7 +29855,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -29881,7 +29881,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -30467,7 +30467,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -30486,7 +30486,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -30512,7 +30512,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -30999,7 +30999,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -31018,7 +31018,7 @@
         {
           "output_layer": 5,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 4,
@@ -31093,7 +31093,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -31112,7 +31112,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -31131,7 +31131,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -31150,7 +31150,7 @@
         {
           "output_layer": 6,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 5,
@@ -49643,12 +49643,12 @@
     "77": "Variable at cs/src/gkr_circuits/delegation/keccak_special5/mod.rs::527",
     "78": "Variable at cs/src/gkr_circuits/delegation/keccak_special5/mod.rs::527",
     "79": "Variable at cs/src/gkr_circuits/delegation/keccak_special5/mod.rs::527",
-    "80": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "81": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "82": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "83": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "84": "Variable at cs/src/cs/circuit_trait.rs::241",
-    "85": "Variable at cs/src/cs/circuit_trait.rs::241",
+    "80": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "81": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "82": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "83": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "84": "Variable at cs/src/cs/circuit_trait.rs::239",
+    "85": "Variable at cs/src/cs/circuit_trait.rs::239",
     "86": "Variable at cs/src/gkr_circuits/delegation/keccak_special5/mod.rs::667",
     "87": "Variable at cs/src/gkr_circuits/delegation/keccak_special5/mod.rs::667",
     "88": "Variable at cs/src/gkr_circuits/delegation/keccak_special5/mod.rs::667",

--- a/cs/compiled_circuits/mem_subword_only_preprocessed_layout_gkr.json
+++ b/cs/compiled_circuits/mem_subword_only_preprocessed_layout_gkr.json
@@ -714,7 +714,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 20
               },
@@ -1115,7 +1115,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 9
               },
@@ -1131,7 +1131,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 8
               },
@@ -1178,7 +1178,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 9
               },
@@ -1377,7 +1377,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 18
               },
@@ -1470,7 +1470,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 19
               },
@@ -1621,7 +1621,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 20
               },
@@ -1669,7 +1669,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 26
               },
@@ -1819,7 +1819,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "Cached": {
                   "layer": 0,
@@ -2915,7 +2915,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3029,7 +3029,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3140,7 +3140,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3159,7 +3159,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3544,7 +3544,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3563,7 +3563,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3679,7 +3679,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3698,7 +3698,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3717,7 +3717,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3736,7 +3736,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3755,7 +3755,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3774,7 +3774,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,

--- a/cs/compiled_circuits/mem_subword_only_preprocessed_layout_no_caches_gkr.json
+++ b/cs/compiled_circuits/mem_subword_only_preprocessed_layout_no_caches_gkr.json
@@ -61,7 +61,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 20
               },
@@ -594,7 +594,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 9
               },
@@ -610,7 +610,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 8
               },
@@ -657,7 +657,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 9
               },
@@ -856,7 +856,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 18
               },
@@ -949,7 +949,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 19
               },
@@ -1100,7 +1100,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 20
               },
@@ -1148,7 +1148,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 26
               },
@@ -2583,7 +2583,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2697,7 +2697,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2808,7 +2808,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2827,7 +2827,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3175,7 +3175,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3194,7 +3194,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -3385,7 +3385,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3404,7 +3404,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3423,7 +3423,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3442,7 +3442,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3461,7 +3461,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -3480,7 +3480,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,

--- a/cs/compiled_circuits/mem_word_only_preprocessed_layout_gkr.json
+++ b/cs/compiled_circuits/mem_word_only_preprocessed_layout_gkr.json
@@ -702,7 +702,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 20
               },
@@ -1021,7 +1021,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 4
               },
@@ -1190,7 +1190,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 20
               },
@@ -1238,7 +1238,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 26
               },
@@ -1388,7 +1388,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "Cached": {
                   "layer": 0,
@@ -2019,7 +2019,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2038,7 +2038,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2095,7 +2095,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2209,7 +2209,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2320,7 +2320,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2339,7 +2339,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2358,7 +2358,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2377,7 +2377,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2721,7 +2721,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -2740,7 +2740,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -2856,7 +2856,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -2875,7 +2875,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -2894,7 +2894,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -2913,7 +2913,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -2932,7 +2932,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -2951,7 +2951,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,

--- a/cs/compiled_circuits/mem_word_only_preprocessed_layout_no_caches_gkr.json
+++ b/cs/compiled_circuits/mem_word_only_preprocessed_layout_no_caches_gkr.json
@@ -61,7 +61,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 20
               },
@@ -512,7 +512,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerWitness": 4
               },
@@ -681,7 +681,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 20
               },
@@ -729,7 +729,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 26
               },
@@ -1759,7 +1759,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -1778,7 +1778,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -1835,7 +1835,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -1949,7 +1949,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2060,7 +2060,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2079,7 +2079,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2098,7 +2098,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2117,7 +2117,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -2369,7 +2369,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -2388,7 +2388,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -2579,7 +2579,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -2598,7 +2598,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -2617,7 +2617,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -2636,7 +2636,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -2655,7 +2655,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -2674,7 +2674,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,

--- a/cs/compiled_circuits/shift_binop_preprocessed_layout_gkr.json
+++ b/cs/compiled_circuits/shift_binop_preprocessed_layout_gkr.json
@@ -718,7 +718,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 21
               },
@@ -2422,7 +2422,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 27
               },
@@ -2572,7 +2572,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "Cached": {
                   "layer": 0,
@@ -3893,7 +3893,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -4099,7 +4099,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -4118,7 +4118,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -4356,7 +4356,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -4375,7 +4375,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -4445,7 +4445,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -4464,7 +4464,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -4483,7 +4483,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -4502,7 +4502,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -4628,7 +4628,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -4647,7 +4647,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -4666,7 +4666,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -4685,7 +4685,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,

--- a/cs/compiled_circuits/shift_binop_preprocessed_layout_no_caches_gkr.json
+++ b/cs/compiled_circuits/shift_binop_preprocessed_layout_no_caches_gkr.json
@@ -61,7 +61,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 21
               },
@@ -1893,7 +1893,7 @@
         {
           "output_layer": 1,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "BaseLayerMemory": 27
               },
@@ -2957,7 +2957,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInBaseField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3163,7 +3163,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -3182,7 +3182,7 @@
         {
           "output_layer": 2,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 1,
@@ -4015,7 +4015,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -4034,7 +4034,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -4104,7 +4104,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -4123,7 +4123,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -4142,7 +4142,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -4161,7 +4161,7 @@
         {
           "output_layer": 3,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 2,
@@ -4287,7 +4287,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -4306,7 +4306,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -4325,7 +4325,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,
@@ -4344,7 +4344,7 @@
         {
           "output_layer": 4,
           "enforced_relation": {
-            "Copy": {
+            "CopyInExtensionField": {
               "input": {
                 "InnerLayer": {
                   "layer": 3,

--- a/cs/src/gkr_compiler/graph.rs
+++ b/cs/src/gkr_compiler/graph.rs
@@ -8,7 +8,8 @@ use std::{collections::BTreeMap, hash::Hash};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum CopyNode {
-    FromBase(GKRAddress),
+    FromBaseLayerInBase(GKRAddress),
+    FromBaseLayerInExtension(GKRAddress),
     FromIntermediateInBase(GKRAddress),
     FromIntermediateInExtension(GKRAddress),
 }
@@ -18,13 +19,10 @@ impl GKRGate for CopyNode {
 
     fn short_name(&self) -> String {
         match self {
-            Self::FromBase(var) => {
+            Self::FromBaseLayerInBase(var) | Self::FromIntermediateInBase(var) => {
                 format!("Copy of {:?} in base field", var)
             }
-            Self::FromIntermediateInBase(var) => {
-                format!("Copy of {:?} in base field", var)
-            }
-            Self::FromIntermediateInExtension(var) => {
+            Self::FromBaseLayerInExtension(var) | Self::FromIntermediateInExtension(var) => {
                 format!("Copy of {:?} in extension field", var)
             }
         }
@@ -38,8 +36,8 @@ impl GKRGate for CopyNode {
     ) -> (Self::Output, NoFieldGKRRelation) {
         let output = graph.add_intermediate_variable_at_layer(output_layer);
         match self {
-            Self::FromBase(input) | Self::FromIntermediateInBase(input) => {
-                println!("Copying variable {:?} -> {:?}", input, output);
+            Self::FromBaseLayerInBase(input) | Self::FromIntermediateInBase(input) => {
+                println!("Copying variable {:?} -> {:?} in base field", input, output);
                 let rel = NoFieldGKRRelation::CopyInBaseField {
                     input: *input,
                     output,
@@ -48,8 +46,11 @@ impl GKRGate for CopyNode {
 
                 (output, rel)
             }
-            Self::FromIntermediateInExtension(input) => {
-                println!("Copying variable {:?} -> {:?}", input, output);
+            Self::FromBaseLayerInExtension(input) | Self::FromIntermediateInExtension(input) => {
+                println!(
+                    "Copying variable {:?} -> {:?} in extension field",
+                    input, output
+                );
                 let rel = NoFieldGKRRelation::CopyInExtensionField {
                     input: *input,
                     output,
@@ -362,7 +363,7 @@ impl GraphHolder for GKRGraph {
 
     fn copy_base_layer_variable(&mut self, variable: Variable) -> GKRAddress {
         let pos = self.get_address_for_variable(variable);
-        let node = CopyNode::FromBase(pos);
+        let node = CopyNode::FromBaseLayerInBase(pos);
         let (out, _) = node.add_at_layer(self, 1);
 
         out

--- a/cs/src/gkr_compiler/graph.rs
+++ b/cs/src/gkr_compiler/graph.rs
@@ -9,7 +9,8 @@ use std::{collections::BTreeMap, hash::Hash};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum CopyNode {
     FromBase(GKRAddress),
-    FromIntermediate(GKRAddress),
+    FromIntermediateInBase(GKRAddress),
+    FromIntermediateInExtension(GKRAddress),
 }
 
 impl GKRGate for CopyNode {
@@ -18,10 +19,13 @@ impl GKRGate for CopyNode {
     fn short_name(&self) -> String {
         match self {
             Self::FromBase(var) => {
-                format!("Copy of {:?}", var)
+                format!("Copy of {:?} in base field", var)
             }
-            Self::FromIntermediate(var) => {
-                format!("Copy of {:?}", var)
+            Self::FromIntermediateInBase(var) => {
+                format!("Copy of {:?} in base field", var)
+            }
+            Self::FromIntermediateInExtension(var) => {
+                format!("Copy of {:?} in extension field", var)
             }
         }
     }
@@ -33,15 +37,28 @@ impl GKRGate for CopyNode {
         output_layer: usize,
     ) -> (Self::Output, NoFieldGKRRelation) {
         let output = graph.add_intermediate_variable_at_layer(output_layer);
-        let input = match self {
-            Self::FromBase(input) => *input,
-            Self::FromIntermediate(input) => *input,
-        };
-        println!("Copying variable {:?} -> {:?}", input, output);
-        let rel = NoFieldGKRRelation::Copy { input, output };
-        graph.add_enforced_relation(rel.clone(), output_layer);
+        match self {
+            Self::FromBase(input) | Self::FromIntermediateInBase(input) => {
+                println!("Copying variable {:?} -> {:?}", input, output);
+                let rel = NoFieldGKRRelation::CopyInBaseField {
+                    input: *input,
+                    output,
+                };
+                graph.add_enforced_relation(rel.clone(), output_layer);
 
-        (output, rel)
+                (output, rel)
+            }
+            Self::FromIntermediateInExtension(input) => {
+                println!("Copying variable {:?} -> {:?}", input, output);
+                let rel = NoFieldGKRRelation::CopyInExtensionField {
+                    input: *input,
+                    output,
+                };
+                graph.add_enforced_relation(rel.clone(), output_layer);
+
+                (output, rel)
+            }
+        }
     }
 }
 
@@ -351,11 +368,21 @@ impl GraphHolder for GKRGraph {
         out
     }
 
-    fn copy_intermediate_layer_variable(&mut self, pos: GKRAddress) -> GKRAddress {
+    fn copy_intermediate_layer_base_field_variable(&mut self, pos: GKRAddress) -> GKRAddress {
         let GKRAddress::InnerLayer { layer, .. } = pos else {
             unreachable!()
         };
-        let node = CopyNode::FromIntermediate(pos);
+        let node = CopyNode::FromIntermediateInBase(pos);
+        let (out, _) = node.add_at_layer(self, layer + 1);
+
+        out
+    }
+
+    fn copy_intermediate_layer_extension_field_variable(&mut self, pos: GKRAddress) -> GKRAddress {
+        let GKRAddress::InnerLayer { layer, .. } = pos else {
+            unreachable!()
+        };
+        let node = CopyNode::FromIntermediateInExtension(pos);
         let (out, _) = node.add_at_layer(self, layer + 1);
 
         out
@@ -378,7 +405,11 @@ pub trait GraphHolder {
 
     // copy variables across layers
     fn copy_base_layer_variable(&mut self, variable: Variable) -> GKRAddress;
-    fn copy_intermediate_layer_variable(&mut self, variable: GKRAddress) -> GKRAddress;
+    fn copy_intermediate_layer_base_field_variable(&mut self, variable: GKRAddress) -> GKRAddress;
+    fn copy_intermediate_layer_extension_field_variable(
+        &mut self,
+        variable: GKRAddress,
+    ) -> GKRAddress;
 
     // add cached relations
     fn add_cached_relation(

--- a/cs/src/gkr_compiler/layout.rs
+++ b/cs/src/gkr_compiler/layout.rs
@@ -100,7 +100,8 @@ impl GKRGraph {
                                 // copy
                                 *current_output =
                                     current_output.each_ref().map(|(addr, _relation)| {
-                                        let copy_node = CopyNode::FromIntermediate(*addr);
+                                        let copy_node =
+                                            CopyNode::FromIntermediateInExtension(*addr);
                                         copy_node.add_at_layer(self, next_layer)
                                     });
                             }
@@ -123,11 +124,11 @@ impl GKRGraph {
                             for next_layer in (layer + 1)..=max_output_layer {
                                 // copy
                                 let [num, den] = &current_output.0;
-                                let copy_node = CopyNode::FromIntermediate(*num);
+                                let copy_node = CopyNode::FromIntermediateInExtension(*num);
                                 let (new_num_addr, new_num_rel) =
                                     copy_node.add_at_layer(self, next_layer);
 
-                                let copy_node = CopyNode::FromIntermediate(*den);
+                                let copy_node = CopyNode::FromIntermediateInExtension(*den);
                                 let (new_den_addr, new_den_rel) =
                                     copy_node.add_at_layer(self, next_layer);
                                 *current_output = (

--- a/cs/src/gkr_compiler/lookup.rs
+++ b/cs/src/gkr_compiler/lookup.rs
@@ -727,8 +727,9 @@ fn drive_lookup_placement<F: PrimeField, const SINGLE_COLUMN: bool>(
                 LookupNumerator::Identity,
                 LookupDenominator::BaseFieldValueWithoutAdditiveConstant(input),
             ) => {
+                assert!(SINGLE_COLUMN);
                 let output = graph.add_intermediate_variable_at_layer(input_layer + 1);
-                let relation = NoFieldGKRRelation::Copy { input, output };
+                let relation = NoFieldGKRRelation::CopyInBaseField { input, output };
                 graph.add_enforced_relation(relation.clone(), input_layer + 1);
 
                 intermediate_values
@@ -743,8 +744,9 @@ fn drive_lookup_placement<F: PrimeField, const SINGLE_COLUMN: bool>(
                 LookupNumerator::Identity,
                 LookupDenominator::ExtensionFieldValueWithoutAdditiveConstant(input),
             ) => {
+                assert!(SINGLE_COLUMN == false);
                 let output = graph.add_intermediate_variable_at_layer(input_layer + 1);
-                let relation = NoFieldGKRRelation::Copy { input, output };
+                let relation = NoFieldGKRRelation::CopyInExtensionField { input, output };
                 graph.add_enforced_relation(relation.clone(), input_layer + 1);
 
                 intermediate_values
@@ -762,7 +764,7 @@ fn drive_lookup_placement<F: PrimeField, const SINGLE_COLUMN: bool>(
                 // copy them
                 let [num, den] = [num, den].map(|el| {
                     let output = graph.add_intermediate_variable_at_layer(input_layer + 1);
-                    let relation = NoFieldGKRRelation::Copy { input: el, output };
+                    let relation = NoFieldGKRRelation::CopyInExtensionField { input: el, output };
                     graph.add_enforced_relation(relation.clone(), input_layer + 1);
 
                     output

--- a/cs/src/gkr_compiler/lookup_nodes.rs
+++ b/cs/src/gkr_compiler/lookup_nodes.rs
@@ -52,7 +52,7 @@ impl GKRGate for MaterializeSingleInputNode {
         if self.input.input.is_trivial_single_input() {
             // just copy
             let input = self.input.input.linear_terms[0].1;
-            let relation = NoFieldGKRRelation::Copy { input, output };
+            let relation = NoFieldGKRRelation::CopyInBaseField { input, output };
             graph.add_enforced_relation(relation.clone(), output_layer);
 
             return (output, relation);
@@ -67,7 +67,7 @@ impl GKRGate for MaterializeSingleInputNode {
             let layer_for_caches = output_layer - 1;
             let cached_input = graph.add_cached_relation(cached_input, layer_for_caches);
 
-            let relation = NoFieldGKRRelation::Copy {
+            let relation = NoFieldGKRRelation::CopyInBaseField {
                 input: cached_input,
                 output,
             };

--- a/cs/src/gkr_compiler/memory_like_grand_product.rs
+++ b/cs/src/gkr_compiler/memory_like_grand_product.rs
@@ -590,8 +590,8 @@ pub(crate) fn accumulate_memory_like_grand_product(
     let mut next_read_set = vec![];
     let mut next_write_set = vec![];
 
-    copied_predicate_for_grand_product_masking =
-        graph.copy_intermediate_layer_variable(copied_predicate_for_grand_product_masking);
+    copied_predicate_for_grand_product_masking = graph
+        .copy_intermediate_layer_base_field_variable(copied_predicate_for_grand_product_masking);
     copied_predicate_for_grand_product_masking.assert_as_layer(output_layer);
 
     assert!(grand_product_read_accumulation_nodes.len() > 1);
@@ -633,7 +633,8 @@ pub(crate) fn accumulate_memory_like_grand_product(
                     "Copying remaining contribution {:?} to the next layer",
                     &remainder
                 );
-                let copied_remainder = graph.copy_intermediate_layer_variable(*remainder);
+                let copied_remainder =
+                    graph.copy_intermediate_layer_extension_field_variable(*remainder);
                 dst.push(copied_remainder);
             }
             _ => {
@@ -662,8 +663,10 @@ pub(crate) fn accumulate_memory_like_grand_product(
 
             let initial_len = current_read_set.len();
 
-            copied_predicate_for_grand_product_masking =
-                graph.copy_intermediate_layer_variable(copied_predicate_for_grand_product_masking);
+            copied_predicate_for_grand_product_masking = graph
+                .copy_intermediate_layer_base_field_variable(
+                    copied_predicate_for_grand_product_masking,
+                );
             copied_predicate_for_grand_product_masking.assert_as_layer(output_layer);
 
             println!(
@@ -697,7 +700,8 @@ pub(crate) fn accumulate_memory_like_grand_product(
                             "Copying remaining contribution {:?} to the next layer",
                             &remainder
                         );
-                        let copied_remainder = graph.copy_intermediate_layer_variable(*remainder);
+                        let copied_remainder =
+                            graph.copy_intermediate_layer_extension_field_variable(*remainder);
                         dst.push(copied_remainder);
                     }
                     _ => {

--- a/cs/src/gkr_compiler/memory_like_grand_product.rs
+++ b/cs/src/gkr_compiler/memory_like_grand_product.rs
@@ -119,7 +119,7 @@ impl GKRGate for GrandProductAccumulationStep {
                     let cached = graph.add_cached_relation(expr, cache_layer);
 
                     // and copy it
-                    let copy_node = CopyNode::FromBase(cached);
+                    let copy_node = CopyNode::FromBaseLayerInExtension(cached);
                     copy_node.add_at_layer(graph, output_layer)
                 } else {
                     let input = mem_permutation_expr_into_gkr_relation(access, graph);

--- a/cs/src/gkr_compiler/mod.rs
+++ b/cs/src/gkr_compiler/mod.rs
@@ -342,11 +342,14 @@ pub enum NoFieldGKRRelation {
     // LookupAggregationPostTrivialNumerator(NoFieldLookupPostTrivialNumeratorRelation),
 
     // Copy across GKR layers, relation is a(x) = \sum_y eq(x, y) a(y) formally
-    Copy {
+    CopyInBaseField {
         input: GKRAddress,
         output: GKRAddress,
     },
-
+    CopyInExtensionField {
+        input: GKRAddress,
+        output: GKRAddress,
+    },
     // Memory-like argument related
 
     // Computes (memory tuple) * (memory tuple)
@@ -522,7 +525,16 @@ impl NoFieldGKRRelation {
             Self::LinearBaseFieldRelation { .. } => vec![],
             Self::MaxQuadratic { input, output } => vec![],
             Self::EnforceConstraintsMaxQuadratic { input } => vec![],
-            Self::Copy { input, output } => {
+            Self::CopyInBaseField { input, output } => {
+                assert!(output.is_cache() == false);
+
+                if input.is_cache() {
+                    vec![*input]
+                } else {
+                    vec![]
+                }
+            }
+            Self::CopyInExtensionField { input, output } => {
                 assert!(output.is_cache() == false);
 
                 if input.is_cache() {

--- a/cs/src/gkr_compiler/utils.rs
+++ b/cs/src/gkr_compiler/utils.rs
@@ -63,7 +63,8 @@ pub fn no_field_gkr_max_quadratic_from_constraint<F: PrimeField>(
             if c.is_one() {
                 // just copy
                 let input = graph.get_address_for_variable(var);
-                return NoFieldGKRRelation::Copy { input, output };
+                // in circuits all elements are in base field
+                return NoFieldGKRRelation::CopyInBaseField { input, output };
             }
         }
     }

--- a/prover/src/gkr/prover/forward_loop/mod.rs
+++ b/prover/src/gkr/prover/forward_loop/mod.rs
@@ -221,7 +221,8 @@ pub fn evaluate_layer<F: PrimeField, E: FieldExtension<F> + Field>(
 
         // let now = std::time::Instant::now();
         match &gate.enforced_relation {
-            NoFieldGKRRelation::Copy { input, output } => {
+            NoFieldGKRRelation::CopyInBaseField { input, output }
+            | NoFieldGKRRelation::CopyInExtensionField { input, output } => {
                 // println!("Should evaluate {:?}", &gate.enforced_relation);
                 copy::forward_evaluate_copy::<F, E, false>(
                     *input,
@@ -303,7 +304,8 @@ pub fn evaluate_layer<F: PrimeField, E: FieldExtension<F> + Field>(
 
         // let now = std::time::Instant::now();
         match &gate.enforced_relation {
-            NoFieldGKRRelation::Copy { input, output } => {
+            NoFieldGKRRelation::CopyInBaseField { input, output }
+            | NoFieldGKRRelation::CopyInExtensionField { input, output } => {
                 // even though it's handled above, we may need to copy cache relation to the
                 // next layer after making it, so we try again, but infailable option
                 copy::forward_evaluate_copy::<F, E, true>(

--- a/prover/src/gkr/prover/sumcheck_loop/kernel_collector.rs
+++ b/prover/src/gkr/prover/sumcheck_loop/kernel_collector.rs
@@ -171,7 +171,6 @@ impl<F: PrimeField, E: FieldExtension<F> + Field> KernelVariant<F, E> {
     pub fn from_enforced_relations(
         relation: &NoFieldGKRRelation,
         layer_idx: usize,
-        gkr_storage: &GKRStorage<F, E>,
         lookup_challenges_multiplicative_part: E,
         lookup_challenges_additive_part: E,
         challenge_for_constraints: E,
@@ -187,42 +186,27 @@ impl<F: PrimeField, E: FieldExtension<F> + Field> KernelVariant<F, E> {
         };
 
         match relation {
-            NoFieldGKRRelation::Copy { input, output } => {
+            NoFieldGKRRelation::CopyInBaseField { input, output } => {
                 let challenge = [get_challenge()];
-                let is_base_field = gkr_storage.layers[layer_idx]
-                    .base_field_inputs
-                    .contains_key(input);
-                if is_base_field {
-                    assert!(
-                        gkr_storage.layers[layer_idx]
-                            .extension_field_inputs
-                            .contains_key(input)
-                            == false
-                    );
-                    Self::BaseCopy(
-                        BaseFieldCopyGKRRelation {
-                            input: *input,
-                            output: *output,
-                        },
-                        challenge,
-                        *output,
-                    )
-                } else {
-                    assert!(
-                        gkr_storage.layers[layer_idx]
-                            .base_field_inputs
-                            .contains_key(input)
-                            == false
-                    );
-                    Self::ExtCopy(
-                        ExtensionCopyGKRRelation {
-                            input: *input,
-                            output: *output,
-                        },
-                        challenge,
-                        *output,
-                    )
-                }
+                Self::BaseCopy(
+                    BaseFieldCopyGKRRelation {
+                        input: *input,
+                        output: *output,
+                    },
+                    challenge,
+                    *output,
+                )
+            }
+            NoFieldGKRRelation::CopyInExtensionField { input, output } => {
+                let challenge = [get_challenge()];
+                Self::ExtCopy(
+                    ExtensionCopyGKRRelation {
+                        input: *input,
+                        output: *output,
+                    },
+                    challenge,
+                    *output,
+                )
             }
             NoFieldGKRRelation::InitialGrandProductFromCaches { input, output }
             | NoFieldGKRRelation::TrivialProduct { input, output } => {
@@ -610,7 +594,6 @@ impl<F: PrimeField, E: FieldExtension<F> + Field> KernelCollector<F, E> {
         layer: &GKRLayerDescription,
         layer_idx: usize,
         batch_challenge_base: E,
-        gkr_storage: &GKRStorage<F, E>,
         lookup_challenges_multiplicative_part: E,
         lookup_challenges_additive_part: E,
         challenge_for_constraints: E,
@@ -631,7 +614,6 @@ impl<F: PrimeField, E: FieldExtension<F> + Field> KernelCollector<F, E> {
             let kernel = KernelVariant::from_enforced_relations(
                 &gate.enforced_relation,
                 layer_idx,
-                gkr_storage,
                 lookup_challenges_multiplicative_part,
                 lookup_challenges_additive_part,
                 challenge_for_constraints,

--- a/prover/src/gkr/prover/sumcheck_loop/mod.rs
+++ b/prover/src/gkr/prover/sumcheck_loop/mod.rs
@@ -210,7 +210,6 @@ where
         layer,
         layer_idx,
         batch_challenge_base,
-        gkr_storage,
         lookup_challenges_multiplicative_part,
         lookup_challenges_additive_part,
         constraints_batch_challenge,

--- a/prover/src/gkr/sumcheck/tests/sumcheck_loop.rs
+++ b/prover/src/gkr/sumcheck/tests/sumcheck_loop.rs
@@ -197,7 +197,7 @@ fn test_sumcheck_loop_multiple_gates() {
         gates: vec![
             GateArtifacts {
                 output_layer: 1,
-                enforced_relation: NoFieldGKRRelation::Copy {
+                enforced_relation: NoFieldGKRRelation::CopyInExtensionField {
                     input: addr_copy_in,
                     output: addr_copy_out,
                 },


### PR DESCRIPTION
## What ❔

Now all sumcheck analysis only requires circuit artifact and no runtime storage access

## Is this a breaking change?
- [ ] Yes
- [x] No