### PR TITLE
fix(gpu_prover): update era_cudart to 0.156.0 and fix CUB size-query callsites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,12 +762,12 @@ dependencies = [
 
 [[package]]
 name = "era_cudart"
-version = "0.154.10"
+version = "0.156.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a26bb3038da2def3a910c1052b30e2e20b78cbea51efb5d71c6033877ade4a"
+checksum = "de3f38cd4f1fa1c2535e30b1d1aa197b8f3c73d4368fbeb6524ac06fd7c23ef9"
 dependencies = [
  "bitflags",
- "era_cudart_sys 0.154.10",
+ "era_cudart_sys 0.156.0",
  "paste",
 ]
 
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "era_cudart_sys"
-version = "0.154.10"
+version = "0.156.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322b32fb10bdffc0cebe146cbdc7ba0f3fa6ed7aac8700facff0c0077c5642b8"
+checksum = "37e6d410237bb86a4321999d771c0ea55c31a9073997c9657fe68ab6a255224a"
 dependencies = [
  "regex-lite",
 ]
@@ -1096,8 +1096,8 @@ dependencies = [
  "cs",
  "env_logger",
  "era_criterion_cuda",
- "era_cudart 0.154.10",
- "era_cudart_sys 0.154.10",
+ "era_cudart 0.156.0",
+ "era_cudart_sys 0.156.0",
  "execution_utils",
  "fft",
  "field",

--- a/gpu_prover/Cargo.toml
+++ b/gpu_prover/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 
 [build-dependencies]
 cmake = "0.1"
-era_cudart_sys = "0.154"
+era_cudart_sys = "=0.156.0"
 
 [dependencies]
 blake2s_u32 = { workspace = true }
@@ -25,8 +25,8 @@ trace_and_split = { workspace = true }
 worker = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
-era_cudart = "0.154"
-era_cudart_sys = "0.154"
+era_cudart = "=0.156.0"
+era_cudart_sys = "=0.156.0"
 crossbeam-channel = "0.5"
 crossbeam-utils = "0.8"
 nvtx = "1"

--- a/gpu_prover/src/ops_cub/device_radix_sort.rs
+++ b/gpu_prover/src/ops_cub/device_radix_sort.rs
@@ -1,4 +1,4 @@
-use std::ptr::null_mut;
+use std::ptr::{null, null_mut};
 
 use era_cudart::result::{CudaResult, CudaResultWrap};
 use era_cudart::slice::DeviceSlice;
@@ -55,17 +55,17 @@ pub trait SortKeys: Sized {
         begin_bit: i32,
         end_bit: i32,
     ) -> CudaResult<usize> {
-        let d_temp_storage = DeviceSlice::empty_mut();
+        // CUB convention: `d_temp_storage == nullptr` puts the call in
+        // size-query mode — CUB writes the required scratch size into
+        // `temp_storage_bytes` and returns without touching any data pointer.
         let mut temp_storage_bytes = 0;
-        let d_keys_in = DeviceSlice::empty();
-        let d_keys_out = DeviceSlice::empty_mut();
         let function = Self::get_function(descending);
         unsafe {
             function(
-                d_temp_storage.as_mut_ptr(),
+                null_mut(),
                 &mut temp_storage_bytes,
-                d_keys_in.as_ptr(),
-                d_keys_out.as_mut_ptr(),
+                null(),
+                null_mut(),
                 num_items,
                 begin_bit,
                 end_bit,
@@ -224,21 +224,19 @@ pub trait SortPairs<K, V> {
         begin_bit: i32,
         end_bit: i32,
     ) -> CudaResult<usize> {
-        let d_temp_storage = DeviceSlice::empty_mut();
+        // CUB convention: `d_temp_storage == nullptr` puts the call in
+        // size-query mode — CUB writes the required scratch size into
+        // `temp_storage_bytes` and returns without touching any data pointer.
         let mut temp_storage_bytes = 0;
-        let d_keys_in = DeviceSlice::empty();
-        let d_keys_out = DeviceSlice::empty_mut();
-        let d_values_in = DeviceSlice::empty();
-        let d_values_out = DeviceSlice::empty_mut();
         let function = Self::get_function(descending);
         unsafe {
             function(
-                d_temp_storage.as_mut_ptr(),
+                null_mut(),
                 &mut temp_storage_bytes,
-                d_keys_in.as_ptr(),
-                d_keys_out.as_mut_ptr(),
-                d_values_in.as_ptr(),
-                d_values_out.as_mut_ptr(),
+                null(),
+                null_mut(),
+                null(),
+                null_mut(),
                 num_items,
                 begin_bit,
                 end_bit,

--- a/gpu_prover/src/ops_cub/device_run_length_encode.rs
+++ b/gpu_prover/src/ops_cub/device_run_length_encode.rs
@@ -1,4 +1,4 @@
-use std::ptr::null_mut;
+use std::ptr::{null, null_mut};
 
 use era_cudart::result::{CudaResult, CudaResultWrap};
 use era_cudart::slice::{DeviceSlice, DeviceVariable};
@@ -35,21 +35,20 @@ pub trait Encode: Sized {
     fn get_function() -> EncodeFunction<Self>;
 
     fn get_encode_temp_storage_bytes(num_items: i32) -> CudaResult<usize> {
-        let d_temp_storage = DeviceSlice::empty_mut();
+        // CUB convention: `d_temp_storage == nullptr` puts the call in
+        // size-query mode — CUB writes the required scratch size into
+        // `temp_storage_bytes` and returns without touching any data pointer.
+        // The other pointer arguments are likewise ignored in this mode.
         let mut temp_storage_bytes = 0;
-        let d_in = DeviceSlice::empty();
-        let d_unique_out = DeviceSlice::empty_mut();
-        let d_counts_out = DeviceSlice::empty_mut();
-        let d_num_runs_out = DeviceSlice::empty_mut();
         let function = Self::get_function();
         unsafe {
             function(
-                d_temp_storage.as_mut_ptr(),
+                null_mut(),
                 &mut temp_storage_bytes,
-                d_in.as_ptr(),
-                d_unique_out.as_mut_ptr(),
-                d_counts_out.as_mut_ptr(),
-                d_num_runs_out.as_mut_ptr(),
+                null(),
+                null_mut(),
+                null_mut(),
+                null_mut(),
                 num_items,
                 null_mut(),
             )

--- a/gpu_prover/src/ops_cub/device_scan.rs
+++ b/gpu_prover/src/ops_cub/device_scan.rs
@@ -1,4 +1,4 @@
-use std::ptr::null_mut;
+use std::ptr::{null, null_mut};
 
 use era_cudart::event::{CudaEvent, CudaEventCreateFlags};
 use era_cudart::paste::paste;
@@ -61,17 +61,17 @@ pub trait Scan: Sized {
         inclusive: bool,
         num_items: i32,
     ) -> CudaResult<usize> {
-        let d_temp_storage = DeviceSlice::empty_mut();
+        // CUB convention: `d_temp_storage == nullptr` puts the call in
+        // size-query mode — CUB writes the required scratch size into
+        // `temp_storage_bytes` and returns without touching any data pointer.
         let mut temp_storage_bytes = 0;
-        let d_in = DeviceSlice::empty();
-        let d_out = DeviceSlice::empty_mut();
         let function = Self::get_function(operation, inclusive);
         unsafe {
             function(
-                d_temp_storage.as_mut_ptr(),
+                null_mut(),
                 &mut temp_storage_bytes,
-                d_in.as_ptr(),
-                d_out.as_mut_ptr(),
+                null(),
+                null_mut(),
                 num_items,
                 null_mut(),
             )


### PR DESCRIPTION
## What ❔

- Bump `era_cudart` / `era_cudart_sys` to `=0.156.0` in `gpu_prover/Cargo.toml`.
- Fix four CUB size-query wrappers in `gpu_prover/src/ops_cub/` to pass `null_mut()` / `null()` directly at the FFI boundary instead of going through `DeviceSlice::empty[_mut]().as_[mut_]ptr()`.

## Why ❔

`era_cudart` 0.156.0 (matter-labs/zksync-crypto-gpu#145) changes `DeviceSlice::empty()` / `empty_mut()` to back empty slices with `NonNull::<T>::dangling()` instead of `ptr::null()` — constructing a Rust reference from a null pointer is UB even for zero-length slices, and LLVM exploited this to miscompile shivini.

That is a breaking change for consumers relying on the null runtime value. In this repo, the only affected code is `gpu_prover`'s CUB wrappers, which relied on that null to trigger CUB's `d_temp_storage == nullptr` size-query convention. They now pass `NULL` explicitly.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.