### PR TITLE
fix(gpu_prover): drop replayer tracer before completion signal

### DIFF
--- a/gpu_prover/src/execution/cpu_worker.rs
+++ b/gpu_prover/src/execution/cpu_worker.rs
@@ -216,6 +216,7 @@ pub(crate) fn run_replayer<T: TracingType>(
             &mut tracer,
         );
         let elapsed = instant.elapsed();
+        drop(tracer);
         free_trace_chunks.send(trace).unwrap();
         assert_eq!(state.pc, final_state.pc);
         assert_eq!(state.timestamp, final_state.timestamp);


### PR DESCRIPTION
## What ❔

Drop the CPU replayer tracer before returning the trace chunk and before sending `SnapshotReplayed`.

## Why ❔

`SnapshotReplayed` is consumed by the prover as the signal that tracing data for the snapshot can be unblocked and, in cached paths, potentially freed. The tracer owns `trace_ranges`, whose `PtrRange` values hold `Arc` clones into the tracing data chunks. If the worker sends `SnapshotReplayed` while the tracer is still in scope, the main prover thread can race ahead to `free_tracing_data` and hit `Arc::into_inner(...).unwrap()` while those clones are still alive.

Dropping the tracer first makes the completion signal accurately reflect that no replayer-owned references into the tracing data remain.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.
