### PR TITLE
perf(gpu_prover): L2 persistence for whir LDE->leaf transform->leaf hash sequence

### DIFF
--- a/gpu/circuit_prover/src/prover/trace/holder/mod.rs
+++ b/gpu/circuit_prover/src/prover/trace/holder/mod.rs
@@ -1322,7 +1322,10 @@ pub(crate) fn commit_trace_from_ntt_single_tree(
     let l2_bytes = device_properties.l2_cache_size_bytes;
     let single_bf_col_bytes = std::mem::size_of::<BF>() << log_trace_len;
     let single_coset_bytes = src_cols_per_coset * single_bf_col_bytes;
-    let cosets_in_tile_chunk = if l2_bytes >= single_coset_bytes {
+    // Deactivate chunking for log_trace_len < 18 because it doesn't seem to play well
+    // with the small dit kernels.
+    // TODO: investigate
+    let cosets_in_tile_chunk = if l2_bytes >= single_coset_bytes && log_trace_len >= 18 {
         let nearest = l2_bytes / single_coset_bytes;
         if nearest.is_power_of_two() {
             nearest
@@ -1340,8 +1343,7 @@ pub(crate) fn commit_trace_from_ntt_single_tree(
     let mut ntt_output_matrix = DeviceMatrixMut::new(ntt_output, trace_len);
 
     for coset_index_base in (0..total_cosets).step_by(cosets_in_tile_chunk) {
-        let cosets_in_tile =
-            std::cmp::min(cosets_in_tile_chunk, total_cosets - coset_index_base);
+        let cosets_in_tile = std::cmp::min(cosets_in_tile_chunk, total_cosets - coset_index_base);
         // The NTT and hashing APIs don't internally apply an offset for coset_index_base,
         // so for them we have to manually select the start in ntt_output.
         let offset = src_cols_per_coset * trace_len * coset_index_base;

--- a/gpu/circuit_prover/src/prover/trace/holder/mod.rs
+++ b/gpu/circuit_prover/src/prover/trace/holder/mod.rs
@@ -219,23 +219,24 @@ impl<T> TraceHolder<T> {
         }
     }
 
-    // /// Mutable shared-borrow of the full `CosetsHolder::Full` backing, intended
-    // /// for callers that fill all cosets in one shot (multi-coset NTT writing
-    // /// directly into the cosets backing). Asserts `!self.cosets_materialized`;
-    // /// the caller is responsible for calling `mark_cosets_materialized` once the
-    // /// fill completes.
-    // pub(crate) fn get_uninit_consolidated_cosets_mut(&mut self) -> &mut DeviceSlice<T> {
-    //     assert!(
-    //         !self.cosets_materialized,
-    //         "get_uninit_consolidated_cosets_mut: cosets already materialized"
-    //     );
-    //     match &mut self.cosets {
-    //         CosetsHolder::Full(backing) => backing,
-    //         CosetsHolder::None(_) => {
-    //             panic!("cosets not allocated — call ensure_cosets_materialized first")
-    //         }
-    //     }
-    // }
+    /// Mutable shared-borrow of the full `CosetsHolder::Full` backing, intended
+    /// for callers that fill all cosets in one shot (multi-coset NTT writing
+    /// directly into the cosets backing). Asserts `!self.cosets_materialized`;
+    /// the caller is responsible for calling `mark_cosets_materialized` once the
+    /// fill completes.
+    #[allow(dead_code)]
+    pub(crate) fn get_uninit_consolidated_cosets_mut(&mut self) -> &mut DeviceSlice<T> {
+        assert!(
+            !self.cosets_materialized,
+            "get_uninit_consolidated_cosets_mut: cosets already materialized"
+        );
+        match &mut self.cosets {
+            CosetsHolder::Full(backing) => backing,
+            CosetsHolder::None(_) => {
+                panic!("cosets not allocated — call ensure_cosets_materialized first")
+            }
+        }
+    }
 
     pub(crate) fn get_evaluations(&self) -> &DeviceSlice<T> {
         self.get_coset_evaluations(0)
@@ -1322,7 +1323,7 @@ pub(crate) fn commit_trace_from_ntt_single_tree(
     let l2_bytes = device_properties.l2_cache_size_bytes;
     let single_bf_col_bytes = std::mem::size_of::<BF>() << log_trace_len;
     let single_coset_bytes = src_cols_per_coset * single_bf_col_bytes;
-    // Deactivate chunking for log_trace_len < 18 because it doesn't seem to play well
+    // Deactivate chunking for log_trace_len < 18 because it doesn't play well
     // with the small dit kernels.
     // TODO: investigate
     let cosets_in_tile_chunk = if l2_bytes >= single_coset_bytes && log_trace_len >= 18 {

--- a/gpu/circuit_prover/src/prover/trace/holder/mod.rs
+++ b/gpu/circuit_prover/src/prover/trace/holder/mod.rs
@@ -17,19 +17,26 @@ use crate::ops::blake2s::{
     gather_leaf_rows, gather_merkle_paths_device, gather_merkle_paths_from_rows,
 };
 use crate::ops::ntt::{
-    bitreversed_monomials_to_natural_evals_multi_coset, hypercube_x1_msb_evals_to_x1_msb_monomials,
-    log_size_supports_transposed_monomials, transform_whir_leaves_from_ntt_in_place_multi_coset,
+    bitreversed_monomials_to_natural_evals_multi_coset,
+    bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range,
+    hypercube_x1_msb_evals_to_x1_msb_monomials, log_size_supports_transposed_monomials,
+    transform_whir_leaves_from_ntt_in_place_multi_coset,
 };
 use crate::primitives::context::DeviceAllocation;
 #[cfg(test)]
 use crate::primitives::context::HostAllocation;
 #[cfg(test)]
 use crate::primitives::device_structures::DeviceMatrix;
-use crate::primitives::device_structures::{DeviceMatrixChunk, DeviceMatrixImpl, DeviceMatrixMut};
-use crate::primitives::field::BF;
+use crate::primitives::device_structures::{
+    DeviceMatrixChunk, DeviceMatrixImpl, DeviceMatrixMut, DeviceMatrixMutImpl,
+};
+use crate::primitives::field::{BF, E4};
 use crate::prover::ProverContext;
+use crate::upstream::FieldExtension;
 
 pub(crate) const PARTIAL_TREE_REDUCTION_LAYERS: u32 = crate::primitives::utils::LOG_WARP_SIZE;
+
+const EXT4_DEGREE: usize = <E4 as FieldExtension<BF>>::DEGREE;
 
 #[derive(Copy, Clone)]
 pub(crate) enum TreesCacheMode {
@@ -215,23 +222,23 @@ impl<T> TraceHolder<T> {
         }
     }
 
-    /// Mutable shared-borrow of the full `CosetsHolder::Full` backing, intended
-    /// for callers that fill all cosets in one shot (multi-coset NTT writing
-    /// directly into the cosets backing). Asserts `!self.cosets_materialized`;
-    /// the caller is responsible for calling `mark_cosets_materialized` once the
-    /// fill completes.
-    pub(crate) fn get_uninit_consolidated_cosets_mut(&mut self) -> &mut DeviceSlice<T> {
-        assert!(
-            !self.cosets_materialized,
-            "get_uninit_consolidated_cosets_mut: cosets already materialized"
-        );
-        match &mut self.cosets {
-            CosetsHolder::Full(backing) => backing,
-            CosetsHolder::None(_) => {
-                panic!("cosets not allocated — call ensure_cosets_materialized first")
-            }
-        }
-    }
+    // /// Mutable shared-borrow of the full `CosetsHolder::Full` backing, intended
+    // /// for callers that fill all cosets in one shot (multi-coset NTT writing
+    // /// directly into the cosets backing). Asserts `!self.cosets_materialized`;
+    // /// the caller is responsible for calling `mark_cosets_materialized` once the
+    // /// fill completes.
+    // pub(crate) fn get_uninit_consolidated_cosets_mut(&mut self) -> &mut DeviceSlice<T> {
+    //     assert!(
+    //         !self.cosets_materialized,
+    //         "get_uninit_consolidated_cosets_mut: cosets already materialized"
+    //     );
+    //     match &mut self.cosets {
+    //         CosetsHolder::Full(backing) => backing,
+    //         CosetsHolder::None(_) => {
+    //             panic!("cosets not allocated — call ensure_cosets_materialized first")
+    //         }
+    //     }
+    // }
 
     pub(crate) fn get_evaluations(&self) -> &DeviceSlice<T> {
         self.get_coset_evaluations(0)
@@ -621,8 +628,9 @@ impl TraceHolder<BF> {
     /// (the WHIR oracle's TraceHolder shape). The natural lde factor and
     /// per-leaf size are passed as arguments — they live outside the TraceHolder
     /// abstraction.
-    pub(crate) fn commit_all_into_from_ntt(
+    pub(crate) fn whir_lde_and_commit_all_into(
         &mut self,
+        inputs_matrix: &DeviceMatrixChunk<BF>,
         dst_u32: &mut DeviceSlice<u32>,
         log_trace_len: u32,
         natural_log_lde_factor: u32,
@@ -633,22 +641,22 @@ impl TraceHolder<BF> {
     ) -> CudaResult<()> {
         assert_eq!(
             self.log_lde_factor, 0,
-            "commit_all_into_from_ntt: TraceHolder must be the WHIR-oracle shape (log_lde_factor = 0)"
+            "whir_lde_and_commit_all_into: TraceHolder must be the WHIR-oracle shape (log_lde_factor = 0)"
         );
         assert_eq!(
             self.log_rows_per_leaf, 0,
-            "commit_all_into_from_ntt: TraceHolder must be the WHIR-oracle shape (log_rows_per_leaf = 0)"
+            "whir_lde_and_commit_all_into: TraceHolder must be the WHIR-oracle shape (log_rows_per_leaf = 0)"
         );
         assert!(
-            self.cosets_materialized,
-            "commit_all_into_from_ntt: cosets backing must be materialized first"
+            !self.cosets_materialized,
+            "whir_lde_and_commit_all_into: cosets already materialized"
         );
         let stream = context.get_exec_stream();
         let cap_size = 1usize << self.log_tree_cap_size;
         assert_eq!(
             dst_u32.len(),
             cap_size * BLAKE2S_DIGEST_SIZE_U32_WORDS,
-            "commit_all_into_from_ntt dst_u32 length must match cap_size * DIGEST_U32_WORDS",
+            "whir_lde_and_commit_all_into dst_u32 length must match cap_size * DIGEST_U32_WORDS",
         );
 
         // Snapshot the cosets backing as a raw const slice so we can borrow
@@ -678,6 +686,7 @@ impl TraceHolder<BF> {
         match &mut self.trees {
             TreesHolder::Full(backing) => {
                 commit_trace_from_ntt_single_tree(
+                    inputs_matrix,
                     ntt_output,
                     backing,
                     log_trace_len,
@@ -704,6 +713,7 @@ impl TraceHolder<BF> {
                 // = PARTIAL_TREE_REDUCTION_LAYERS.
                 let top_log_cap = total_leaf_count_log2 + 1 - PARTIAL_TREE_REDUCTION_LAYERS;
                 commit_trace_from_ntt_single_tree(
+                    inputs_matrix,
                     ntt_output,
                     &mut tree_top[..],
                     log_trace_len,
@@ -733,7 +743,7 @@ impl TraceHolder<BF> {
                 transient_tree_tops = None; // partial path doesn't reuse via gather
             }
             TreesHolder::None => {
-                panic!("commit_all_into_from_ntt: TreesCacheMode::CacheNone is not supported; use CachePartial or CacheFull");
+                panic!("whir_lde_and_commit_all_into: TreesCacheMode::CacheNone is not supported; use CachePartial or CacheFull");
             }
         }
 
@@ -789,12 +799,13 @@ impl TraceHolder<BF> {
         Ok(())
     }
 
-    /// Wrapper around `commit_all_into_from_ntt` that allocates a private
+    /// Wrapper around `whir_lde_and_commit_all_into` that allocates a private
     /// `unified_device_cap` (mirrors `commit_all`'s relationship to
     /// `commit_all_into`). Used by `#[cfg(test)]` callers that don't have a slab
     /// destination handy.
-    pub(crate) fn commit_all_from_ntt(
+    pub(crate) fn whir_lde_and_commit_all(
         &mut self,
+        inputs_matrix: &DeviceMatrixChunk<BF>,
         log_trace_len: u32,
         natural_log_lde_factor: u32,
         log_values_per_leaf: u32,
@@ -815,7 +826,8 @@ impl TraceHolder<BF> {
         let dst_ptr = unified_cap_mut.as_mut_ptr() as *mut u32;
         let dst_len = cap_size * BLAKE2S_DIGEST_SIZE_U32_WORDS;
         let dst_u32 = unsafe { DeviceSlice::from_raw_parts_mut(dst_ptr, dst_len) };
-        self.commit_all_into_from_ntt(
+        self.whir_lde_and_commit_all_into(
+            inputs_matrix,
             dst_u32,
             log_trace_len,
             natural_log_lde_factor,
@@ -1270,6 +1282,7 @@ pub(crate) fn commit_trace_multi_coset(
 /// (typically `whir_steps_lde_factors[i].trailing_zeros()`), NOT the
 /// `TraceHolder`'s `log_lde_factor`.
 pub(crate) fn commit_trace_from_ntt_single_tree(
+    inputs_matrix: &DeviceMatrixChunk<BF>,
     ntt_output: &mut DeviceSlice<BF>,
     trees_backing: &mut DeviceSlice<Digest>,
     log_trace_len: u32,
@@ -1282,6 +1295,7 @@ pub(crate) fn commit_trace_from_ntt_single_tree(
 ) -> CudaResult<()> {
     assert!(natural_log_lde_factor >= 1);
     assert!(log_trace_len >= log_values_per_leaf);
+    let trace_len = 1 << log_trace_len;
     let packed_leaf_count = 1usize << (log_trace_len - log_values_per_leaf);
     let total_leaf_count = packed_leaf_count
         .checked_mul(1 << natural_log_lde_factor)
@@ -1292,22 +1306,60 @@ pub(crate) fn commit_trace_from_ntt_single_tree(
     let layers_count = total_leaf_count_log2 + 1 - log_tree_cap_size;
     let (leaves, nodes) = trees_backing.split_at_mut(total_leaf_count);
     let stream = context.get_exec_stream();
-    // TODO: Accept cosets_in_tile and coset_index_base as arguments for coset-based
-    // L2 chunking of the full NTT->transform->commit rows->commit nodes sequence.
-    if transform_leaves_to_multilinear_coeffs {
-        let l2_bytes = context.get_device_properties().l2_cache_size_bytes;
-        let single_bf_col_bytes = std::mem::size_of::<BF>() << log_trace_len;
-        let single_coset_bytes = src_cols_per_coset * single_bf_col_bytes;
-        let cosets_in_tile_chunk = if l2_bytes >= single_coset_bytes {
-            l2_bytes / single_coset_bytes
+
+    let device_properties = context.get_device_properties();
+    let ntt_ctx = context.ntt_device_context();
+    // Recursive WHIR folds to a small trace (trace_len_log2 <= 13), the DIT
+    // forward-NTT range, which needs a pooled d-table scratch (len >= N).
+    // Allocate from the stream-ordered pool so this stays enqueue-only per
+    // the GPU scheduling contract; the handle outlives the launches below.
+    // Outside the DIT range the compact path ignores the scratch, so the
+    // allocation is skipped entirely.
+    let mut d_scratch = if log_trace_len <= 13 {
+        Some(context.alloc::<BF>(trace_len, AllocationPlacement::BestFit)?)
+    } else {
+        None
+    };
+
+    let l2_bytes = device_properties.l2_cache_size_bytes;
+    let single_bf_col_bytes = std::mem::size_of::<BF>() << log_trace_len;
+    let single_coset_bytes = src_cols_per_coset * single_bf_col_bytes;
+    let cosets_in_tile_chunk = if l2_bytes >= single_coset_bytes {
+        let nearest = l2_bytes / single_coset_bytes;
+        if nearest.is_power_of_two() {
+            nearest
         } else {
-            1
-        };
-        let mut ntt_output_matrix = DeviceMatrixMut::new(ntt_output, 1 << log_trace_len);
-        let total_cosets = 1 << natural_log_lde_factor;
-        for coset_index_base in (0..total_cosets).step_by(cosets_in_tile_chunk) {
-            let cosets_in_tile =
-                std::cmp::min(cosets_in_tile_chunk, total_cosets - coset_index_base);
+            nearest.next_power_of_two() >> 1
+        }
+    } else {
+        1
+    };
+    let total_cosets = 1 << natural_log_lde_factor;
+    if total_cosets > cosets_in_tile_chunk {
+        assert_eq!(total_cosets % cosets_in_tile_chunk, 0);
+    }
+    let mut ntt_output_matrix = DeviceMatrixMut::new(ntt_output, trace_len);
+    for coset_index_base in (0..total_cosets).step_by(cosets_in_tile_chunk) {
+        let cosets_in_tile =
+            std::cmp::min(cosets_in_tile_chunk, total_cosets - coset_index_base);
+        let scratch_opt = d_scratch.as_mut().map(|s| &mut s[..]);
+        // The NTT API does not internally apply an offset for coset_index_base.
+        let offset = EXT4_DEGREE * trace_len * coset_index_base;
+        bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range(
+            inputs_matrix,
+            &mut (ntt_output_matrix.slice_mut())[offset..],
+            log_trace_len as usize,
+            natural_log_lde_factor as usize,
+            cosets_in_tile,
+            coset_index_base,
+            EXT4_DEGREE,
+            false,
+            ntt_ctx,
+            scratch_opt,
+            stream,
+            device_properties,
+        )?;
+        if transform_leaves_to_multilinear_coeffs {
             transform_whir_leaves_from_ntt_in_place_multi_coset(
                 &mut ntt_output_matrix,
                 log_trace_len,
@@ -1318,35 +1370,37 @@ pub(crate) fn commit_trace_from_ntt_single_tree(
                 src_cols_per_coset as u32,
                 stream,
             )?;
-            crate::ops::blake2s::launch_leaves_kernel_from_ntt_multi_coset(
-                ntt_output_matrix.slice(),
-                leaves,
-                log_values_per_leaf,
-                src_cols_per_coset as u32,
-                natural_log_lde_factor,
-                coset_index_base as u32,
-                cosets_in_tile,
-                packed_leaf_count,
-                1u32 << log_trace_len,
-                stream,
-            )?;
         }
-    } else {
-        let coset_index_base = 0;
-        let cosets_in_tile = 1usize << natural_log_lde_factor;
         crate::ops::blake2s::launch_leaves_kernel_from_ntt_multi_coset(
-            ntt_output,
+            ntt_output_matrix.slice(),
             leaves,
             log_values_per_leaf,
             src_cols_per_coset as u32,
             natural_log_lde_factor,
-            coset_index_base,
+            coset_index_base as u32,
             cosets_in_tile,
             packed_leaf_count,
-            1u32 << log_trace_len,
+            trace_len as u32,
             stream,
         )?;
     }
+    // } else {
+    //     let coset_index_base = 0;
+    //     let cosets_in_tile = 1usize << natural_log_lde_factor;
+    //     crate::ops::blake2s::launch_leaves_kernel_from_ntt_multi_coset(
+    //         ntt_output,
+    //         leaves,
+    //         log_values_per_leaf,
+    //         src_cols_per_coset as u32,
+    //         natural_log_lde_factor,
+    //         coset_index_base,
+    //         cosets_in_tile,
+    //         packed_leaf_count,
+    //         trace_len as u32,
+    //         stream,
+    //     )?;
+    // }
+
     // Single-tree node layers: build_merkle_tree_nodes operates on a flat
     // `[leaves | nodes]` slab. `layers_count - 1` because the leaf layer is
     // already written; the function builds the remaining `layers_count - 1`

--- a/gpu/circuit_prover/src/prover/trace/holder/mod.rs
+++ b/gpu/circuit_prover/src/prover/trace/holder/mod.rs
@@ -30,13 +30,10 @@ use crate::primitives::device_structures::DeviceMatrix;
 use crate::primitives::device_structures::{
     DeviceMatrixChunk, DeviceMatrixImpl, DeviceMatrixMut, DeviceMatrixMutImpl,
 };
-use crate::primitives::field::{BF, E4};
+use crate::primitives::field::BF;
 use crate::prover::ProverContext;
-use crate::upstream::FieldExtension;
 
 pub(crate) const PARTIAL_TREE_REDUCTION_LAYERS: u32 = crate::primitives::utils::LOG_WARP_SIZE;
-
-const EXT4_DEGREE: usize = <E4 as FieldExtension<BF>>::DEGREE;
 
 #[derive(Copy, Clone)]
 pub(crate) enum TreesCacheMode {
@@ -1321,6 +1318,7 @@ pub(crate) fn commit_trace_from_ntt_single_tree(
         None
     };
 
+    let total_cosets = 1 << natural_log_lde_factor;
     let l2_bytes = device_properties.l2_cache_size_bytes;
     let single_bf_col_bytes = std::mem::size_of::<BF>() << log_trace_len;
     let single_coset_bytes = src_cols_per_coset * single_bf_col_bytes;
@@ -1332,19 +1330,22 @@ pub(crate) fn commit_trace_from_ntt_single_tree(
             nearest.next_power_of_two() >> 1
         }
     } else {
-        1
+        // don't bother with chunking
+        total_cosets
     };
-    let total_cosets = 1 << natural_log_lde_factor;
     if total_cosets > cosets_in_tile_chunk {
         assert_eq!(total_cosets % cosets_in_tile_chunk, 0);
     }
+
     let mut ntt_output_matrix = DeviceMatrixMut::new(ntt_output, trace_len);
+
     for coset_index_base in (0..total_cosets).step_by(cosets_in_tile_chunk) {
         let cosets_in_tile =
             std::cmp::min(cosets_in_tile_chunk, total_cosets - coset_index_base);
+        // The NTT and hashing APIs don't internally apply an offset for coset_index_base,
+        // so for them we have to manually select the start in ntt_output.
+        let offset = src_cols_per_coset * trace_len * coset_index_base;
         let scratch_opt = d_scratch.as_mut().map(|s| &mut s[..]);
-        // The NTT API does not internally apply an offset for coset_index_base.
-        let offset = EXT4_DEGREE * trace_len * coset_index_base;
         bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range(
             inputs_matrix,
             &mut (ntt_output_matrix.slice_mut())[offset..],
@@ -1352,7 +1353,7 @@ pub(crate) fn commit_trace_from_ntt_single_tree(
             natural_log_lde_factor as usize,
             cosets_in_tile,
             coset_index_base,
-            EXT4_DEGREE,
+            src_cols_per_coset,
             false,
             ntt_ctx,
             scratch_opt,
@@ -1372,7 +1373,7 @@ pub(crate) fn commit_trace_from_ntt_single_tree(
             )?;
         }
         crate::ops::blake2s::launch_leaves_kernel_from_ntt_multi_coset(
-            ntt_output_matrix.slice(),
+            &(ntt_output_matrix.slice())[offset..],
             leaves,
             log_values_per_leaf,
             src_cols_per_coset as u32,
@@ -1384,22 +1385,6 @@ pub(crate) fn commit_trace_from_ntt_single_tree(
             stream,
         )?;
     }
-    // } else {
-    //     let coset_index_base = 0;
-    //     let cosets_in_tile = 1usize << natural_log_lde_factor;
-    //     crate::ops::blake2s::launch_leaves_kernel_from_ntt_multi_coset(
-    //         ntt_output,
-    //         leaves,
-    //         log_values_per_leaf,
-    //         src_cols_per_coset as u32,
-    //         natural_log_lde_factor,
-    //         coset_index_base,
-    //         cosets_in_tile,
-    //         packed_leaf_count,
-    //         trace_len as u32,
-    //         stream,
-    //     )?;
-    // }
 
     // Single-tree node layers: build_merkle_tree_nodes operates on a flat
     // `[leaves | nodes]` slab. `layers_count - 1` because the leaf layer is

--- a/gpu/circuit_prover/src/prover/whir/mod.rs
+++ b/gpu/circuit_prover/src/prover/whir/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod kernels;
 use era_cudart::memory::memory_copy_async;
 use era_cudart::result::CudaResult;
 
+#[cfg(test)]
 use crate::allocator::tracker::AllocationPlacement;
 #[cfg(test)]
 use crate::ops::blake2s::Digest;
@@ -175,7 +176,6 @@ impl GpuWhirExtensionOracle {
         //     bit_reverse_in_place(&mut coeffs_matrix, stream)?;
         // }
 
-        let stream = context.get_exec_stream();
         let mut trace_holder = TraceHolder::new(
             total_leaf_count_log2,
             0,
@@ -192,41 +192,13 @@ impl GpuWhirExtensionOracle {
         // `commit_all_into_from_ntt`) reads the natural layout in place.
         let monomial_coeffs_slice = monomial_coeffs.slice();
         let monomial_coeffs_stride = monomial_coeffs.stride();
-        let device_properties = context.get_device_properties();
         let inputs_matrix =
             DeviceMatrixChunk::new(monomial_coeffs_slice, monomial_coeffs_stride, 0, trace_len);
-        let ntt_ctx = context.ntt_device_context();
-        // Recursive WHIR folds to a small trace (trace_len_log2 <= 13), the DIT
-        // forward-NTT range, which needs a pooled d-table scratch (len >= N).
-        // Allocate from the stream-ordered pool so this stays enqueue-only per
-        // the GPU scheduling contract; the handle outlives the launches below.
-        // Outside the DIT range the compact path ignores the scratch, so the
-        // allocation is skipped entirely.
-        let mut d_scratch = if trace_len_log2 <= 13 {
-            Some(context.alloc::<BF>(trace_len, AllocationPlacement::BestFit)?)
-        } else {
-            None
-        };
-        let scratch_opt = d_scratch.as_mut().map(|s| &mut s[..]);
-        {
-            let cosets_backing = trace_holder.get_uninit_consolidated_cosets_mut();
-            crate::ops::ntt::bitreversed_monomials_to_natural_evals_multi_coset(
-                &inputs_matrix,
-                cosets_backing,
-                trace_len_log2,
-                log_lde_factor as usize,
-                EXT4_DEGREE,
-                false,
-                ntt_ctx,
-                scratch_opt,
-                stream,
-                device_properties,
-            )?;
-        }
-        trace_holder.mark_cosets_materialized();
+
         match cap_target {
             CapTarget::OwnAllocation => {
-                trace_holder.commit_all_from_ntt(
+                trace_holder.whir_lde_and_commit_all(
+                    &inputs_matrix,
                     trace_len_log2 as u32,
                     log_lde_factor,
                     log_values_per_leaf,
@@ -236,7 +208,8 @@ impl GpuWhirExtensionOracle {
                 )?;
             }
             CapTarget::Slab(dst_u32) => {
-                trace_holder.commit_all_into_from_ntt(
+                trace_holder.whir_lde_and_commit_all_into(
+                    &inputs_matrix,
                     dst_u32,
                     trace_len_log2 as u32,
                     log_lde_factor,
@@ -247,6 +220,7 @@ impl GpuWhirExtensionOracle {
                 )?;
             }
         }
+        trace_holder.mark_cosets_materialized();
 
         Ok(Self {
             trace_holder,

--- a/gpu/circuit_prover/src/prover/whir/mod.rs
+++ b/gpu/circuit_prover/src/prover/whir/mod.rs
@@ -809,6 +809,8 @@ pub(crate) mod tests {
             make_test_context(2048, 64)
         };
 
+        const LDE_FACTOR: usize = 4;
+
         // Tests a range of parameters.
         for &log_coeff_size in log_coeff_sizes.iter() {
             for &values_per_leaf in values_per_leafs.iter() {
@@ -817,7 +819,7 @@ pub(crate) mod tests {
                 let cpu = cpu_extension_oracle_from_monomial_form(
                     &monomial_coeffs,
                     &twiddles,
-                    4,
+                    LDE_FACTOR,
                     values_per_leaf,
                     4,
                     transform_leaves_to_multilinear_coeffs,
@@ -825,7 +827,7 @@ pub(crate) mod tests {
                 );
                 let gpu = GpuWhirExtensionOracle::from_monomial_coeffs(
                     &monomial_coeffs,
-                    4,
+                    LDE_FACTOR,
                     values_per_leaf,
                     4,
                     transform_leaves_to_multilinear_coeffs,
@@ -833,7 +835,7 @@ pub(crate) mod tests {
                 )
                 .unwrap();
 
-                for coset_index in 0..4 {
+                for coset_index in 0..LDE_FACTOR {
                     // helpful for debugging
                     // let gpu_results = gpu.copy_coset_values(coset_index, &context);
                     // let cpu_results = cpu.cosets[coset_index].values_normal_order.column.to_vec();

--- a/gpu/ntt/src/ntt/mod.rs
+++ b/gpu/ntt/src/ntt/mod.rs
@@ -46,6 +46,7 @@ mod strategy;
 #[allow(dead_code)]
 pub use ntt::{
     bitreversed_monomials_to_natural_evals, bitreversed_monomials_to_natural_evals_multi_coset,
+    bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range,
     natural_evals_to_bitreversed_monomials,
 };
 #[cfg(test)]

--- a/gpu/ntt/src/ntt/ntt.rs
+++ b/gpu/ntt/src/ntt/ntt.rs
@@ -1214,14 +1214,16 @@ pub fn monomials_to_evals_2_pass(
 
 /// Multi-coset variant of `bitreversed_monomials_to_natural_evals`.
 ///
-/// Runs the same forward NTT across the full power-of-two LDE — all
-/// `num_cosets = 1 << log_lde_factor` cosets, starting at coset 0 (the coset
-/// range is always full and pow2-aligned, derived from `log_lde_factor`; there
-/// is no caller-controlled coset subrange). For the compact 1-pass range
-/// (`log_n <= 12`) all cosets are batched into one launch via `gridDim.x`,
-/// eliminating the per-coset launch overhead that previously dominated
-/// small-`log_n` work. For larger `log_n` (2-pass-compact-initial, 3-pass
-/// forward) cosets are batched up to the L2-pressure cap from the strategy.
+/// Runs the same forward NTT across the full power-of-two LDE: all
+/// `num_cosets = 1 << log_lde_factor` cosets, starting at coset 0. Use
+/// [`bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range`] to
+/// process a caller-selected power-of-two coset subrange.
+///
+/// For the compact 1-pass range (`log_n <= 12`) all cosets are batched into one
+/// launch via `gridDim.x`, eliminating the per-coset launch overhead that
+/// previously dominated small-`log_n` work. For larger `log_n`
+/// (2-pass-compact-initial, 3-pass forward) cosets are batched up to the
+/// L2-pressure cap from the strategy.
 ///
 /// Output layout: coset-major outer, column-major inner. Coset k's columns
 /// occupy `outputs[(k * num_cols_per_coset_stride + col) * trace_len ..]` for
@@ -1243,13 +1245,100 @@ pub fn bitreversed_monomials_to_natural_evals_multi_coset(
     stream: &CudaStream,
     device_properties: &DeviceProperties,
 ) -> CudaResult<()> {
+    let num_cosets = 1usize << log_lde_factor;
+    bitreversed_monomials_to_natural_evals_multi_coset_impl(
+        inputs_matrix,
+        outputs,
+        log_n,
+        log_lde_factor,
+        num_cosets,
+        0,
+        num_cols_per_coset_stride,
+        transposed_monomials,
+        ntt_ctx,
+        d_table_scratch,
+        stream,
+        device_properties,
+    )
+}
+
+/// Multi-coset forward NTT over a caller-selected coset range.
+///
+/// `log_lde_factor` still describes the full LDE domain and therefore the
+/// coset-factor shift. `num_cosets` is the number of local cosets written to
+/// `outputs`, while `coset_index_base` is the global coset index used for the
+/// first local coset's coset factor. Both caller-controlled values must be
+/// powers of two, and the selected range must fit within the full LDE coset
+/// domain.
+#[allow(dead_code)]
+pub fn bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range(
+    inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    outputs: &mut DeviceSlice<BF>,
+    log_n: usize,
+    log_lde_factor: usize,
+    num_cosets: usize,
+    coset_index_base: usize,
+    num_cols_per_coset_stride: usize,
+    transposed_monomials: bool,
+    ntt_ctx: &crate::ntt_twiddles::DeviceContext,
+    d_table_scratch: Option<&mut DeviceSlice<BF>>,
+    stream: &CudaStream,
+    device_properties: &DeviceProperties,
+) -> CudaResult<()> {
+    assert!(
+        num_cosets.is_power_of_two(),
+        "num_cosets must be a power of 2 (got {num_cosets})"
+    );
+    // assert!(
+    //     (coset_index_base == 0) || coset_index_base.is_power_of_two(),
+    //     "coset_index_base must be a power of 2 (got {coset_index_base})"
+    // );
+    bitreversed_monomials_to_natural_evals_multi_coset_impl(
+        inputs_matrix,
+        outputs,
+        log_n,
+        log_lde_factor,
+        num_cosets,
+        coset_index_base,
+        num_cols_per_coset_stride,
+        transposed_monomials,
+        ntt_ctx,
+        d_table_scratch,
+        stream,
+        device_properties,
+    )
+}
+
+fn bitreversed_monomials_to_natural_evals_multi_coset_impl(
+    inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    outputs: &mut DeviceSlice<BF>,
+    log_n: usize,
+    log_lde_factor: usize,
+    num_cosets: usize,
+    coset_index_base: usize,
+    num_cols_per_coset_stride: usize,
+    transposed_monomials: bool,
+    ntt_ctx: &crate::ntt_twiddles::DeviceContext,
+    d_table_scratch: Option<&mut DeviceSlice<BF>>,
+    stream: &CudaStream,
+    device_properties: &DeviceProperties,
+) -> CudaResult<()> {
     assert!(
         log_n + log_lde_factor <= OMEGA_LOG_ORDER as usize,
         "log_n ({log_n}) + log_lde_factor ({log_lde_factor}) > OMEGA_LOG_ORDER ({OMEGA_LOG_ORDER})",
     );
-    // Coset range is always the full power-of-two LDE: structurally pow2, base 0.
-    let num_cosets = 1usize << log_lde_factor;
-    let coset_index_base = 0usize;
+    assert!(
+        num_cosets.is_power_of_two(),
+        "num_cosets must be a power of 2 (got {num_cosets})"
+    );
+    let full_num_cosets = 1usize << log_lde_factor;
+    let coset_index_end = coset_index_base
+        .checked_add(num_cosets)
+        .expect("coset_index_base + num_cosets overflow");
+    assert!(
+        coset_index_end <= full_num_cosets,
+        "coset range [{coset_index_base}, {coset_index_end}) exceeds full LDE coset count {full_num_cosets}",
+    );
     let trace_len = 1usize << log_n;
     let num_cols = inputs_matrix.cols();
     assert!(

--- a/gpu/ntt/src/ntt/tests/mod.rs
+++ b/gpu/ntt/src/ntt/tests/mod.rs
@@ -761,17 +761,32 @@ compact_parity_test!(compact_monomials_to_evals_log_n_20, 20);
 #[cfg(not(no_cuda))]
 #[allow(dead_code)]
 fn run_multi_coset_monomials_to_evals_parity(log_n: usize, num_cosets: usize) {
+    let log_lde_factor = num_cosets.trailing_zeros() as usize;
+    assert_eq!(1usize << log_lde_factor, num_cosets);
+    run_multi_coset_monomials_to_evals_parity_for_range(log_n, log_lde_factor, 0, num_cosets);
+}
+
+#[cfg(not(no_cuda))]
+#[allow(dead_code)]
+fn run_multi_coset_monomials_to_evals_parity_for_range(
+    log_n: usize,
+    log_lde_factor: usize,
+    coset_index_base: usize,
+    num_cosets: usize,
+) {
     use super::ntt::{
         monomials_to_evals_2_pass_compact_initial, monomials_to_evals_compact_1_pass,
     };
     use super::{
         bitreversed_monomials_to_natural_evals, bitreversed_monomials_to_natural_evals_multi_coset,
+        bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range,
     };
     use crate::ntt_twiddles::OMEGA_LOG_ORDER;
     use gpu_core::primitives::device_structures::{DeviceMatrixChunk, DeviceMatrixChunkMut};
 
-    let log_lde_factor = num_cosets.trailing_zeros() as usize;
-    assert_eq!(1usize << log_lde_factor, num_cosets);
+    assert!(num_cosets.is_power_of_two());
+    assert!(coset_index_base == 0 || coset_index_base.is_power_of_two());
+    assert!(coset_index_base + num_cosets <= (1usize << log_lde_factor));
     const NUM_COLS: usize = 4;
 
     let context = make_context();
@@ -804,19 +819,37 @@ fn run_multi_coset_monomials_to_evals_parity(log_n: usize, num_cosets: usize) {
         } else {
             None
         };
-        bitreversed_monomials_to_natural_evals_multi_coset(
-            &inputs_matrix,
-            &mut candidate_device[..],
-            log_n,
-            log_lde_factor,
-            NUM_COLS,
-            false,
-            context.device_context(),
-            scratch_opt,
-            stream,
-            device_props,
-        )
-        .unwrap();
+        if coset_index_base == 0 && num_cosets == (1usize << log_lde_factor) {
+            bitreversed_monomials_to_natural_evals_multi_coset(
+                &inputs_matrix,
+                &mut candidate_device[..],
+                log_n,
+                log_lde_factor,
+                NUM_COLS,
+                false,
+                context.device_context(),
+                scratch_opt,
+                stream,
+                device_props,
+            )
+            .unwrap();
+        } else {
+            bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range(
+                &inputs_matrix,
+                &mut candidate_device[..],
+                log_n,
+                log_lde_factor,
+                num_cosets,
+                coset_index_base,
+                NUM_COLS,
+                false,
+                context.device_context(),
+                scratch_opt,
+                stream,
+                device_props,
+            )
+            .unwrap();
+        }
     }
 
     {
@@ -829,8 +862,9 @@ fn run_multi_coset_monomials_to_evals_parity(log_n: usize, num_cosets: usize) {
         // log_n > 13 (no DIT) the existing single-coset entry stays independent.
         let coset_factor_shift = (OMEGA_LOG_ORDER as usize - log_n - log_lde_factor) as u32;
         let reference_slice = &mut reference_device[..];
-        for coset_index in 0..num_cosets {
-            let chunk_start = coset_index * cols_size;
+        for coset_offset in 0..num_cosets {
+            let coset_index = coset_index_base + coset_offset;
+            let chunk_start = coset_offset * cols_size;
             let chunk_end = chunk_start + cols_size;
             let inputs_matrix = DeviceMatrixChunk::new(&inputs_device[..], stride, 0, n);
             let mut ref_chunk = DeviceMatrixChunkMut::new(
@@ -892,14 +926,14 @@ fn run_multi_coset_monomials_to_evals_parity(log_n: usize, num_cosets: usize) {
     memory_copy_async(&mut reference_host, &reference_device, stream).unwrap();
     stream.synchronize().unwrap();
 
-    for coset_index in 0..num_cosets {
+    for coset_offset in 0..num_cosets {
         for col in 0..NUM_COLS {
-            let base = coset_index * cols_size + col * stride;
+            let base = coset_offset * cols_size + col * stride;
             for k in 0..n {
                 assert_eq!(
                     candidate_host[base + k],
                     reference_host[base + k],
-                    "log_n={log_n}, num_cosets={num_cosets}, coset={coset_index}, col={col}, k={k}"
+                    "log_n={log_n}, log_lde_factor={log_lde_factor}, num_cosets={num_cosets}, coset_index_base={coset_index_base}, coset_offset={coset_offset}, col={col}, k={k}"
                 );
             }
         }
@@ -917,8 +951,38 @@ macro_rules! multi_coset_parity_test {
     };
 }
 
+macro_rules! multi_coset_range_parity_test {
+    ($name:ident, $log_n:expr, $log_lde_factor:expr, $coset_index_base:expr, $num_cosets:expr) => {
+        #[test]
+        #[cfg(not(no_cuda))]
+        #[serial]
+        fn $name() {
+            run_multi_coset_monomials_to_evals_parity_for_range(
+                $log_n,
+                $log_lde_factor,
+                $coset_index_base,
+                $num_cosets,
+            );
+        }
+    };
+}
+
 // Compact 1-pass range: kernel batches all cosets into one launch.
 multi_coset_parity_test!(multi_coset_monomials_to_evals_log_n_4_cosets_4, 4, 4);
+multi_coset_range_parity_test!(
+    multi_coset_monomials_to_evals_log_n_8_cosets_4_base_4,
+    8,
+    4,
+    4,
+    4
+);
+multi_coset_range_parity_test!(
+    multi_coset_monomials_to_evals_log_n_8_cosets_23_base_4,
+    23,
+    4,
+    4,
+    4
+);
 multi_coset_parity_test!(multi_coset_monomials_to_evals_log_n_7_cosets_8, 7, 8);
 multi_coset_parity_test!(multi_coset_monomials_to_evals_log_n_8_cosets_32, 8, 32);
 // Multi-coset parity over the small-`log_n` range (2..8): the candidate runs


### PR DESCRIPTION
## What ❔

Chunks the LDE->leaf transform->leaf hash operations over cosets so each chunk stays resident in L2 for all kernels.

## Why ❔

Performance, hopefully.

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.