### PR TITLE
feat: unreduced accumulation

### DIFF
--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -18,6 +18,12 @@ quote = {version = "1", optional = true }
 
 [dev-dependencies]
 proptest = "1"
+criterion = "0.5"
+rand = { workspace = true, features = ["std", "std_rng", "small_rng"] }
+
+[[bench]]
+name = "unreduced_accum"
+harness = false
 
 [features]
 use_division = []

--- a/field/benches/unreduced_accum.rs
+++ b/field/benches/unreduced_accum.rs
@@ -1,0 +1,114 @@
+// Microbenchmark: unreduced accumulation vs Montgomery-per-iteration.
+//
+// Two loop shapes, each over N random inputs:
+//   Base scalar:  acc += a_i * b_i  (both base field)
+//   Base × Ext4:  acc += a_i * c_i  (a base, c Ext4)
+//
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use field::baby_bear::base::BabyBearField;
+use field::baby_bear::ext4::BabyBearExt4;
+use field::baby_bear::unreduced::{BabyBearExt4RawProductSum, BabyBearRawProductSum};
+use field::field::{Field, FieldExtension};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+
+fn random_base(rng: &mut impl Rng) -> BabyBearField {
+    BabyBearField::new(rng.random_range(0..BabyBearField::ORDER))
+}
+
+fn random_ext4(rng: &mut impl Rng) -> BabyBearExt4 {
+    <BabyBearExt4 as FieldExtension<BabyBearField>>::from_coeffs([
+        random_base(rng),
+        random_base(rng),
+        random_base(rng),
+        random_base(rng),
+    ])
+}
+
+fn bench_base_dot_product(c: &mut Criterion) {
+    let mut group = c.benchmark_group("base_dot_product");
+    for &log_n in &[10usize, 16, 20] {
+        let n = 1usize << log_n;
+        let mut r = SmallRng::seed_from_u64(0xC0FFEE_u64 ^ (log_n as u64));
+        let pairs: Vec<(BabyBearField, BabyBearField)> = (0..n)
+            .map(|_| (random_base(&mut r), random_base(&mut r)))
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("baseline_mul_mod", log_n),
+            &pairs,
+            |b, pairs| {
+                b.iter(|| {
+                    let mut acc = BabyBearField::ZERO;
+                    for (a, b) in pairs {
+                        let mut t = *a;
+                        t.mul_assign(b);
+                        acc.add_assign(&t);
+                    }
+                    black_box(acc)
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("unreduced_raw_product_sum", log_n),
+            &pairs,
+            |b, pairs| {
+                b.iter(|| {
+                    let mut acc = BabyBearRawProductSum::ZERO;
+                    for (a, b) in pairs {
+                        acc.add_assign_product(*a, *b);
+                    }
+                    black_box(acc.finalize())
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_base_times_ext4(c: &mut Criterion) {
+    let mut group = c.benchmark_group("base_times_ext4");
+    for &log_n in &[10usize, 16, 20] {
+        let n = 1usize << log_n;
+        let mut r = SmallRng::seed_from_u64(0xC0FFEE_u64 ^ (log_n as u64));
+        let terms: Vec<(BabyBearField, BabyBearExt4)> = (0..n)
+            .map(|_| (random_base(&mut r), random_ext4(&mut r)))
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("baseline_mul_by_base", log_n),
+            &terms,
+            |b, terms| {
+                b.iter(|| {
+                    let mut acc = BabyBearExt4::ZERO;
+                    for (a, c) in terms {
+                        let mut t = *c;
+                        t.mul_assign_by_base(a);
+                        acc.add_assign(&t);
+                    }
+                    black_box(acc)
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("unreduced_ext4_raw_product_sum", log_n),
+            &terms,
+            |b, terms| {
+                b.iter(|| {
+                    let mut acc = BabyBearExt4RawProductSum::ZERO;
+                    for (a, c) in terms {
+                        acc.add_assign_base_times_ext(*a, *c);
+                    }
+                    black_box(acc.finalize())
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_base_dot_product, bench_base_times_ext4);
+criterion_main!(benches);

--- a/field/src/baby_bear/base.rs
+++ b/field/src/baby_bear/base.rs
@@ -25,7 +25,7 @@ impl BabyBearField {
         let r = (1u64 << 32) % (Self::ORDER as u64);
         r as u32
     };
-    const MONT_R2: u32 = const {
+    pub(crate) const MONT_R2: u32 = const {
         let r = (1u64 << 32) % (Self::ORDER as u64);
         let r2 = (r * r) % (Self::ORDER as u64);
         r2 as u32

--- a/field/src/baby_bear/ext4.rs
+++ b/field/src/baby_bear/ext4.rs
@@ -348,6 +348,9 @@ impl FieldExtension<BabyBearField> for BabyBearExt4 {
 
     type Coeffs = [BabyBearField; 4];
 
+    #[cfg(not(target_arch = "riscv32"))]
+    type Unreduced = crate::baby_bear::unreduced::BabyBearExt4RawProductSum;
+
     #[cfg_attr(not(feature = "no_inline"), inline(always))]
     fn into_coeffs(self) -> Self::Coeffs {
         [self.c0.c0, self.c0.c1, self.c1.c0, self.c1.c1]

--- a/field/src/baby_bear/mod.rs
+++ b/field/src/baby_bear/mod.rs
@@ -3,4 +3,7 @@ pub mod ext2;
 pub mod ext4;
 pub mod ext6;
 
+#[cfg(not(target_arch = "riscv32"))]
+pub mod unreduced;
+
 mod ops;

--- a/field/src/baby_bear/unreduced.rs
+++ b/field/src/baby_bear/unreduced.rs
@@ -1,6 +1,7 @@
 use crate::baby_bear::base::BabyBearField;
+use crate::baby_bear::ext2::BabyBearExt2;
 use crate::baby_bear::ext4::BabyBearExt4;
-use crate::field::{FieldExtension, UnreducedAccumulator};
+use crate::field::UnreducedAccumulator;
 
 #[derive(Clone, Copy, Debug)]
 #[repr(transparent)]
@@ -10,11 +11,18 @@ impl BabyBearRawProductSum {
     pub const ZERO: Self = Self(0);
 
     #[cfg_attr(not(feature = "no_inline"), inline(always))]
+    pub fn from_product(a: BabyBearField, b: BabyBearField) -> Self {
+        let raw = (a.0 as u64).wrapping_mul(b.0 as u64);
+        Self(raw as u128)
+    }
+
+    #[cfg_attr(not(feature = "no_inline"), inline(always))]
     pub fn add_assign_product(&mut self, a: BabyBearField, b: BabyBearField) {
         let raw = (a.0 as u64).wrapping_mul(b.0 as u64);
         self.0 = self.0.wrapping_add(raw as u128);
     }
 
+    #[cfg_attr(not(feature = "no_inline"), inline(always))]
     pub fn finalize(self) -> BabyBearField {
         debug_assert!(self.0 < (1u128 << 127));
 
@@ -41,32 +49,50 @@ impl BabyBearExt4RawProductSum {
     pub const ZERO: Self = Self { lanes: [0; 4] };
 
     #[cfg_attr(not(feature = "no_inline"), inline(always))]
+    pub fn from_base_times_ext(a: BabyBearField, c: BabyBearExt4) -> Self {
+        let a = a.0 as u64;
+        let coeffs = [c.c0.c0.0, c.c0.c1.0, c.c1.c0.0, c.c1.c1.0];
+        Self {
+            lanes: [
+                a.wrapping_mul(coeffs[0] as u64) as u128,
+                a.wrapping_mul(coeffs[1] as u64) as u128,
+                a.wrapping_mul(coeffs[2] as u64) as u128,
+                a.wrapping_mul(coeffs[3] as u64) as u128,
+            ],
+        }
+    }
+
+    #[cfg_attr(not(feature = "no_inline"), inline(always))]
     pub fn add_assign_base_times_ext(&mut self, a: BabyBearField, c: BabyBearExt4) {
-        let coeffs = <BabyBearExt4 as FieldExtension<BabyBearField>>::into_coeffs(c);
+        let coeffs = [c.c0.c0.0, c.c0.c1.0, c.c1.c0.0, c.c1.c1.0];
         for k in 0..4 {
-            let raw = (a.0 as u64).wrapping_mul(coeffs[k].0 as u64);
+            let raw = (a.0 as u64).wrapping_mul(coeffs[k] as u64);
             self.lanes[k] = self.lanes[k].wrapping_add(raw as u128);
         }
     }
 
     #[cfg_attr(not(feature = "no_inline"), inline(always))]
     pub fn add_assign_ext(&mut self, e: BabyBearExt4) {
-        let coeffs = <BabyBearExt4 as FieldExtension<BabyBearField>>::into_coeffs(e);
+        let coeffs = [e.c0.c0.0, e.c0.c1.0, e.c1.c0.0, e.c1.c1.0];
         for k in 0..4 {
-            let delta = (coeffs[k].0 as u128) << 32;
+            let delta = (coeffs[k] as u128) << 32;
             self.lanes[k] = self.lanes[k].wrapping_add(delta);
         }
     }
 
+    #[cfg_attr(not(feature = "no_inline"), inline(always))]
     pub fn finalize(self) -> BabyBearExt4 {
         let [l0, l1, l2, l3] = self.lanes;
-        let coeffs = [
-            BabyBearRawProductSum(l0).finalize(),
-            BabyBearRawProductSum(l1).finalize(),
-            BabyBearRawProductSum(l2).finalize(),
-            BabyBearRawProductSum(l3).finalize(),
-        ];
-        <BabyBearExt4 as FieldExtension<BabyBearField>>::from_coeffs(coeffs)
+        BabyBearExt4 {
+            c0: BabyBearExt2 {
+                c0: BabyBearRawProductSum(l0).finalize(),
+                c1: BabyBearRawProductSum(l1).finalize(),
+            },
+            c1: BabyBearExt2 {
+                c0: BabyBearRawProductSum(l2).finalize(),
+                c1: BabyBearRawProductSum(l3).finalize(),
+            },
+        }
     }
 }
 
@@ -102,7 +128,7 @@ fn mont_reduce_step(x: u128) -> u128 {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::field::Field;
+    use crate::field::{Field, FieldExtension};
     use proptest::prelude::*;
 
     fn arb_babybear() -> impl Strategy<Value = BabyBearField> {

--- a/field/src/baby_bear/unreduced.rs
+++ b/field/src/baby_bear/unreduced.rs
@@ -1,0 +1,248 @@
+use crate::baby_bear::base::BabyBearField;
+use crate::baby_bear::ext4::BabyBearExt4;
+use crate::field::{FieldExtension, UnreducedAccumulator};
+
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct BabyBearRawProductSum(pub u128);
+
+impl BabyBearRawProductSum {
+    pub const ZERO: Self = Self(0);
+
+    #[cfg_attr(not(feature = "no_inline"), inline(always))]
+    pub fn add_assign_product(&mut self, a: BabyBearField, b: BabyBearField) {
+        let raw = (a.0 as u64).wrapping_mul(b.0 as u64);
+        self.0 = self.0.wrapping_add(raw as u128);
+    }
+
+    pub fn finalize(self) -> BabyBearField {
+        debug_assert!(self.0 < (1u128 << 127));
+
+        let x = mont_reduce_step(self.0);
+        let x = mont_reduce_step(x);
+        let x = mont_reduce_step(x);
+
+        let x = (x as u64) % BabyBearField::ORDER as u64;
+        let x = x as u32;
+
+        let corrected = crate::baby_bear::ops::mul_mod(x, BabyBearField::MONT_R2);
+        let corrected = crate::baby_bear::ops::mul_mod(corrected, BabyBearField::MONT_R2);
+        BabyBearField::from_raw_u32(corrected)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct BabyBearExt4RawProductSum {
+    pub lanes: [u128; 4],
+}
+
+impl BabyBearExt4RawProductSum {
+    pub const ZERO: Self = Self { lanes: [0; 4] };
+
+    #[cfg_attr(not(feature = "no_inline"), inline(always))]
+    pub fn add_assign_base_times_ext(&mut self, a: BabyBearField, c: BabyBearExt4) {
+        let coeffs = <BabyBearExt4 as FieldExtension<BabyBearField>>::into_coeffs(c);
+        for k in 0..4 {
+            let raw = (a.0 as u64).wrapping_mul(coeffs[k].0 as u64);
+            self.lanes[k] = self.lanes[k].wrapping_add(raw as u128);
+        }
+    }
+
+    #[cfg_attr(not(feature = "no_inline"), inline(always))]
+    pub fn add_assign_ext(&mut self, e: BabyBearExt4) {
+        let coeffs = <BabyBearExt4 as FieldExtension<BabyBearField>>::into_coeffs(e);
+        for k in 0..4 {
+            let delta = (coeffs[k].0 as u128) << 32;
+            self.lanes[k] = self.lanes[k].wrapping_add(delta);
+        }
+    }
+
+    pub fn finalize(self) -> BabyBearExt4 {
+        let [l0, l1, l2, l3] = self.lanes;
+        let coeffs = [
+            BabyBearRawProductSum(l0).finalize(),
+            BabyBearRawProductSum(l1).finalize(),
+            BabyBearRawProductSum(l2).finalize(),
+            BabyBearRawProductSum(l3).finalize(),
+        ];
+        <BabyBearExt4 as FieldExtension<BabyBearField>>::from_coeffs(coeffs)
+    }
+}
+
+impl UnreducedAccumulator<BabyBearField, BabyBearExt4> for BabyBearExt4RawProductSum {
+    const ZERO: Self = Self::ZERO;
+
+    #[cfg_attr(not(feature = "no_inline"), inline(always))]
+    fn add_assign_base_times_ext(&mut self, a: BabyBearField, c: BabyBearExt4) {
+        Self::add_assign_base_times_ext(self, a, c)
+    }
+
+    #[cfg_attr(not(feature = "no_inline"), inline(always))]
+    fn add_assign_ext(&mut self, e: BabyBearExt4) {
+        Self::add_assign_ext(self, e)
+    }
+
+    #[cfg_attr(not(feature = "no_inline"), inline(always))]
+    fn finalize(self) -> BabyBearExt4 {
+        Self::finalize(self)
+    }
+}
+
+// One Montgomery reduction step on a u128: result ≡ x · R⁻¹ (mod p).
+// Bound: result ≤ x/R + p. Precondition: x + m·p must not overflow u128.
+#[cfg_attr(not(feature = "no_inline"), inline(always))]
+fn mont_reduce_step(x: u128) -> u128 {
+    let low32 = x as u32;
+    let m = low32.wrapping_mul(BabyBearField::MONT_K);
+    let addend = (m as u128) * (BabyBearField::ORDER as u128);
+    (x + addend) >> 32
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::field::Field;
+    use proptest::prelude::*;
+
+    fn arb_babybear() -> impl Strategy<Value = BabyBearField> {
+        (0..BabyBearField::ORDER).prop_map(BabyBearField::new)
+    }
+
+    #[test]
+    fn single_product_reduces_like_mul_mod() {
+        let a = BabyBearField::new(3);
+        let b = BabyBearField::new(5);
+
+        let mut acc = BabyBearRawProductSum::ZERO;
+        acc.add_assign_product(a, b);
+
+        let mut expected = a;
+        expected.mul_assign(&b);
+
+        assert_eq!(acc.finalize(), expected);
+    }
+
+    #[test]
+    fn two_products_match_reduced_sum() {
+        let pairs = [
+            (BabyBearField::new(3), BabyBearField::new(5)),
+            (BabyBearField::new(7), BabyBearField::new(11)),
+        ];
+
+        let mut acc = BabyBearRawProductSum::ZERO;
+        for (a, b) in pairs {
+            acc.add_assign_product(a, b);
+        }
+        let got = acc.finalize();
+
+        let mut expected = BabyBearField::ZERO;
+        for (a, b) in pairs {
+            let mut ab = a;
+            ab.mul_assign(&b);
+            expected.add_assign(&ab);
+        }
+
+        assert_eq!(got, expected);
+    }
+
+    fn arb_ext4() -> impl Strategy<Value = BabyBearExt4> {
+        [
+            arb_babybear(),
+            arb_babybear(),
+            arb_babybear(),
+            arb_babybear(),
+        ]
+        .prop_map(|[a, b, c, d]| {
+            <BabyBearExt4 as FieldExtension<BabyBearField>>::from_coeffs([a, b, c, d])
+        })
+    }
+
+    #[test]
+    fn ext4_single_base_times_ext_matches_reference() {
+        let a = BabyBearField::new(7);
+        let c = <BabyBearExt4 as FieldExtension<BabyBearField>>::from_coeffs([
+            BabyBearField::new(3),
+            BabyBearField::new(5),
+            BabyBearField::new(11),
+            BabyBearField::new(13),
+        ]);
+
+        let mut acc = BabyBearExt4RawProductSum::ZERO;
+        acc.add_assign_base_times_ext(a, c);
+
+        let mut expected = c;
+        expected.mul_assign_by_base(&a);
+
+        assert_eq!(acc.finalize(), expected);
+    }
+
+    proptest! {
+        #[test]
+        fn sum_of_products_matches_reference(
+            pairs in prop::collection::vec((arb_babybear(), arb_babybear()), 0..=256)
+        ) {
+            let mut acc = BabyBearRawProductSum::ZERO;
+            for (a, b) in &pairs {
+                acc.add_assign_product(*a, *b);
+            }
+            let got = acc.finalize();
+
+            let mut expected = BabyBearField::ZERO;
+            for (a, b) in &pairs {
+                let mut ab = *a;
+                ab.mul_assign(b);
+                expected.add_assign(&ab);
+            }
+
+            prop_assert_eq!(got, expected);
+        }
+
+        #[test]
+        fn ext4_add_assign_ext_matches_reference(
+            initial_terms in prop::collection::vec((arb_babybear(), arb_ext4()), 0..=8),
+            adds in prop::collection::vec(arb_ext4(), 0..=8),
+        ) {
+            let mut acc = BabyBearExt4RawProductSum::ZERO;
+            for (a, c) in &initial_terms {
+                acc.add_assign_base_times_ext(*a, *c);
+            }
+            for e in &adds {
+                acc.add_assign_ext(*e);
+            }
+            let got = acc.finalize();
+
+            let mut expected = BabyBearExt4::ZERO;
+            for (a, c) in &initial_terms {
+                let mut term = *c;
+                term.mul_assign_by_base(a);
+                expected.add_assign(&term);
+            }
+            for e in &adds {
+                expected.add_assign(e);
+            }
+
+            prop_assert_eq!(got, expected);
+        }
+
+        #[test]
+        fn ext4_sum_of_base_times_ext_matches_reference(
+            terms in prop::collection::vec((arb_babybear(), arb_ext4()), 0..=256)
+        ) {
+            let mut acc = BabyBearExt4RawProductSum::ZERO;
+            for (a, c) in &terms {
+                acc.add_assign_base_times_ext(*a, *c);
+            }
+            let got = acc.finalize();
+
+            let mut expected = BabyBearExt4::ZERO;
+            for (a, c) in &terms {
+                let mut term = *c;
+                term.mul_assign_by_base(a);
+                expected.add_assign(&term);
+            }
+
+            prop_assert_eq!(got, expected);
+        }
+    }
+}

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -219,7 +219,47 @@ impl<F: Field, const M: usize> FixedArrayConvertible<F> for [F; M] {
     }
 }
 
-pub trait FieldExtension<BaseField: Field>: 'static + Clone + Copy + Send + Sync {
+pub trait UnreducedAccumulator<F, E>: 'static + Clone + Copy + Send + Sync + Sized {
+    const ZERO: Self;
+
+    fn add_assign_base_times_ext(&mut self, a: F, c: E);
+
+    fn add_assign_ext(&mut self, e: E);
+
+    fn finalize(self) -> E;
+}
+
+/// Default "no optimization" accumulator — keeps each partial sum fully Montgomery-reduced.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReducedAccumulator<E>(pub E);
+
+impl<F, E> UnreducedAccumulator<F, E> for ReducedAccumulator<E>
+where
+    F: Field,
+    E: Field + FieldExtension<F>,
+{
+    const ZERO: Self = ReducedAccumulator(E::ZERO);
+
+    #[cfg_attr(not(feature = "no_inline"), inline(always))]
+    fn add_assign_base_times_ext(&mut self, a: F, c: E) {
+        let mut t = c;
+        t.mul_assign_by_base(&a);
+        self.0.add_assign(&t);
+    }
+
+    #[cfg_attr(not(feature = "no_inline"), inline(always))]
+    fn add_assign_ext(&mut self, e: E) {
+        self.0.add_assign(&e);
+    }
+
+    #[cfg_attr(not(feature = "no_inline"), inline(always))]
+    fn finalize(self) -> E {
+        self.0
+    }
+}
+
+pub trait FieldExtension<BaseField: Field>: 'static + Clone + Copy + Send + Sync + Field {
     const DEGREE: usize;
 
     type Coeffs: 'static
@@ -233,6 +273,8 @@ pub trait FieldExtension<BaseField: Field>: 'static + Clone + Copy + Send + Sync
         + Index<usize, Output = BaseField>
         + IndexMut<usize, Output = BaseField>
         + FixedArrayConvertible<BaseField>;
+
+    type Unreduced: UnreducedAccumulator<BaseField, Self> = ReducedAccumulator<Self>;
 
     fn into_coeffs(self) -> Self::Coeffs;
     fn from_coeffs(coeffs: Self::Coeffs) -> Self;

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(target_arch = "riscv32", allow(internal_features))]
 #![cfg_attr(target_arch = "riscv32", feature(core_intrinsics))]
 #![cfg_attr(target_arch = "riscv32", feature(const_eval_select))]
+#![feature(associated_type_defaults)]
 
 use core::fmt::Debug;
 use core::fmt::Display;

--- a/prover/src/gkr/prover/sumcheck_loop/batch_evaluation.rs
+++ b/prover/src/gkr/prover/sumcheck_loop/batch_evaluation.rs
@@ -1,7 +1,10 @@
 use super::*;
 use crate::definitions::sumcheck_kernel::*;
-use crate::gkr::sumcheck::access_and_fold::ExtensionFieldPolyContinuingSource;
+use crate::gkr::sumcheck::access_and_fold::{
+    BaseFieldPolySource, ExtensionFieldPolyContinuingSource, ExtensionFieldPolyInitialSource,
+};
 use crate::gkr::sumcheck::evaluation_kernels::BatchedGKRTermDescriptionConstants;
+use field::{ReducedAccumulator, UnreducedAccumulator};
 
 #[derive(Clone, Debug, Default)]
 struct BatchedGKRDescriptionDraft<F: PrimeField, E: FieldExtension<F> + Field> {
@@ -190,7 +193,7 @@ pub(crate) fn evaluate_batched_gkr_description<
     storage: &mut GKRStorage<F, E>,
     step: usize,
     folding_challenges: &[E],
-    accumulator: &mut [[E; 2]],
+    output: &mut [[E; 2]],
     total_sumcheck_rounds: usize,
     last_evaluations: &mut BTreeMap<GKRAddress, [E; N]>,
     worker: &Worker,
@@ -201,16 +204,21 @@ pub(crate) fn evaluate_batched_gkr_description<
 
     // TODO: restructure to batch [(b, c)] and then multiply by a
 
-    let work_size = accumulator.len();
+    let work_size = output.len();
     assert!(work_size.is_power_of_two());
 
-    match step {
-        0 => {
+    if step == 0 {
+        let zero = <<E as FieldExtension<F>>::Unreduced as UnreducedAccumulator<F, E>>::ZERO;
+        let mut scratch: Vec<[<E as FieldExtension<F>>::Unreduced; 2]> = vec![[zero; 2]; work_size];
+        let accumulator: &mut [[<E as FieldExtension<F>>::Unreduced; 2]] = scratch.as_mut_slice();
+
+        {
             for (a, other_terms) in description.quadratic_part_base_by_base.iter() {
                 for (b, c) in other_terms {
                     let a_s = storage.get_base_field_initial_source(a);
                     let b_s = storage.get_base_field_initial_source(b);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, true, false>(
+
+                    evaluate_quadratic_term_first_round_base_by_base::<F, E>(
                         &a_s,
                         &b_s,
                         *c,
@@ -223,7 +231,8 @@ pub(crate) fn evaluate_batched_gkr_description<
                 for (b, c) in other_terms {
                     let a_s = storage.get_base_field_initial_source(a);
                     let b_s = storage.get_extension_field_initial_source(b);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, true, false>(
+
+                    evaluate_quadratic_term_first_round_base_by_ext::<F, E>(
                         &a_s,
                         &b_s,
                         *c,
@@ -236,7 +245,7 @@ pub(crate) fn evaluate_batched_gkr_description<
                 for (b, c) in other_terms {
                     let a_s = storage.get_extension_field_initial_source(a);
                     let b_s = storage.get_extension_field_initial_source(b);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, true, false>(
+                    evaluate_quadratic_term::<F, E, _, _, _, _, _, true, false>(
                         &a_s,
                         &b_s,
                         *c,
@@ -247,256 +256,330 @@ pub(crate) fn evaluate_batched_gkr_description<
             }
             for (a, c) in description.linear_part_base_by_everything.iter() {
                 let a_s = storage.get_base_field_initial_source(a);
-                evaluate_linear_term::<F, E, _, _, true, false>(&a_s, *c, accumulator, worker);
+                evaluate_linear_term::<F, E, _, _, _, true, false>(&a_s, *c, accumulator, worker);
             }
             for (a, c) in description.linear_part_ext_by_everything.iter() {
                 let a_s = storage.get_extension_field_initial_source(a);
-                evaluate_linear_term::<F, E, _, _, true, false>(&a_s, *c, accumulator, worker);
+                evaluate_linear_term::<F, E, _, _, _, true, false>(&a_s, *c, accumulator, worker);
             }
             for (a, c) in description.outputs_in_base.iter() {
                 let a_s = storage.get_base_field_initial_source(a);
-                add_output_term::<F, E, _, _>(&a_s, *c, accumulator, worker);
+                add_output_term::<F, E, _, _, _>(&a_s, *c, accumulator, worker);
             }
             for (a, c) in description.outputs_in_ext.iter() {
                 let a_s = storage.get_extension_field_initial_source(a);
-                add_output_term::<F, E, _, _>(&a_s, *c, accumulator, worker);
+                add_output_term::<F, E, _, _, _>(&a_s, *c, accumulator, worker);
             }
         }
-        // for all other rounds we care bound constant term as we do not have outputs
-        1 => {
-            fill_constant_term::<_, _, false>(description.constant_term, accumulator, worker);
 
-            for (a, other_terms) in description.quadratic_part_base_by_base.iter() {
-                for (b, c) in other_terms {
+        for i in 0..work_size {
+            output[i][0] = accumulator[i][0].finalize();
+            output[i][1] = accumulator[i][1].finalize();
+        }
+    } else {
+        output.fill([E::ZERO; 2]);
+
+        let accumulator: &mut [[ReducedAccumulator<E>; 2]] = unsafe {
+            let len = output.len();
+            let ptr = output.as_mut_ptr() as *mut [ReducedAccumulator<E>; 2];
+            std::slice::from_raw_parts_mut(ptr, len)
+        };
+
+        match step {
+            0 => unreachable!(),
+            1 => {
+                fill_constant_term::<_, _, _, false>(
+                    description.constant_term,
+                    accumulator,
+                    worker,
+                );
+
+                for (a, other_terms) in description.quadratic_part_base_by_base.iter() {
+                    for (b, c) in other_terms {
+                        let a_s = storage.make_base_source_for_round_1(*a, folding_challenges);
+                        let b_s = storage.make_base_source_for_round_1(*b, folding_challenges);
+                        evaluate_quadratic_term::<F, E, _, _, _, _, _, false, false>(
+                            &a_s,
+                            &b_s,
+                            *c,
+                            accumulator,
+                            worker,
+                        );
+                    }
+                }
+                for (a, other_terms) in description.quadratic_part_base_by_ext.iter() {
+                    for (b, c) in other_terms {
+                        let a_s = storage.make_base_source_for_round_1(*a, folding_challenges);
+                        let b_s =
+                            storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
+                        evaluate_quadratic_term::<F, E, _, _, _, _, _, false, false>(
+                            &a_s,
+                            &b_s,
+                            *c,
+                            accumulator,
+                            worker,
+                        );
+                    }
+                }
+                for (a, other_terms) in description.quadratic_part_ext_by_ext.iter() {
+                    for (b, c) in other_terms {
+                        let a_s =
+                            storage.make_ext_source_for_rounds_1_and_beyond(*a, folding_challenges);
+                        let b_s =
+                            storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
+                        evaluate_quadratic_term::<F, E, _, _, _, _, _, false, false>(
+                            &a_s,
+                            &b_s,
+                            *c,
+                            accumulator,
+                            worker,
+                        );
+                    }
+                }
+                for (a, c) in description.linear_part_base_by_everything.iter() {
                     let a_s = storage.make_base_source_for_round_1(*a, folding_challenges);
-                    let b_s = storage.make_base_source_for_round_1(*b, folding_challenges);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, false, false>(
+                    evaluate_linear_term::<F, E, _, _, _, false, false>(
                         &a_s,
-                        &b_s,
                         *c,
                         accumulator,
                         worker,
                     );
                 }
-            }
-            for (a, other_terms) in description.quadratic_part_base_by_ext.iter() {
-                for (b, c) in other_terms {
-                    let a_s = storage.make_base_source_for_round_1(*a, folding_challenges);
-                    let b_s =
-                        storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, false, false>(
-                        &a_s,
-                        &b_s,
-                        *c,
-                        accumulator,
-                        worker,
-                    );
-                }
-            }
-            for (a, other_terms) in description.quadratic_part_ext_by_ext.iter() {
-                for (b, c) in other_terms {
+                for (a, c) in description.linear_part_ext_by_everything.iter() {
                     let a_s =
                         storage.make_ext_source_for_rounds_1_and_beyond(*a, folding_challenges);
-                    let b_s =
-                        storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, false, false>(
+                    evaluate_linear_term::<F, E, _, _, _, false, false>(
                         &a_s,
-                        &b_s,
                         *c,
                         accumulator,
                         worker,
                     );
                 }
             }
-            for (a, c) in description.linear_part_base_by_everything.iter() {
-                let a_s = storage.make_base_source_for_round_1(*a, folding_challenges);
-                evaluate_linear_term::<F, E, _, _, false, false>(&a_s, *c, accumulator, worker);
-            }
-            for (a, c) in description.linear_part_ext_by_everything.iter() {
-                let a_s = storage.make_ext_source_for_rounds_1_and_beyond(*a, folding_challenges);
-                evaluate_linear_term::<F, E, _, _, false, false>(&a_s, *c, accumulator, worker);
-            }
-        }
-        2 => {
-            fill_constant_term::<_, _, false>(description.constant_term, accumulator, worker);
+            2 => {
+                fill_constant_term::<_, _, _, false>(
+                    description.constant_term,
+                    accumulator,
+                    worker,
+                );
 
-            for (a, other_terms) in description.quadratic_part_base_by_base.iter() {
-                for (b, c) in other_terms {
+                for (a, other_terms) in description.quadratic_part_base_by_base.iter() {
+                    for (b, c) in other_terms {
+                        let a_s = storage.make_base_source_for_round_2(*a, folding_challenges);
+                        let b_s = storage.make_base_source_for_round_2(*b, folding_challenges);
+                        evaluate_quadratic_term::<F, E, _, _, _, _, _, false, false>(
+                            &a_s,
+                            &b_s,
+                            *c,
+                            accumulator,
+                            worker,
+                        );
+                    }
+                }
+                for (a, other_terms) in description.quadratic_part_base_by_ext.iter() {
+                    for (b, c) in other_terms {
+                        let a_s = storage.make_base_source_for_round_2(*a, folding_challenges);
+                        let b_s =
+                            storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
+                        evaluate_quadratic_term::<F, E, _, _, _, _, _, false, false>(
+                            &a_s,
+                            &b_s,
+                            *c,
+                            accumulator,
+                            worker,
+                        );
+                    }
+                }
+                for (a, other_terms) in description.quadratic_part_ext_by_ext.iter() {
+                    for (b, c) in other_terms {
+                        let a_s =
+                            storage.make_ext_source_for_rounds_1_and_beyond(*a, folding_challenges);
+                        let b_s =
+                            storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
+                        evaluate_quadratic_term::<F, E, _, _, _, _, _, false, false>(
+                            &a_s,
+                            &b_s,
+                            *c,
+                            accumulator,
+                            worker,
+                        );
+                    }
+                }
+                for (a, c) in description.linear_part_base_by_everything.iter() {
                     let a_s = storage.make_base_source_for_round_2(*a, folding_challenges);
-                    let b_s = storage.make_base_source_for_round_2(*b, folding_challenges);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, false, false>(
+                    evaluate_linear_term::<F, E, _, _, _, false, false>(
                         &a_s,
-                        &b_s,
                         *c,
                         accumulator,
                         worker,
                     );
                 }
-            }
-            for (a, other_terms) in description.quadratic_part_base_by_ext.iter() {
-                for (b, c) in other_terms {
-                    let a_s = storage.make_base_source_for_round_2(*a, folding_challenges);
-                    let b_s =
-                        storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, false, false>(
-                        &a_s,
-                        &b_s,
-                        *c,
-                        accumulator,
-                        worker,
-                    );
-                }
-            }
-            for (a, other_terms) in description.quadratic_part_ext_by_ext.iter() {
-                for (b, c) in other_terms {
+                for (a, c) in description.linear_part_ext_by_everything.iter() {
                     let a_s =
                         storage.make_ext_source_for_rounds_1_and_beyond(*a, folding_challenges);
-                    let b_s =
-                        storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, false, false>(
+                    evaluate_linear_term::<F, E, _, _, _, false, false>(
                         &a_s,
-                        &b_s,
                         *c,
                         accumulator,
                         worker,
                     );
                 }
             }
-            for (a, c) in description.linear_part_base_by_everything.iter() {
-                let a_s = storage.make_base_source_for_round_2(*a, folding_challenges);
-                evaluate_linear_term::<F, E, _, _, false, false>(&a_s, *c, accumulator, worker);
-            }
-            for (a, c) in description.linear_part_ext_by_everything.iter() {
-                let a_s = storage.make_ext_source_for_rounds_1_and_beyond(*a, folding_challenges);
-                evaluate_linear_term::<F, E, _, _, false, false>(&a_s, *c, accumulator, worker);
-            }
-        }
-        i if i + 1 == total_sumcheck_rounds => {
-            assert!(i >= 3);
-            fill_constant_term::<_, _, true>(description.constant_term, accumulator, worker);
+            i if i + 1 == total_sumcheck_rounds => {
+                assert!(i >= 3);
+                fill_constant_term::<_, _, _, true>(description.constant_term, accumulator, worker);
 
-            for (a, other_terms) in description.quadratic_part_base_by_base.iter() {
-                for (b, c) in other_terms {
+                for (a, other_terms) in description.quadratic_part_base_by_base.iter() {
+                    for (b, c) in other_terms {
+                        let a_s = storage
+                            .make_base_source_for_rounds_3_and_beyond(*a, folding_challenges);
+                        let b_s = storage
+                            .make_base_source_for_rounds_3_and_beyond(*b, folding_challenges);
+                        evaluate_quadratic_term::<F, E, _, _, _, _, _, false, true>(
+                            &a_s,
+                            &b_s,
+                            *c,
+                            accumulator,
+                            worker,
+                        );
+
+                        dump_last_evals(a, a_s, last_evaluations);
+                        dump_last_evals(b, b_s, last_evaluations);
+                    }
+                }
+                for (a, other_terms) in description.quadratic_part_base_by_ext.iter() {
+                    for (b, c) in other_terms {
+                        let a_s = storage
+                            .make_base_source_for_rounds_3_and_beyond(*a, folding_challenges);
+                        let b_s =
+                            storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
+                        evaluate_quadratic_term::<F, E, _, _, _, _, _, false, true>(
+                            &a_s,
+                            &b_s,
+                            *c,
+                            accumulator,
+                            worker,
+                        );
+
+                        dump_last_evals(a, a_s, last_evaluations);
+                        dump_last_evals(b, b_s, last_evaluations);
+                    }
+                }
+                for (a, other_terms) in description.quadratic_part_ext_by_ext.iter() {
+                    for (b, c) in other_terms {
+                        let a_s =
+                            storage.make_ext_source_for_rounds_1_and_beyond(*a, folding_challenges);
+                        let b_s =
+                            storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
+                        evaluate_quadratic_term::<F, E, _, _, _, _, _, false, true>(
+                            &a_s,
+                            &b_s,
+                            *c,
+                            accumulator,
+                            worker,
+                        );
+
+                        dump_last_evals(a, a_s, last_evaluations);
+                        dump_last_evals(b, b_s, last_evaluations);
+                    }
+                }
+                for (a, c) in description.linear_part_base_by_everything.iter() {
                     let a_s =
                         storage.make_base_source_for_rounds_3_and_beyond(*a, folding_challenges);
-                    let b_s =
-                        storage.make_base_source_for_rounds_3_and_beyond(*b, folding_challenges);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, false, true>(
+                    evaluate_linear_term::<F, E, _, _, _, false, true>(
                         &a_s,
-                        &b_s,
                         *c,
                         accumulator,
                         worker,
                     );
 
                     dump_last_evals(a, a_s, last_evaluations);
-                    dump_last_evals(b, b_s, last_evaluations);
                 }
-            }
-            for (a, other_terms) in description.quadratic_part_base_by_ext.iter() {
-                for (b, c) in other_terms {
+                for (a, c) in description.linear_part_ext_by_everything.iter() {
                     let a_s =
-                        storage.make_base_source_for_rounds_3_and_beyond(*a, folding_challenges);
-                    let b_s =
-                        storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, false, true>(
+                        storage.make_ext_source_for_rounds_1_and_beyond(*a, folding_challenges);
+                    evaluate_linear_term::<F, E, _, _, _, false, true>(
                         &a_s,
-                        &b_s,
                         *c,
                         accumulator,
                         worker,
                     );
 
                     dump_last_evals(a, a_s, last_evaluations);
-                    dump_last_evals(b, b_s, last_evaluations);
                 }
             }
-            for (a, other_terms) in description.quadratic_part_ext_by_ext.iter() {
-                for (b, c) in other_terms {
-                    let a_s =
-                        storage.make_ext_source_for_rounds_1_and_beyond(*a, folding_challenges);
-                    let b_s =
-                        storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, false, true>(
-                        &a_s,
-                        &b_s,
-                        *c,
-                        accumulator,
-                        worker,
-                    );
+            3.. => {
+                fill_constant_term::<_, _, _, false>(
+                    description.constant_term,
+                    accumulator,
+                    worker,
+                );
 
-                    dump_last_evals(a, a_s, last_evaluations);
-                    dump_last_evals(b, b_s, last_evaluations);
+                for (a, other_terms) in description.quadratic_part_base_by_base.iter() {
+                    for (b, c) in other_terms {
+                        let a_s = storage
+                            .make_base_source_for_rounds_3_and_beyond(*a, folding_challenges);
+                        let b_s = storage
+                            .make_base_source_for_rounds_3_and_beyond(*b, folding_challenges);
+                        evaluate_quadratic_term::<F, E, _, _, _, _, _, false, false>(
+                            &a_s,
+                            &b_s,
+                            *c,
+                            accumulator,
+                            worker,
+                        );
+                    }
                 }
-            }
-            for (a, c) in description.linear_part_base_by_everything.iter() {
-                let a_s = storage.make_base_source_for_rounds_3_and_beyond(*a, folding_challenges);
-                evaluate_linear_term::<F, E, _, _, false, true>(&a_s, *c, accumulator, worker);
-
-                dump_last_evals(a, a_s, last_evaluations);
-            }
-            for (a, c) in description.linear_part_ext_by_everything.iter() {
-                let a_s = storage.make_ext_source_for_rounds_1_and_beyond(*a, folding_challenges);
-                evaluate_linear_term::<F, E, _, _, false, true>(&a_s, *c, accumulator, worker);
-
-                dump_last_evals(a, a_s, last_evaluations);
-            }
-        }
-        3.. => {
-            fill_constant_term::<_, _, false>(description.constant_term, accumulator, worker);
-
-            for (a, other_terms) in description.quadratic_part_base_by_base.iter() {
-                for (b, c) in other_terms {
+                for (a, other_terms) in description.quadratic_part_base_by_ext.iter() {
+                    for (b, c) in other_terms {
+                        let a_s = storage
+                            .make_base_source_for_rounds_3_and_beyond(*a, folding_challenges);
+                        let b_s =
+                            storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
+                        evaluate_quadratic_term::<F, E, _, _, _, _, _, false, false>(
+                            &a_s,
+                            &b_s,
+                            *c,
+                            accumulator,
+                            worker,
+                        );
+                    }
+                }
+                for (a, other_terms) in description.quadratic_part_ext_by_ext.iter() {
+                    for (b, c) in other_terms {
+                        let a_s =
+                            storage.make_ext_source_for_rounds_1_and_beyond(*a, folding_challenges);
+                        let b_s =
+                            storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
+                        evaluate_quadratic_term::<F, E, _, _, _, _, _, false, false>(
+                            &a_s,
+                            &b_s,
+                            *c,
+                            accumulator,
+                            worker,
+                        );
+                    }
+                }
+                for (a, c) in description.linear_part_base_by_everything.iter() {
                     let a_s =
                         storage.make_base_source_for_rounds_3_and_beyond(*a, folding_challenges);
-                    let b_s =
-                        storage.make_base_source_for_rounds_3_and_beyond(*b, folding_challenges);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, false, false>(
+                    evaluate_linear_term::<F, E, _, _, _, false, false>(
                         &a_s,
-                        &b_s,
                         *c,
                         accumulator,
                         worker,
                     );
                 }
-            }
-            for (a, other_terms) in description.quadratic_part_base_by_ext.iter() {
-                for (b, c) in other_terms {
-                    let a_s =
-                        storage.make_base_source_for_rounds_3_and_beyond(*a, folding_challenges);
-                    let b_s =
-                        storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, false, false>(
-                        &a_s,
-                        &b_s,
-                        *c,
-                        accumulator,
-                        worker,
-                    );
-                }
-            }
-            for (a, other_terms) in description.quadratic_part_ext_by_ext.iter() {
-                for (b, c) in other_terms {
+                for (a, c) in description.linear_part_ext_by_everything.iter() {
                     let a_s =
                         storage.make_ext_source_for_rounds_1_and_beyond(*a, folding_challenges);
-                    let b_s =
-                        storage.make_ext_source_for_rounds_1_and_beyond(*b, folding_challenges);
-                    evaluate_quadratic_term::<F, E, _, _, _, _, false, false>(
+                    evaluate_linear_term::<F, E, _, _, _, false, false>(
                         &a_s,
-                        &b_s,
                         *c,
                         accumulator,
                         worker,
                     );
                 }
-            }
-            for (a, c) in description.linear_part_base_by_everything.iter() {
-                let a_s = storage.make_base_source_for_rounds_3_and_beyond(*a, folding_challenges);
-                evaluate_linear_term::<F, E, _, _, false, false>(&a_s, *c, accumulator, worker);
-            }
-            for (a, c) in description.linear_part_ext_by_everything.iter() {
-                let a_s = storage.make_ext_source_for_rounds_1_and_beyond(*a, folding_challenges);
-                evaluate_linear_term::<F, E, _, _, false, false>(&a_s, *c, accumulator, worker);
             }
         }
     }
@@ -509,13 +592,14 @@ fn evaluate_quadratic_term<
     RB: EvaluationRepresentation<F, E>,
     SA: EvaluationFormStorage<F, E, RA>,
     SB: EvaluationFormStorage<F, E, RB>,
+    A: UnreducedAccumulator<F, E>,
     const FIRST_ROUND: bool,
     const EXPLICIT_FORM: bool,
 >(
     a_s: &SA,
     b_s: &SB,
     c: E,
-    accumulator: &mut [[E; 2]],
+    accumulator: &mut [[A; 2]],
     worker: &Worker,
 ) {
     use crate::gkr::prover::apply_row_wise;
@@ -541,7 +625,7 @@ fn evaluate_quadratic_term<
                     let eval_1 = a1.mul_by_ext::<true>(&c, a_ctx);
                     let eval_1 = b1.mul_by_ext::<true>(&eval_1, b_ctx);
 
-                    accumulator[index][1].add_assign(&eval_1);
+                    accumulator[index][1].add_assign_ext(eval_1);
                 } else {
                     let [a0, a1] = a_s.get_two_points::<EXPLICIT_FORM>(absolute_index);
                     let [b0, b1] = b_s.get_two_points::<EXPLICIT_FORM>(absolute_index);
@@ -551,9 +635,83 @@ fn evaluate_quadratic_term<
                     let eval_1 = a1.mul_by_ext::<true>(&c, a_ctx);
                     let eval_1 = b1.mul_by_ext::<true>(&eval_1, b_ctx);
 
-                    accumulator[index][0].add_assign(&eval_0);
-                    accumulator[index][1].add_assign(&eval_1);
+                    accumulator[index][0].add_assign_ext(eval_0);
+                    accumulator[index][1].add_assign_ext(eval_1);
                 }
+            }
+        },
+    );
+}
+
+fn evaluate_quadratic_term_first_round_base_by_base<F: PrimeField, E: FieldExtension<F> + Field>(
+    a_s: &BaseFieldPolySource<F>,
+    b_s: &BaseFieldPolySource<F>,
+    c: E,
+    accumulator: &mut [[<E as FieldExtension<F>>::Unreduced; 2]],
+    worker: &Worker,
+) {
+    use crate::gkr::prover::apply_row_wise;
+    let work_size = accumulator.len();
+    apply_row_wise::<F, _>(
+        vec![],
+        vec![accumulator],
+        work_size,
+        worker,
+        |_, mut ext_dest, chunk_start, chunk_size| {
+            assert_eq!(ext_dest.len(), 1);
+            let accumulator = ext_dest.pop().unwrap();
+            for index in 0..chunk_size {
+                let absolute_index = chunk_start + index;
+                let a1 = <BaseFieldPolySource<F> as EvaluationFormStorage<
+                    F,
+                    E,
+                    BaseFieldRepresentation<F>,
+                >>::get_f1_minus_f0_only(a_s, absolute_index);
+                let b1 = <BaseFieldPolySource<F> as EvaluationFormStorage<
+                    F,
+                    E,
+                    BaseFieldRepresentation<F>,
+                >>::get_f1_minus_f0_only(b_s, absolute_index);
+                let mut s = a1.0;
+                s.mul_assign(&b1.0);
+                accumulator[index][1].add_assign_base_times_ext(s, c);
+            }
+        },
+    );
+}
+
+fn evaluate_quadratic_term_first_round_base_by_ext<F: PrimeField, E: FieldExtension<F> + Field>(
+    a_s: &BaseFieldPolySource<F>,
+    b_s: &ExtensionFieldPolyInitialSource<F, E>,
+    c: E,
+    accumulator: &mut [[<E as FieldExtension<F>>::Unreduced; 2]],
+    worker: &Worker,
+) {
+    use crate::gkr::prover::apply_row_wise;
+    let work_size = accumulator.len();
+    apply_row_wise::<F, _>(
+        vec![],
+        vec![accumulator],
+        work_size,
+        worker,
+        |_, mut ext_dest, chunk_start, chunk_size| {
+            assert_eq!(ext_dest.len(), 1);
+            let accumulator = ext_dest.pop().unwrap();
+            for index in 0..chunk_size {
+                let absolute_index = chunk_start + index;
+                let a1 = <BaseFieldPolySource<F> as EvaluationFormStorage<
+                    F,
+                    E,
+                    BaseFieldRepresentation<F>,
+                >>::get_f1_minus_f0_only(a_s, absolute_index);
+                let b1 = <ExtensionFieldPolyInitialSource<F, E> as EvaluationFormStorage<
+                    F,
+                    E,
+                    ExtensionFieldRepresentation<F, E>,
+                >>::get_f1_minus_f0_only(b_s, absolute_index);
+                let mut bc = b1.value;
+                bc.mul_assign(&c);
+                accumulator[index][1].add_assign_base_times_ext(a1.0, bc);
             }
         },
     );
@@ -564,12 +722,13 @@ fn evaluate_linear_term<
     E: FieldExtension<F> + Field,
     RA: EvaluationRepresentation<F, E>,
     SA: EvaluationFormStorage<F, E, RA>,
+    A: UnreducedAccumulator<F, E>,
     const FIRST_ROUND: bool,
     const EXPLICIT_FORM: bool,
 >(
     a_s: &SA,
     c: E,
-    accumulator: &mut [[E; 2]],
+    accumulator: &mut [[A; 2]],
     worker: &Worker,
 ) {
     if FIRST_ROUND {
@@ -602,15 +761,15 @@ fn evaluate_linear_term<
 
                         let eval_1 = a1.mul_by_ext::<true>(&c, a_ctx);
 
-                        accumulator[index][0].add_assign(&eval_0);
-                        accumulator[index][1].add_assign(&eval_1);
+                        accumulator[index][0].add_assign_ext(eval_0);
+                        accumulator[index][1].add_assign_ext(eval_1);
                     } else {
                         // only half
                         let a0 = a_s.get_f0_only(absolute_index);
 
                         let eval_0 = a0.mul_by_ext::<true>(&c, a_ctx);
 
-                        accumulator[index][0].add_assign(&eval_0);
+                        accumulator[index][0].add_assign_ext(eval_0);
                     }
                 }
             }
@@ -623,10 +782,11 @@ fn add_output_term<
     E: FieldExtension<F> + Field,
     RA: EvaluationRepresentation<F, E>,
     SA: EvaluationFormStorage<F, E, RA>,
+    A: UnreducedAccumulator<F, E>,
 >(
     a_s: &SA,
     c: E,
-    accumulator: &mut [[E; 2]],
+    accumulator: &mut [[A; 2]],
     worker: &Worker,
 ) {
     use crate::gkr::prover::apply_row_wise;
@@ -648,18 +808,25 @@ fn add_output_term<
 
                 let eval_0 = a0.mul_by_ext::<true>(&c, a_ctx);
 
-                accumulator[index][0].add_assign(&eval_0);
+                accumulator[index][0].add_assign_ext(eval_0);
             }
         },
     );
 }
 
-fn fill_constant_term<F: PrimeField, E: FieldExtension<F> + Field, const EXPLICIT_FORM: bool>(
+fn fill_constant_term<
+    F: PrimeField,
+    E: FieldExtension<F> + Field,
+    A: UnreducedAccumulator<F, E>,
+    const EXPLICIT_FORM: bool,
+>(
     c: E,
-    accumulator: &mut [[E; 2]],
+    accumulator: &mut [[A; 2]],
     worker: &Worker,
 ) {
     use crate::gkr::prover::apply_row_wise;
+    let mut unreduced_c = A::ZERO;
+    unreduced_c.add_assign_ext(c);
     let work_size = accumulator.len();
     apply_row_wise::<F, _>(
         vec![],
@@ -670,9 +837,9 @@ fn fill_constant_term<F: PrimeField, E: FieldExtension<F> + Field, const EXPLICI
             assert_eq!(ext_dest.len(), 1);
             let accumulator = ext_dest.pop().unwrap();
             for index in 0..chunk_size {
-                accumulator[index][0] = c;
+                accumulator[index][0] = unreduced_c;
                 if EXPLICIT_FORM {
-                    accumulator[index][1] = c;
+                    accumulator[index][1] = unreduced_c;
                 }
             }
         },

--- a/prover/src/gkr/prover/sumcheck_loop/mod.rs
+++ b/prover/src/gkr/prover/sumcheck_loop/mod.rs
@@ -467,9 +467,6 @@ where
     for step in 0..folding_steps - 1 {
         let acc_size = 1 << (folding_steps - step - 1);
         let accumulator = &mut accumulator_buffer[..acc_size];
-        if step > 0 {
-            accumulator.fill([E::ZERO; 2]);
-        }
 
         if USE_BATCHING {
             use crate::gkr::prover::sumcheck_loop::batch_evaluation::evaluate_batched_gkr_description;
@@ -545,7 +542,6 @@ where
     {
         let step = folding_steps - 1;
         let accumulator = &mut accumulator_buffer[..1];
-        accumulator.fill([E::ZERO; 2]);
 
         if USE_BATCHING {
             use crate::gkr::prover::sumcheck_loop::batch_evaluation::evaluate_batched_gkr_description;

--- a/prover/src/gkr/sumcheck/tests/batched.rs
+++ b/prover/src/gkr/sumcheck/tests/batched.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
 
 use cs::definitions::GKRAddress;
-use field::{Field, FieldExtension, Mersenne31Field, Mersenne31Quartic, PrimeField};
+use field::baby_bear::{base::BabyBearField, ext4::BabyBearExt4};
+use field::{Field, FieldExtension, PrimeField};
 use worker::Worker;
 
 use super::utils::*;
@@ -15,8 +16,8 @@ use crate::gkr::sumcheck::{
     output_univariate_monomial_form_max_quadratic,
 };
 
-type F = Mersenne31Field;
-type E = Mersenne31Quartic;
+type F = BabyBearField;
+type E = BabyBearExt4;
 
 #[test]
 fn test_batched_kernels() {

--- a/prover/src/gkr/sumcheck/tests/boolean_constraint.rs
+++ b/prover/src/gkr/sumcheck/tests/boolean_constraint.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use cs::definitions::GKRAddress;
 use cs::gkr_compiler::NoFieldMaxQuadraticConstraintsGKRRelation;
-use field::{Field, FieldExtension, Mersenne31Field, Mersenne31Quartic};
+use field::baby_bear::{base::BabyBearField, ext4::BabyBearExt4};
+use field::{Field, FieldExtension};
 use worker::Worker;
 
 use crate::gkr::sumcheck::access_and_fold::BaseFieldPoly;
@@ -17,8 +18,8 @@ use super::*;
 
 #[test]
 fn test_boolean_constraints() {
-    type F = Mersenne31Field;
-    type E = Mersenne31Quartic;
+    type F = BabyBearField;
+    type E = BabyBearExt4;
 
     const FOLDING_STEPS: usize = 5;
     const POLY_SIZE: usize = 1 << FOLDING_STEPS;
@@ -51,15 +52,15 @@ fn test_boolean_constraints() {
                 GKRAddress::BaseLayerMemory(0),
                 GKRAddress::BaseLayerMemory(0),
             ),
-            vec![(F::ONE.to_reduced_u32(), 0)].into_boxed_slice(),
+            vec![(F::ONE.as_u32_reduced(), 0)].into_boxed_slice(),
         )]
         .into_boxed_slice(),
         linear_terms: vec![(
             GKRAddress::BaseLayerMemory(0),
-            vec![(F::MINUS_ONE.to_reduced_u32(), 0)].into_boxed_slice(),
+            vec![(F::MINUS_ONE.as_u32_reduced(), 0)].into_boxed_slice(),
         )]
         .into_boxed_slice(),
-        constants: vec![(F::ZERO.to_reduced_u32(), 0)].into_boxed_slice(),
+        constants: vec![(F::ZERO.as_u32_reduced(), 0)].into_boxed_slice(),
     };
 
     let kernel = BatchConstraintEvalGKRRelation::new(&constraint, E::ONE);

--- a/prover/src/gkr/sumcheck/tests/fixed_kernels.rs
+++ b/prover/src/gkr/sumcheck/tests/fixed_kernels.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
 
 use cs::definitions::GKRAddress;
-use field::{Field, FieldExtension, Mersenne31Field, Mersenne31Quartic, PrimeField};
+use field::baby_bear::{base::BabyBearField, ext4::BabyBearExt4};
+use field::{Field, FieldExtension, PrimeField};
 use worker::Worker;
 
 use crate::gkr::sumcheck::{
@@ -16,8 +17,8 @@ use crate::gkr::sumcheck::{
 
 use super::utils::*;
 
-type F = Mersenne31Field;
-type E = Mersenne31Quartic;
+type F = BabyBearField;
+type E = BabyBearExt4;
 
 #[test]
 fn test_same_size_product_basic() {

--- a/prover/src/gkr/sumcheck/tests/logup_variants.rs
+++ b/prover/src/gkr/sumcheck/tests/logup_variants.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
 
 use cs::definitions::GKRAddress;
-use field::{Field, FieldExtension, Mersenne31Field, Mersenne31Quartic};
+use field::baby_bear::{base::BabyBearField, ext4::BabyBearExt4};
+use field::{Field, FieldExtension};
 use worker::Worker;
 
 use crate::gkr::sumcheck::access_and_fold::BaseFieldPoly;
@@ -15,8 +16,8 @@ use super::*;
 
 #[test]
 fn test_base_minus_multiplicity_by_base() {
-    type F = Mersenne31Field;
-    type E = Mersenne31Quartic;
+    type F = BabyBearField;
+    type E = BabyBearExt4;
 
     const FOLDING_STEPS: usize = 4;
     const POLY_SIZE: usize = 1 << FOLDING_STEPS;

--- a/prover/src/gkr/sumcheck/tests/quadratic_constraint_with_constant.rs
+++ b/prover/src/gkr/sumcheck/tests/quadratic_constraint_with_constant.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use cs::definitions::GKRAddress;
 use cs::gkr_compiler::NoFieldMaxQuadraticConstraintsGKRRelation;
-use field::{Field, FieldExtension, Mersenne31Field, Mersenne31Quartic};
+use field::baby_bear::{base::BabyBearField, ext4::BabyBearExt4};
+use field::{Field, FieldExtension};
 use worker::Worker;
 
 use crate::gkr::sumcheck::access_and_fold::BaseFieldPoly;
@@ -17,8 +18,8 @@ use super::*;
 
 #[test]
 fn test_quadratic_constraint_with_constant() {
-    type F = Mersenne31Field;
-    type E = Mersenne31Quartic;
+    type F = BabyBearField;
+    type E = BabyBearExt4;
 
     const FOLDING_STEPS: usize = 5;
     const POLY_SIZE: usize = 1 << FOLDING_STEPS;
@@ -57,29 +58,29 @@ fn test_quadratic_constraint_with_constant() {
                     GKRAddress::BaseLayerMemory(0),
                     GKRAddress::BaseLayerMemory(0),
                 ),
-                vec![(F::ONE.to_reduced_u32(), 0)].into_boxed_slice(),
+                vec![(F::ONE.as_u32_reduced(), 0)].into_boxed_slice(),
             ),
             (
                 (
                     GKRAddress::BaseLayerMemory(0),
                     GKRAddress::BaseLayerMemory(1),
                 ),
-                vec![(F::ONE.to_reduced_u32(), 1)].into_boxed_slice(),
+                vec![(F::ONE.as_u32_reduced(), 1)].into_boxed_slice(),
             ),
         ]
         .into_boxed_slice(),
         linear_terms: vec![
             (
                 GKRAddress::BaseLayerMemory(0),
-                vec![(F::ONE.to_reduced_u32(), 0)].into_boxed_slice(),
+                vec![(F::ONE.as_u32_reduced(), 0)].into_boxed_slice(),
             ),
             (
                 GKRAddress::BaseLayerMemory(1),
-                vec![(F::MINUS_ONE.to_reduced_u32(), 1)].into_boxed_slice(),
+                vec![(F::MINUS_ONE.as_u32_reduced(), 1)].into_boxed_slice(),
             ),
         ]
         .into_boxed_slice(),
-        constants: vec![(minus_6.to_reduced_u32(), 0), (minus_4.to_reduced_u32(), 1)]
+        constants: vec![(minus_6.as_u32_reduced(), 0), (minus_4.as_u32_reduced(), 1)]
             .into_boxed_slice(),
     };
 

--- a/prover/src/gkr/sumcheck/tests/quadratic_constraint_with_diverse_witness.rs
+++ b/prover/src/gkr/sumcheck/tests/quadratic_constraint_with_diverse_witness.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use cs::definitions::GKRAddress;
 use cs::gkr_compiler::NoFieldMaxQuadraticConstraintsGKRRelation;
-use field::{Field, FieldExtension, Mersenne31Field, Mersenne31Quartic, Rand};
+use field::baby_bear::{base::BabyBearField, ext4::BabyBearExt4};
+use field::{Field, FieldExtension, Rand};
 use rand::SeedableRng;
 use worker::Worker;
 
@@ -18,8 +19,8 @@ use super::*;
 
 #[test]
 fn test_quadratic_constraint_with_constant() {
-    type F = Mersenne31Field;
-    type E = Mersenne31Quartic;
+    type F = BabyBearField;
+    type E = BabyBearExt4;
 
     use rand::Rng;
     let mut seed = [0u8; 32];
@@ -71,36 +72,36 @@ fn test_quadratic_constraint_with_constant() {
                     GKRAddress::BaseLayerMemory(0),
                     GKRAddress::BaseLayerMemory(0),
                 ),
-                vec![(F::ONE.to_reduced_u32(), 0)].into_boxed_slice(),
+                vec![(F::ONE.as_u32_reduced(), 0)].into_boxed_slice(),
             ),
             (
                 (
                     GKRAddress::BaseLayerMemory(0),
                     GKRAddress::BaseLayerMemory(1),
                 ),
-                vec![(minus_two.to_reduced_u32(), 0)].into_boxed_slice(),
+                vec![(minus_two.as_u32_reduced(), 0)].into_boxed_slice(),
             ),
             (
                 (
                     GKRAddress::BaseLayerMemory(1),
                     GKRAddress::BaseLayerMemory(1),
                 ),
-                vec![(F::ONE.to_reduced_u32(), 0)].into_boxed_slice(),
+                vec![(F::ONE.as_u32_reduced(), 0)].into_boxed_slice(),
             ),
         ]
         .into_boxed_slice(),
         linear_terms: vec![
             (
                 GKRAddress::BaseLayerMemory(0),
-                vec![(F::ONE.to_reduced_u32(), 0)].into_boxed_slice(),
+                vec![(F::ONE.as_u32_reduced(), 0)].into_boxed_slice(),
             ),
             (
                 GKRAddress::BaseLayerMemory(1),
-                vec![(F::MINUS_ONE.to_reduced_u32(), 0)].into_boxed_slice(),
+                vec![(F::MINUS_ONE.as_u32_reduced(), 0)].into_boxed_slice(),
             ),
         ]
         .into_boxed_slice(),
-        constants: vec![(F::ZERO.to_reduced_u32(), 0)].into_boxed_slice(),
+        constants: vec![(F::ZERO.as_u32_reduced(), 0)].into_boxed_slice(),
     };
 
     let kernel = BatchConstraintEvalGKRRelation::new(&constraint, E::random_element(&mut rng));

--- a/prover/src/gkr/sumcheck/tests/simple_product.rs
+++ b/prover/src/gkr/sumcheck/tests/simple_product.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use cs::definitions::GKRAddress;
-use field::{Field, FieldExtension, Mersenne31Field, Mersenne31Quartic};
+use field::baby_bear::{base::BabyBearField, ext4::BabyBearExt4};
+use field::{Field, FieldExtension};
 use worker::Worker;
 
 use crate::gkr::sumcheck::eq_poly::*;
@@ -34,8 +35,8 @@ use super::*;
 
 #[test]
 fn test_simple_product() {
-    type F = Mersenne31Field;
-    type E = Mersenne31Quartic;
+    type F = BabyBearField;
+    type E = BabyBearExt4;
 
     const FOLDING_STEPS: usize = 4;
     const POLY_SIZE: usize = 1 << FOLDING_STEPS;

--- a/prover/src/gkr/sumcheck/tests/sumcheck_loop.rs
+++ b/prover/src/gkr/sumcheck/tests/sumcheck_loop.rs
@@ -3,7 +3,8 @@ use std::mem::MaybeUninit;
 
 use cs::definitions::GKRAddress;
 use cs::gkr_compiler::{GKRLayerDescription, GateArtifacts, NoFieldGKRRelation};
-use field::{Field, FieldExtension, Mersenne31Field, Mersenne31Quartic, PrimeField};
+use field::baby_bear::{base::BabyBearField, ext4::BabyBearExt4};
+use field::{Field, FieldExtension, PrimeField};
 use transcript::Seed;
 use worker::Worker;
 
@@ -12,8 +13,8 @@ use crate::gkr::prover::sumcheck_loop::evaluate_sumcheck_for_layer;
 use crate::gkr::prover::GKRExternalChallenges;
 use crate::gkr::sumcheck::eq_poly::*;
 
-type F = Mersenne31Field;
-type E = Mersenne31Quartic;
+type F = BabyBearField;
+type E = BabyBearExt4;
 
 /// Test the full sumcheck loop with a simple product gate.
 #[test]


### PR DESCRIPTION
## What ❔
Proof of concept for unreduced accumulation in prover. Applied to step 0 of batched sumcheck and resulted in a ~2.1s reduction in prover time for add sub (without self-checks). Benches show 3x improvement compared to Montgomery reduction at every op. 

To integrate this to later steps we need to implement the split eq and small value optimisations from https://eprint.iacr.org/2026/587.pdf

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.