### PR TITLE
fix(gpu_prover): enable rand features for dev-dependencies

### DIFF
--- a/gpu_prover/Cargo.toml
+++ b/gpu_prover/Cargo.toml
@@ -49,7 +49,7 @@ security_100 = ["verifier_common/security_100"]
 [dev-dependencies]
 # execution_utils = { workspace = true }
 prover = { workspace = true, features = ["test"] }
-rand = { workspace = true }
+rand = { workspace = true, features = ["std", "thread_rng", "std_rng"] }
 riscv_common = { workspace = true }
 setups = { workspace = true, features = ["witness_eval_fn"] }
 trace_holder = { workspace = true }


### PR DESCRIPTION
## What ❔

Enable `["std", "thread_rng", "std_rng"]` on `rand` in `gpu_prover`'s dev-dependencies.

## Why ❔

rand 0.9 gates `rand::rng()` / `rand::random()` behind `thread_rng` and `StdRng` behind `std_rng`. The workspace pin uses `default-features = false`, so gpu_prover tests currently fail to compile on `dev`:

```
error[E0432]: unresolved import `rand::random`
error[E0423]: expected function, found module `rand::rng`
```

Feature set matches what `cs`, `fft`, and `riscv_common` already use. Verified with `cargo test -p gpu_prover --release --no-run`.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.