### PR TITLE
fix(riscv_transpiler): account CSR-backed JIT counters under AddSubLui

### DIFF
--- a/riscv_transpiler/src/jit/impls.rs
+++ b/riscv_transpiler/src/jit/impls.rs
@@ -1582,7 +1582,7 @@ impl<I: ContextImpl> JittedCode<I> {
                                 store_result(&mut ops, rd);
                                 pre_bump_timestamp_and_touch!(ops, 1, rd);
                                 bump_timestamp!(ops, 2);
-                                record_circuit_type(&mut ops, CounterType::ShiftBinaryCsr, 1);
+                                record_circuit_type(&mut ops, CounterType::AddSubLui, 1);
                                 issue_snapshot = true;
                             } else if parts.rs1() != 0 {
                                 let rd = (raw_instruction >> 7) & 0x1F;
@@ -1614,7 +1614,7 @@ impl<I: ContextImpl> JittedCode<I> {
                                 );
                                 pre_bump_timestamp_and_touch!(ops, 1, 0);
                                 bump_timestamp!(ops, 2);
-                                record_circuit_type(&mut ops, CounterType::ShiftBinaryCsr, 1);
+                                record_circuit_type(&mut ops, CounterType::AddSubLui, 1);
                             } else {
                                 panic!(
                                     "CSRRW with non-determinism CSR and invalid rs1/rd combination"
@@ -1692,7 +1692,7 @@ impl<I: ContextImpl> JittedCode<I> {
                             assert!(cycles_taken <= u16::MAX as usize);
                             record_circuit_type(
                                 &mut ops,
-                                CounterType::ShiftBinaryCsr,
+                                CounterType::AddSubLui,
                                 cycles_taken as u16,
                             );
 


### PR DESCRIPTION
## What ❔
Reclassify JIT accounting for non-determinism CSR reads/writes and delegation cycle-family bumps from `ShiftBinaryCsr` to `AddSubLui` in `riscv_transpiler/src/jit/impls.rs`.

## Why ❔
The VM and replayer already classify these CSR-backed operations under the add-sub family, so the JIT counters were out of parity.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.
