### PR TITLE
feat(gpu_prover): WHIR optimization part 2: Batched base layer handling

### DIFF
--- a/gpu_prover/native/prover/whir/columns.cu
+++ b/gpu_prover/native/prover/whir/columns.cu
@@ -33,19 +33,37 @@ EXTERN __global__ void ab_deserialize_whir_e4_columns_kernel(const bf *src, e4 *
   store<e4, st_modifier::cs>(dst, e4(coeffs), gid);
 }
 
-EXTERN __global__ void ab_accumulate_whir_base_columns_e4_kernel(const bf *values, const unsigned stride, const e4 *weights, const unsigned cols, e4 *result,
-                                                                 const unsigned rows) {
+constexpr unsigned TRACE_CHUNKS = 3;
+
+struct BaseColumnsBatchingMetadata {
+  const bf *values[TRACE_CHUNKS];
+  const e4 *weights[TRACE_CHUNKS];
+  const unsigned cols[TRACE_CHUNKS];
+  const unsigned strides[TRACE_CHUNKS];
+  e4 *result;
+  const unsigned rows;
+};
+
+EXTERN __global__ void ab_accumulate_whir_base_columns_e4_kernel(const BaseColumnsBatchingMetadata metadata) {
+  const unsigned rows = metadata.rows;
   const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
   if (gid >= rows)
     return;
 
-  e4 acc = load<e4, ld_modifier::cs>(result, gid);
-  for (unsigned col = 0; col < cols; ++col) {
-    const bf value = load<bf, ld_modifier::cs>(values, col * stride + gid);
-    const e4 weight = load<e4, ld_modifier::cs>(weights, col);
-    acc = e4::fma(weight, value, acc);
+  e4 acc{e4::ZERO()};
+  for (unsigned i = 0; i < TRACE_CHUNKS; i++) {
+    const bf *values = metadata.values[i];
+    const e4 *weights = metadata.weights[i];
+    const unsigned cols = metadata.cols[i];
+    const unsigned stride = metadata.strides[i];
+    for (unsigned col = 0; col < cols; ++col) {
+      const bf value = load<bf, ld_modifier::cs>(values, col * stride + gid);
+      const e4 weight = load<e4, ld_modifier::cs>(weights, col);
+      acc = e4::fma(weight, value, acc);
+    }
   }
-  store<e4, st_modifier::cs>(result, acc, gid);
+
+  store<e4, st_modifier::cs>(metadata.result, acc, gid);
 }
 
 } // namespace airbender::prover::whir

--- a/gpu_prover/src/ntt/hypercube.rs
+++ b/gpu_prover/src/ntt/hypercube.rs
@@ -275,7 +275,7 @@ pub(crate) fn hypercube_evals_to_monomials_2_pass(
 }
 
 #[allow(unused)]
-pub fn hypercube_X1_MSB_evals_to_X1_MSB_monomials(
+pub fn hypercube_x1_msb_evals_to_x1_msb_monomials(
     inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
     outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
     log_n: usize,

--- a/gpu_prover/src/ntt/mod.rs
+++ b/gpu_prover/src/ntt/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use ntt::{
 };
 
 mod hypercube;
-pub use hypercube::hypercube_X1_MSB_evals_to_X1_MSB_monomials;
+pub use hypercube::hypercube_x1_msb_evals_to_x1_msb_monomials;
 #[cfg(test)]
 pub(crate) use hypercube::{
     hypercube_evals_to_monomials_2_pass, hypercube_evals_to_monomials_3_pass,

--- a/gpu_prover/src/ntt/mod.rs
+++ b/gpu_prover/src/ntt/mod.rs
@@ -228,6 +228,7 @@ pub(crate) fn hypercube_coeffs_to_evals_impl(
     Ok(())
 }
 
+#[allow(unused)]
 pub(crate) fn hypercube_coeffs_natural_to_natural_evals(
     src: &DeviceSlice<BF>,
     dst: &mut DeviceSlice<BF>,
@@ -237,6 +238,7 @@ pub(crate) fn hypercube_coeffs_natural_to_natural_evals(
     hypercube_coeffs_to_evals_impl(src, dst, log_n, false, stream)
 }
 
+#[allow(unused)]
 pub(crate) fn hypercube_coeffs_bitrev_to_bitrev_evals(
     src: &DeviceSlice<BF>,
     dst: &mut DeviceSlice<BF>,

--- a/gpu_prover/src/prover/proof.rs
+++ b/gpu_prover/src/prover/proof.rs
@@ -701,7 +701,7 @@ pub(crate) fn prove<'a, A: GoodAllocator + 'a>(
     // matches the structurally-derived layout we already used to size the slab.
     // The structural derivation must match every dim-reducing layer's IO map
     // and every main-layer's input address set; if it diverges, the slab is
-    // mis-sized and writes overflow.
+    // improperly sized and writes overflow.
     #[cfg(debug_assertions)]
     {
         let main_layer_input_addresses_per_layer_storage_aware =

--- a/gpu_prover/src/prover/proof.rs
+++ b/gpu_prover/src/prover/proof.rs
@@ -983,6 +983,7 @@ pub(crate) fn prove<'a, A: GoodAllocator + 'a>(
             },
             whir_schedule.cap_size,
             compiled_circuit.trace_len.trailing_zeros() as usize,
+            true, // use_hypercube_evals_for_batching
             proof_slab.as_ref(),
             &proof_layout,
             Some(base_layer_claims_scheduled.take_pending_aggregation()),

--- a/gpu_prover/src/prover/tests.rs
+++ b/gpu_prover/src/prover/tests.rs
@@ -44,7 +44,7 @@ use crate::prover::tracing_data::{
 use crate::prover::whir::GpuWhirExtensionOracle;
 use crate::prover::whir_fold::{
     clone_scheduled_whir_pre_pow_seeds, debug_apply_initial_fold_challenge_for_test,
-    debug_build_initial_batched_main_domain_poly_for_test, debug_build_initial_fold_state_for_test,
+    debug_build_initial_batched_evals_for_test, debug_build_initial_fold_state_for_test,
     debug_build_initial_state_for_test, debug_build_initial_state_snapshots_for_test,
     debug_initial_round_checkpoint_for_test, schedule_gpu_whir_fold_with_sources,
     take_scheduled_whir_proof,
@@ -1350,18 +1350,26 @@ fn assert_recursive_whir_oracle_parity_for_supported_path(
         }
     }
 
-    let gpu_batched_poly_on_main_domain = debug_build_initial_batched_main_domain_poly_for_test(
-        gpu_mem_trace_holder,
-        mem_polys_claims,
-        gpu_wit_trace_holder,
-        wit_polys_claims,
-        gpu_setup_trace_holder,
-        setup_polys_claims,
-        batching_challenge,
-        context,
-    )
-    .unwrap();
-    assert_eq!(gpu_batched_poly_on_main_domain, batched_poly_on_main_domain);
+    let use_hypercube_evals_for_batching = true;
+    // CPU initially creates batched evals from coset 0 evaluations rather than
+    // hypercube evaluations, so we only compare if the GPU also does the former.
+    // (Later on, we'll compare the monomial forms unconditionally,
+    // because they should always match.)
+    if !use_hypercube_evals_for_batching {
+        let gpu_batched_poly_on_main_domain = debug_build_initial_batched_evals_for_test(
+            gpu_mem_trace_holder,
+            mem_polys_claims,
+            gpu_wit_trace_holder,
+            wit_polys_claims,
+            gpu_setup_trace_holder,
+            setup_polys_claims,
+            batching_challenge,
+            use_hypercube_evals_for_batching,
+            context,
+        )
+        .unwrap();
+        assert_eq!(gpu_batched_poly_on_main_domain, batched_poly_on_main_domain);
+    }
     let mut sumchecked_poly_monomial_form =
         compute_column_major_monomial_form_from_main_domain_owned_for_test(
             batched_poly_on_main_domain,
@@ -1401,6 +1409,7 @@ fn assert_recursive_whir_oracle_parity_for_supported_path(
             setup_polys_claims,
             original_evaluation_point,
             batching_challenge,
+            use_hypercube_evals_for_batching,
             context,
         )
         .unwrap();
@@ -1416,6 +1425,7 @@ fn assert_recursive_whir_oracle_parity_for_supported_path(
             setup_polys_claims,
             original_evaluation_point,
             batching_challenge,
+            use_hypercube_evals_for_batching,
             context,
         )
         .unwrap();
@@ -1459,6 +1469,7 @@ fn assert_recursive_whir_oracle_parity_for_supported_path(
         setup_polys_claims,
         original_evaluation_point,
         batching_challenge,
+        use_hypercube_evals_for_batching,
         context,
     )
     .unwrap();
@@ -1542,6 +1553,7 @@ fn assert_recursive_whir_oracle_parity_for_supported_path(
         first_lde_factor,
         next_folding_steps,
         whir_schedule.cap_size,
+        use_hypercube_evals_for_batching,
         transcript_seed_before_initial_rounds,
         context,
     )
@@ -1949,6 +1961,7 @@ fn assert_recursive_whir_oracle_parity_for_supported_path(
         move || scheduled_transcript_seed,
         whir_schedule.cap_size,
         trace_len_log2,
+        true, // use_hypercube_evals_for_batching
         None,
         &whir_proof_layout,
         None,

--- a/gpu_prover/src/prover/trace_holder.rs
+++ b/gpu_prover/src/prover/trace_holder.rs
@@ -7,7 +7,7 @@ use prover::merkle_trees::MerkleTreeCapVarLength;
 
 use crate::allocator::tracker::AllocationPlacement;
 use crate::ntt::{
-    bitreversed_monomials_to_natural_evals, hypercube_X1_MSB_evals_to_X1_MSB_monomials,
+    bitreversed_monomials_to_natural_evals, hypercube_x1_msb_evals_to_x1_msb_monomials,
     log_size_supports_transposed_monomials,
 };
 use crate::ops::blake2s::{
@@ -311,7 +311,7 @@ impl TraceHolder<BF> {
         for column in 0..self.columns_count {
             let offset = column * domain_size;
             let source_column = &source[offset..offset + domain_size];
-            hypercube_X1_MSB_evals_to_X1_MSB_monomials(
+            hypercube_x1_msb_evals_to_x1_msb_monomials(
                 source_column,
                 &mut coeff_scratch[0..domain_size],
                 self.log_domain_size as usize,

--- a/gpu_prover/src/prover/whir_fold.rs
+++ b/gpu_prover/src/prover/whir_fold.rs
@@ -25,7 +25,7 @@ use worker::Worker;
 
 use crate::allocator::tracker::AllocationPlacement;
 use crate::ntt::{
-    hypercube_x1_msb_evals_to_x1_msb_monomials, hypercube_coeffs_bitrev_to_bitrev_evals,
+    hypercube_coeffs_bitrev_to_bitrev_evals, hypercube_x1_msb_evals_to_x1_msb_monomials,
     natural_evals_to_bitreversed_monomials,
 };
 use crate::ops::blake2s::{Digest, STATE_SIZE};
@@ -1487,8 +1487,7 @@ fn schedule_initialize_batched_forms(
         get_base_columns(memory_trace_holder, rows, use_hypercube_evals_for_batching);
     let witness_values =
         get_base_columns(witness_trace_holder, rows, use_hypercube_evals_for_batching);
-    let setup_values =
-        get_base_columns(setup_trace_holder, rows, use_hypercube_evals_for_batching);
+    let setup_values = get_base_columns(setup_trace_holder, rows, use_hypercube_evals_for_batching);
 
     accumulate_whir_base_columns(
         &memory_values,

--- a/gpu_prover/src/prover/whir_fold.rs
+++ b/gpu_prover/src/prover/whir_fold.rs
@@ -1279,7 +1279,7 @@ fn initialize_batched_monomial_form(
             context.get_device_properties(),
         )?;
         // If we're in this branch, it means state.sumchecked_poly_evaluation_form was
-        // directly created by batching base hypercube evaluation colums, so we're done.
+        // directly created by batching base hypercube evaluation columns, so we're done.
     } else {
         natural_evals_to_bitreversed_monomials(
             &vectorized_batched_evals_matrix,

--- a/gpu_prover/src/prover/whir_fold.rs
+++ b/gpu_prover/src/prover/whir_fold.rs
@@ -24,12 +24,15 @@ use prover::utils::extension_field_from_base_coeffs;
 use worker::Worker;
 
 use crate::allocator::tracker::AllocationPlacement;
-use crate::ntt::{hypercube_coeffs_bitrev_to_bitrev_evals, natural_evals_to_bitreversed_monomials};
+use crate::ntt::{
+    hypercube_x1_msb_evals_to_x1_msb_monomials, hypercube_coeffs_bitrev_to_bitrev_evals,
+    natural_evals_to_bitreversed_monomials,
+};
 use crate::ops::blake2s::{Digest, STATE_SIZE};
 use crate::ops::cub::device_reduce::{get_reduce_temp_storage_bytes, reduce, ReduceOperation};
 use crate::ops::cub::CUB_TEMP_STORAGE_EXTRA_ALIGNMENT_LOG2;
 use crate::ops::powers::get_powers_by_val;
-use crate::ops::simple::{add, add_into_y, mul, mul_into_x, set_to_zero};
+use crate::ops::simple::{add, add_into_y, mul, mul_into_x};
 use crate::ops::transpose::transpose;
 use crate::primitives::callbacks::Callbacks;
 use crate::primitives::context::{
@@ -1124,88 +1127,184 @@ fn fold_coset(
     }
 }
 
-fn build_initial_batched_main_domain_poly_device_impl(
+fn get_base_columns<'a>(
+    trace_holder: &'a TraceHolder<BF>,
+    rows: usize,
+    use_hypercube_evals: bool,
+) -> DeviceMatrix<'a, BF> {
+    let values = if use_hypercube_evals {
+        // TODO: Ask Robert: prefer raw_hypercube_backing here?
+        DeviceMatrix::new(trace_holder.get_hypercube_evals(), rows)
+    } else {
+        assert!(
+            trace_holder.are_cosets_materialized(),
+            "{} {}",
+            "Tried to build WHIR initial state from coset 0, ",
+            "but cosets are not materialized",
+        );
+        DeviceMatrix::new(trace_holder.get_evaluations(), rows)
+    };
+    values
+}
+
+fn build_initial_batched_evals_device_impl(
     memory_trace_holder: &TraceHolder<BF>,
     memory_weights: &[E4],
     witness_trace_holder: &TraceHolder<BF>,
     witness_weights: &[E4],
     setup_trace_holder: &TraceHolder<BF>,
     setup_weights: &[E4],
+    use_hypercube_evals: bool,
     result: &mut DeviceSlice<E4>,
     mut upload_weights: impl FnMut(&mut DeviceSlice<E4>, &[E4], &ProverContext) -> CudaResult<()>,
     context: &ProverContext,
 ) -> CudaResult<Vec<DeviceAllocation<E4>>> {
     let stream = context.get_exec_stream();
-    set_to_zero(result, stream)?;
     let mut weight_buffers = Vec::with_capacity(3);
 
-    for (trace_holder, weights) in [
-        (memory_trace_holder, memory_weights),
-        (witness_trace_holder, witness_weights),
-        (setup_trace_holder, setup_weights),
-    ] {
-        if weights.is_empty() {
-            continue;
-        }
-        assert!(
-            trace_holder.are_cosets_materialized(),
-            "WHIR initial state requires materialized main-domain cosets",
-        );
-        let mut device_weights = context.alloc(weights.len(), AllocationPlacement::BestFit)?;
-        upload_weights(&mut device_weights, weights, context)?;
-        let values = DeviceMatrix::new(trace_holder.get_evaluations(), result.len());
-        accumulate_whir_base_columns(&values, &device_weights, result, stream)?;
-        weight_buffers.push(device_weights);
-    }
+    assert!(memory_weights.len() > 0);
+    assert!(witness_weights.len() > 0);
+    assert!(setup_weights.len() > 0);
+
+    let mut device_memory_weights =
+        context.alloc(memory_weights.len(), AllocationPlacement::BestFit)?;
+    let mut device_witness_weights =
+        context.alloc(witness_weights.len(), AllocationPlacement::BestFit)?;
+    let mut device_setup_weights =
+        context.alloc(setup_weights.len(), AllocationPlacement::BestFit)?;
+
+    upload_weights(&mut device_memory_weights, memory_weights, context)?;
+    upload_weights(&mut device_witness_weights, witness_weights, context)?;
+    upload_weights(&mut device_setup_weights, setup_weights, context)?;
+
+    let rows = result.len();
+    let memory_values = get_base_columns(memory_trace_holder, rows, use_hypercube_evals);
+    let witness_values = get_base_columns(witness_trace_holder, rows, use_hypercube_evals);
+    let setup_values = get_base_columns(setup_trace_holder, rows, use_hypercube_evals);
+
+    accumulate_whir_base_columns(
+        &memory_values,
+        &witness_values,
+        &setup_values,
+        &device_memory_weights,
+        &device_witness_weights,
+        &device_setup_weights,
+        result,
+        stream,
+    )?;
+
+    weight_buffers.push(device_memory_weights);
+    weight_buffers.push(device_witness_weights);
+    weight_buffers.push(device_setup_weights);
 
     Ok(weight_buffers)
 }
 
-fn build_initial_batched_main_domain_poly_device(
+fn build_initial_batched_evals_device(
     memory_trace_holder: &TraceHolder<BF>,
     memory_weights: &[E4],
     witness_trace_holder: &TraceHolder<BF>,
     witness_weights: &[E4],
     setup_trace_holder: &TraceHolder<BF>,
     setup_weights: &[E4],
+    use_hypercube_evals: bool,
     result: &mut DeviceSlice<E4>,
     context: &ProverContext,
 ) -> CudaResult<Vec<DeviceAllocation<E4>>> {
-    build_initial_batched_main_domain_poly_device_impl(
+    build_initial_batched_evals_device_impl(
         memory_trace_holder,
         memory_weights,
         witness_trace_holder,
         witness_weights,
         setup_trace_holder,
         setup_weights,
+        use_hypercube_evals,
         result,
         |dst, values, context| copy_small_to_device(dst, values, context),
         context,
     )
 }
 
-fn schedule_build_initial_batched_main_domain_poly_device(
+fn schedule_build_initial_batched_evals_device(
     memory_trace_holder: &TraceHolder<BF>,
     memory_weights: &[E4],
     witness_trace_holder: &TraceHolder<BF>,
     witness_weights: &[E4],
     setup_trace_holder: &TraceHolder<BF>,
     setup_weights: &[E4],
+    use_hypercube_evals: bool,
     result: &mut DeviceSlice<E4>,
     callbacks: &mut Callbacks<'static>,
     context: &ProverContext,
 ) -> CudaResult<Vec<DeviceAllocation<E4>>> {
-    build_initial_batched_main_domain_poly_device_impl(
+    build_initial_batched_evals_device_impl(
         memory_trace_holder,
         memory_weights,
         witness_trace_holder,
         witness_weights,
         setup_trace_holder,
         setup_weights,
+        use_hypercube_evals,
         result,
         |dst, values, context| schedule_copy_small_to_device(dst, values, callbacks, context),
         context,
     )
+}
+
+// Also initializes evaluation form if use_hypercube_evals_for_batching was false.
+fn initialize_batched_monomial_form(
+    log_domain_size: usize,
+    use_hypercube_evals_for_batching: bool,
+    state: &mut GpuWhirState,
+    context: &ProverContext,
+) -> CudaResult<()> {
+    let trace_len = 1 << log_domain_size;
+    let mut vectorized_scratch =
+        context.alloc(trace_len * EXT4_DEGREE, AllocationPlacement::BestFit)?;
+    let stream = context.get_exec_stream();
+    serialize_whir_e4_columns(
+        &state.sumchecked_poly_evaluation_form[..trace_len],
+        &mut vectorized_scratch,
+        stream,
+    )?;
+    let vectorized_batched_evals_matrix = DeviceMatrix::new(&vectorized_scratch, trace_len);
+
+    if use_hypercube_evals_for_batching {
+        hypercube_x1_msb_evals_to_x1_msb_monomials(
+            &vectorized_batched_evals_matrix,
+            &mut state.sumchecked_poly_monomial_form,
+            log_domain_size,
+            false, // transpsoed_monomials,
+            stream,
+            context.get_device_properties(),
+        )?;
+        // If we're in this branch, it means state.sumchecked_poly_evaluation_form was
+        // directly created by batching base hypercube evaluation colums, so we're done.
+    } else {
+        natural_evals_to_bitreversed_monomials(
+            &vectorized_batched_evals_matrix,
+            &mut state.sumchecked_poly_monomial_form,
+            log_domain_size,
+            false, // transposed_monomials
+            stream,
+            context.get_device_properties(),
+        )?;
+        let monomials_slice = state.sumchecked_poly_monomial_form.slice();
+        for column in 0..EXT4_DEGREE {
+            let src = &monomials_slice[column * trace_len..(column + 1) * trace_len];
+            let dst = &mut vectorized_scratch[column * trace_len..(column + 1) * trace_len];
+            // Interestingly, both work (I think because addition is commutative).
+            // hypercube_coeffs_natural_to_natural_evals(
+            hypercube_coeffs_bitrev_to_bitrev_evals(src, dst, log_domain_size, stream)?;
+        }
+        deserialize_whir_e4_columns(
+            &vectorized_scratch,
+            &mut state.sumchecked_poly_evaluation_form[..trace_len],
+            stream,
+        )?;
+    }
+
+    Ok(())
 }
 
 fn initialize_batched_forms_impl(
@@ -1216,6 +1315,7 @@ fn initialize_batched_forms_impl(
     wit_polys_claims_len: usize,
     setup_polys_claims_len: usize,
     batching_challenge: E4,
+    use_hypercube_evals_for_batching: bool,
     state: &mut GpuWhirState,
     mut build_initial_form: impl FnMut(
         &TraceHolder<BF>,
@@ -1224,6 +1324,7 @@ fn initialize_batched_forms_impl(
         &[E4],
         &TraceHolder<BF>,
         &[E4],
+        bool,
         &mut DeviceSlice<E4>,
         &ProverContext,
     ) -> CudaResult<Vec<DeviceAllocation<E4>>>,
@@ -1258,57 +1359,17 @@ fn initialize_batched_forms_impl(
         witness_weights,
         setup_trace_holder,
         setup_weights,
+        use_hypercube_evals_for_batching,
         &mut state.sumchecked_poly_evaluation_form,
         context,
     )?;
 
-    let mut serialized = context.alloc(trace_len * EXT4_DEGREE, AllocationPlacement::BestFit)?;
-    let stream = context.get_exec_stream();
-    serialize_whir_e4_columns(
-        &state.sumchecked_poly_evaluation_form[..trace_len],
-        &mut serialized,
-        stream,
+    initialize_batched_monomial_form(
+        memory_trace_holder.log_domain_size as usize,
+        use_hypercube_evals_for_batching,
+        state,
+        context,
     )?;
-    let main_domain_evals_matrix = DeviceMatrix::new(&serialized, trace_len);
-    natural_evals_to_bitreversed_monomials(
-        &main_domain_evals_matrix,
-        &mut state.sumchecked_poly_monomial_form,
-        witness_trace_holder.log_domain_size as usize,
-        false, // transposed_monomials
-        stream,
-        context.get_device_properties(),
-    )?;
-    // bit_reverse_in_place(&mut state.sumchecked_poly_monomial_form, stream)?;
-    // deserialize_whir_e4_columns(
-    //     &serialized,
-    //     &mut state.sumchecked_poly_monomial_form[..trace_len],
-    //     stream,
-    // )?;
-    let monomials_slice = state.sumchecked_poly_monomial_form.slice();
-    let mut bf_scratch = context.alloc(trace_len, AllocationPlacement::BestFit)?;
-    for column in 0..EXT4_DEGREE {
-        let src = &monomials_slice[column * trace_len..(column + 1) * trace_len];
-        // Interestingly, both work (I think because addition is commutative).
-        // hypercube_coeffs_natural_to_natural_evals(
-        hypercube_coeffs_bitrev_to_bitrev_evals(
-            src,
-            &mut bf_scratch,
-            trace_len.trailing_zeros() as usize,
-            stream,
-        )?;
-        let dst = &mut serialized[column * trace_len..(column + 1) * trace_len];
-        memory_copy_async(dst, &bf_scratch, stream)?;
-    }
-    // {
-    //     // let mut evals_matrix = DeviceMatrixMut::new(&mut serialized, trace_len);
-    //     // bit_reverse_in_place(&mut evals_matrix, stream)?;
-    // }
-    deserialize_whir_e4_columns(
-        &serialized,
-        &mut state.sumchecked_poly_evaluation_form[..trace_len],
-        stream,
-    )?;
-    // bit_reverse_in_place(&mut state.sumchecked_poly_monomial_form, stream)?;
 
     Ok([
         memory_weights.to_vec(),
@@ -1325,6 +1386,7 @@ fn initialize_batched_forms(
     wit_polys_claims_len: usize,
     setup_polys_claims_len: usize,
     batching_challenge: E4,
+    use_hypercube_evals_for_batching: bool,
     state: &mut GpuWhirState,
     context: &ProverContext,
 ) -> CudaResult<[Vec<E4>; 3]> {
@@ -1336,6 +1398,7 @@ fn initialize_batched_forms(
         wit_polys_claims_len,
         setup_polys_claims_len,
         batching_challenge,
+        use_hypercube_evals_for_batching,
         state,
         |memory_trace_holder,
          memory_weights,
@@ -1343,15 +1406,17 @@ fn initialize_batched_forms(
          witness_weights,
          setup_trace_holder,
          setup_weights,
+         use_hypercube_evals_for_batching,
          result,
          context| {
-            build_initial_batched_main_domain_poly_device(
+            build_initial_batched_evals_device(
                 memory_trace_holder,
                 memory_weights,
                 witness_trace_holder,
                 witness_weights,
                 setup_trace_holder,
                 setup_weights,
+                use_hypercube_evals_for_batching,
                 result,
                 context,
             )
@@ -1368,6 +1433,7 @@ fn schedule_initialize_batched_forms(
     wit_polys_claims_len: usize,
     setup_polys_claims_len: usize,
     batching_challenge_source: impl Fn() -> E4 + Send + Sync + 'static,
+    use_hypercube_evals_for_batching: bool,
     state: &mut GpuWhirState,
     callbacks: &mut Callbacks<'static>,
     context: &ProverContext,
@@ -1406,82 +1472,41 @@ fn schedule_initialize_batched_forms(
         context.alloc(total_base_oracles, AllocationPlacement::BestFit)?;
     memory_copy_async(&mut challenge_powers_device, &challenge_powers_host, stream)?;
 
-    set_to_zero(&mut state.sumchecked_poly_evaluation_form, stream)?;
-    let mut offset = 0usize;
-    for (trace_holder, weights_len) in [
-        (memory_trace_holder, mem_polys_claims_len),
-        (witness_trace_holder, wit_polys_claims_len),
-        (setup_trace_holder, setup_polys_claims_len),
-    ] {
-        if weights_len == 0 {
-            continue;
-        }
-        assert!(
-            trace_holder.are_cosets_materialized(),
-            "WHIR initial state requires materialized main-domain cosets",
-        );
-        let values = DeviceMatrix::new(
-            trace_holder.get_evaluations(),
-            state.sumchecked_poly_evaluation_form.len(),
-        );
-        // TODO: Make vectorized accumulator for this
-        accumulate_whir_base_columns(
-            &values,
-            &challenge_powers_device[offset..offset + weights_len],
-            &mut state.sumchecked_poly_evaluation_form,
-            stream,
-        )?;
-        offset += weights_len;
-    }
-    debug_assert_eq!(offset, total_base_oracles);
+    assert!(mem_polys_claims_len > 0);
+    assert!(wit_polys_claims_len > 0);
+    assert!(setup_polys_claims_len > 0);
 
-    let mut serialized = context.alloc(trace_len * EXT4_DEGREE, AllocationPlacement::BestFit)?;
-    serialize_whir_e4_columns(
-        &state.sumchecked_poly_evaluation_form[..trace_len],
-        &mut serialized,
+    let challenge_powers_device_slice = &mut challenge_powers_device[..];
+    let (device_memory_weights, rest) =
+        challenge_powers_device_slice.split_at_mut(mem_polys_claims_len);
+    let (device_witness_weights, device_setup_weights) = rest.split_at_mut(wit_polys_claims_len);
+    assert_eq!(device_setup_weights.len(), setup_polys_claims_len);
+
+    let rows = state.sumchecked_poly_evaluation_form.len();
+    let memory_values =
+        get_base_columns(memory_trace_holder, rows, use_hypercube_evals_for_batching);
+    let witness_values =
+        get_base_columns(witness_trace_holder, rows, use_hypercube_evals_for_batching);
+    let setup_values =
+        get_base_columns(setup_trace_holder, rows, use_hypercube_evals_for_batching);
+
+    accumulate_whir_base_columns(
+        &memory_values,
+        &witness_values,
+        &setup_values,
+        &device_memory_weights,
+        &device_witness_weights,
+        &device_setup_weights,
+        &mut state.sumchecked_poly_evaluation_form,
         stream,
     )?;
-    let main_domain_evals_matrix = DeviceMatrix::new(&serialized, trace_len);
-    natural_evals_to_bitreversed_monomials(
-        &main_domain_evals_matrix,
-        &mut state.sumchecked_poly_monomial_form,
-        witness_trace_holder.log_domain_size as usize,
-        false, // transposed_monomials
-        stream,
-        context.get_device_properties(),
+
+    initialize_batched_monomial_form(
+        memory_trace_holder.log_domain_size as usize,
+        use_hypercube_evals_for_batching,
+        state,
+        context,
     )?;
-    // bit_reverse_in_place(&mut state.sumchecked_poly_monomial_form, stream)?;
-    // deserialize_whir_e4_columns(
-    //     &serialized,
-    //     &mut state.sumchecked_poly_monomial_form[..trace_len],
-    //     stream,
-    // )?;
-    let monomials_slice = state.sumchecked_poly_monomial_form.slice();
-    // TODO: remove after writing hypercube kernel
-    let mut bf_scratch = context.alloc(trace_len, AllocationPlacement::BestFit)?;
-    for column in 0..EXT4_DEGREE {
-        let src = &monomials_slice[column * trace_len..(column + 1) * trace_len];
-        // Interestingly, both work (I think because addition is commutative).
-        // hypercube_coeffs_natural_to_natural_evals(
-        hypercube_coeffs_bitrev_to_bitrev_evals(
-            src,
-            &mut bf_scratch,
-            trace_len.trailing_zeros() as usize,
-            stream,
-        )?;
-        let dst = &mut serialized[column * trace_len..(column + 1) * trace_len];
-        memory_copy_async(dst, &bf_scratch, stream)?;
-    }
-    // {
-    //     // let mut evals_matrix = DeviceMatrixMut::new(&mut serialized, trace_len);
-    //     // bit_reverse_in_place(&mut evals_matrix, stream)?;
-    // }
-    deserialize_whir_e4_columns(
-        &serialized,
-        &mut state.sumchecked_poly_evaluation_form[..trace_len],
-        stream,
-    )?;
-    // bit_reverse_in_place(&mut state.sumchecked_poly_monomial_form, stream)?;
 
     Ok(())
 }
@@ -1495,6 +1520,7 @@ fn build_initial_state(
     setup_polys_claims: &[E4],
     original_evaluation_point: &[E4],
     batching_challenge: E4,
+    use_hypercube_evals_for_batching: bool,
     state: &mut GpuWhirState,
     context: &ProverContext,
 ) -> CudaResult<([Vec<E4>; 3], E4)> {
@@ -1512,6 +1538,7 @@ fn build_initial_state(
         wit_polys_claims.len(),
         setup_polys_claims.len(),
         batching_challenge,
+        use_hypercube_evals_for_batching,
         state,
         context,
     )?;
@@ -1856,6 +1883,7 @@ pub(crate) fn schedule_gpu_whir_fold_with_sources(
     seed_source: impl Fn() -> Seed + Send + Sync + 'static,
     tree_cap_size: usize,
     trace_len_log2: usize,
+    use_hypercube_evals_for_batching: bool,
     // Phase 3: slab + layout thread through so WHIR sub-phases can route
     // proof fields (`pow_nonces` today; caps, evals, queries, ood_samples,
     // sumcheck_polys, final_monomials in follow-up commits) into slab
@@ -2149,6 +2177,7 @@ pub(crate) fn schedule_gpu_whir_fold_with_sources(
         witness_trace_holder.columns_count,
         setup_trace_holder.columns_count,
         batching_challenge_source,
+        use_hypercube_evals_for_batching,
         &mut state,
         &mut start_callbacks,
         context,
@@ -3228,6 +3257,7 @@ pub(crate) fn debug_build_initial_state_for_test(
     setup_polys_claims: &[E4],
     original_evaluation_point: &[E4],
     batching_challenge: E4,
+    use_hypercube_evals_for_batching: bool,
     context: &ProverContext,
 ) -> CudaResult<([Vec<E4>; 3], E4, Vec<E4>, Vec<E4>, Vec<E4>)> {
     fn copy_back<T: Clone>(values: &DeviceSlice<T>, context: &ProverContext) -> Vec<T> {
@@ -3248,6 +3278,7 @@ pub(crate) fn debug_build_initial_state_for_test(
         setup_polys_claims,
         original_evaluation_point,
         batching_challenge,
+        use_hypercube_evals_for_batching,
         &mut state,
         context,
     )?;
@@ -3270,7 +3301,7 @@ pub(crate) fn debug_build_initial_state_for_test(
 }
 
 #[cfg(test)]
-pub(crate) fn debug_build_initial_batched_main_domain_poly_for_test(
+pub(crate) fn debug_build_initial_batched_evals_for_test(
     memory_trace_holder: &TraceHolder<BF>,
     mem_polys_claims: &[E4],
     witness_trace_holder: &TraceHolder<BF>,
@@ -3278,6 +3309,7 @@ pub(crate) fn debug_build_initial_batched_main_domain_poly_for_test(
     setup_trace_holder: &TraceHolder<BF>,
     setup_polys_claims: &[E4],
     batching_challenge: E4,
+    use_hypercube_evals: bool,
     context: &ProverContext,
 ) -> CudaResult<Vec<E4>> {
     fn copy_back(values: &DeviceSlice<E4>, context: &ProverContext) -> Vec<E4> {
@@ -3307,13 +3339,14 @@ pub(crate) fn debug_build_initial_batched_main_domain_poly_for_test(
     let (witness_weights, setup_weights) = rest.split_at(wit_polys_claims.len());
     debug_assert_eq!(setup_weights.len(), setup_polys_claims.len());
 
-    let _weight_buffers = build_initial_batched_main_domain_poly_device(
+    let _weight_buffers = build_initial_batched_evals_device(
         memory_trace_holder,
         memory_weights,
         witness_trace_holder,
         witness_weights,
         setup_trace_holder,
         setup_weights,
+        use_hypercube_evals,
         &mut state.sumchecked_poly_evaluation_form,
         context,
     )?;
@@ -3333,6 +3366,7 @@ pub(crate) fn debug_build_initial_state_snapshots_for_test(
     setup_polys_claims: &[E4],
     original_evaluation_point: &[E4],
     batching_challenge: E4,
+    use_hypercube_evals_for_batching: bool,
     context: &ProverContext,
 ) -> CudaResult<(Vec<E4>, Vec<E4>)> {
     fn copy_back(values: &DeviceSlice<E4>, context: &ProverContext) -> Vec<E4> {
@@ -3352,6 +3386,7 @@ pub(crate) fn debug_build_initial_state_snapshots_for_test(
         wit_polys_claims.len(),
         setup_polys_claims.len(),
         batching_challenge,
+        use_hypercube_evals_for_batching,
         &mut state,
         context,
     )?;
@@ -3423,6 +3458,7 @@ pub(crate) fn debug_initial_round_checkpoint_for_test(
     first_recursive_lde_factor: usize,
     next_folding_steps: usize,
     tree_cap_size: usize,
+    use_hypercube_evals_for_batching: bool,
     transcript_seed: Seed,
     context: &ProverContext,
 ) -> CudaResult<DebugInitialWhirRoundCheckpoint> {
@@ -3438,6 +3474,7 @@ pub(crate) fn debug_initial_round_checkpoint_for_test(
         setup_polys_claims,
         original_evaluation_point,
         batching_challenge,
+        use_hypercube_evals_for_batching,
         &mut state,
         context,
     )?;
@@ -3519,6 +3556,7 @@ pub(crate) fn debug_build_initial_fold_state_for_test(
     setup_polys_claims: &[E4],
     original_evaluation_point: &[E4],
     batching_challenge: E4,
+    use_hypercube_evals_for_batching: bool,
     context: &ProverContext,
 ) -> CudaResult<DebugWhirInitialFoldState> {
     let trace_len = 1usize << memory_trace_holder.log_domain_size;
@@ -3532,6 +3570,7 @@ pub(crate) fn debug_build_initial_fold_state_for_test(
         setup_polys_claims,
         original_evaluation_point,
         batching_challenge,
+        use_hypercube_evals_for_batching,
         &mut state,
         context,
     )?;
@@ -4200,7 +4239,11 @@ mod tests {
     }
 
     #[cfg(not(no_cuda))]
-    fn run_whir_initial_state_matches_cpu(log_count: usize, is_large: bool) {
+    fn run_whir_initial_state_matches_cpu(
+        log_count: usize,
+        use_hypercube_evals_for_batching: bool,
+        is_large: bool,
+    ) {
         let context = if is_large {
             make_test_context(64 * 1024, 1024)
         } else {
@@ -4258,6 +4301,7 @@ mod tests {
             &setup_polys_claims,
             &original_evaluation_point,
             batching_challenge,
+            use_hypercube_evals_for_batching,
             &mut state,
             &context,
         )
@@ -4349,16 +4393,31 @@ mod tests {
     #[test]
     #[cfg(not(no_cuda))]
     #[serial]
-    fn whir_initial_state_matches_cpu_small() {
-        run_whir_initial_state_matches_cpu(3, false);
+    fn whir_initial_state_matches_cpu_use_coset_0_for_batching_small() {
+        run_whir_initial_state_matches_cpu(3, false, false);
     }
 
     #[test]
     #[cfg(not(no_cuda))]
     #[serial]
     #[ignore]
-    fn whir_initial_state_matches_cpu_large() {
-        run_whir_initial_state_matches_cpu(MIN_LOG_N_FOR_MULTISTAGE_KERNELS + 1, true);
+    fn whir_initial_state_matches_cpu_use_coset_0_for_batching_large() {
+        run_whir_initial_state_matches_cpu(MIN_LOG_N_FOR_MULTISTAGE_KERNELS + 1, false, true);
+    }
+
+    #[test]
+    #[cfg(not(no_cuda))]
+    #[serial]
+    fn whir_initial_state_matches_cpu_use_hypercube_evals_for_batching_small() {
+        run_whir_initial_state_matches_cpu(3, true, false);
+    }
+
+    #[test]
+    #[cfg(not(no_cuda))]
+    #[serial]
+    #[ignore]
+    fn whir_initial_state_matches_cpu_use_hypercube_evals_for_batching_large() {
+        run_whir_initial_state_matches_cpu(MIN_LOG_N_FOR_MULTISTAGE_KERNELS + 1, true, true);
     }
 
     #[test]

--- a/gpu_prover/src/prover/whir_kernels.rs
+++ b/gpu_prover/src/prover/whir_kernels.rs
@@ -76,49 +76,82 @@ pub fn deserialize_whir_e4_columns(
     DeserializeWhirE4ColumnsFunction(ab_deserialize_whir_e4_columns_kernel).launch(&config, &args)
 }
 
-cuda_kernel_signature_arguments_and_function!(
-    AccumulateWhirBaseColumns,
-    values: *const BF,
-    stride: u32,
-    weights: *const E4,
-    cols: u32,
+const TRACE_CHUNKS: usize = 3;
+
+#[repr(C)]
+struct BaseColumnsBatchingMetadata {
+    values: [*const BF; TRACE_CHUNKS],
+    weights: [*const E4; TRACE_CHUNKS],
+    cols: [u32; TRACE_CHUNKS],
+    strides: [u32; TRACE_CHUNKS],
     result: *mut E4,
     rows: u32,
+}
+
+cuda_kernel_signature_arguments_and_function!(
+    AccumulateWhirBaseColumns,
+    metadata: BaseColumnsBatchingMetadata,
 );
 
 cuda_kernel_declaration!(
-    ab_accumulate_whir_base_columns_e4_kernel(
-        values: *const BF,
-        stride: u32,
-        weights: *const E4,
-        cols: u32,
-        result: *mut E4,
-        rows: u32,
-    )
+    ab_accumulate_whir_base_columns_e4_kernel(metadata: BaseColumnsBatchingMetadata)
 );
 
 pub fn accumulate_whir_base_columns(
-    values: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
-    weights: &DeviceSlice<E4>,
+    memory_values: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    witness_values: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    setup_values: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    memory_weights: &DeviceSlice<E4>,
+    witness_weights: &DeviceSlice<E4>,
+    setup_weights: &DeviceSlice<E4>,
     result: &mut DeviceSlice<E4>,
     stream: &CudaStream,
 ) -> CudaResult<()> {
-    assert_eq!(values.cols(), weights.len());
-    assert_eq!(values.rows(), result.len());
-    assert!(values.rows() <= u32::MAX as usize);
-    assert!(values.cols() <= u32::MAX as usize);
-    let rows = values.rows() as u32;
-    let cols = values.cols() as u32;
+    assert_eq!(memory_values.cols(), memory_weights.len());
+    assert_eq!(memory_values.rows(), result.len());
+    assert!(memory_values.rows() <= u32::MAX as usize);
+    assert!(memory_values.cols() <= u32::MAX as usize);
+    assert_eq!(witness_values.cols(), witness_weights.len());
+    assert_eq!(witness_values.rows(), result.len());
+    assert!(witness_values.rows() <= u32::MAX as usize);
+    assert!(witness_values.cols() <= u32::MAX as usize);
+    assert_eq!(setup_values.cols(), setup_weights.len());
+    assert_eq!(setup_values.rows(), result.len());
+    assert!(setup_values.rows() <= u32::MAX as usize);
+    assert!(setup_values.cols() <= u32::MAX as usize);
+    let values = [
+        memory_values.as_ptr(),
+        witness_values.as_ptr(),
+        setup_values.as_ptr(),
+    ];
+    let weights = [
+        memory_weights.as_ptr(),
+        witness_weights.as_ptr(),
+        setup_weights.as_ptr(),
+    ];
+    let cols = [
+        memory_values.cols() as u32,
+        witness_values.cols() as u32,
+        setup_values.cols() as u32,
+    ];
+    let strides = [
+        memory_values.stride() as u32,
+        witness_values.stride() as u32,
+        setup_values.stride() as u32,
+    ];
+    let result = result.as_mut_ptr();
+    let rows = memory_values.rows() as u32;
+    let metadata = BaseColumnsBatchingMetadata {
+        values,
+        weights,
+        cols,
+        strides,
+        result,
+        rows,
+    };
     let (grid_dim, block_dim) = get_launch_dims(rows);
     let config = CudaLaunchConfig::basic(grid_dim, block_dim, stream);
-    let args = AccumulateWhirBaseColumnsArguments::new(
-        values.as_ptr(),
-        values.stride() as u32,
-        weights.as_ptr(),
-        cols,
-        result.as_mut_ptr(),
-        rows,
-    );
+    let args = AccumulateWhirBaseColumnsArguments::new(metadata);
     AccumulateWhirBaseColumnsFunction(ab_accumulate_whir_base_columns_e4_kernel)
         .launch(&config, &args)
 }


### PR DESCRIPTION
## What ❔

- streamlines batched base layer creation
- adds option to create the batched base layer from either hypercube evaluations or coset 0 evaluations (giving us more leeway to tune memory usage)
- changes proof orchestration to use hypercube evaluations as the default source for whir base layers (better performance)