### PR TITLE
fix: bind recursive output and reduced load alignment

### DIFF
--- a/cs/src/machine/ops/load.rs
+++ b/cs/src/machine/ops/load.rs
@@ -8,6 +8,14 @@ pub const LOAD_HALF_WORD_OP_KEY: DecoderInstructionVariantsKey =
 pub const SIGN_EXTEND_ON_LOAD_OP_KEY: DecoderInstructionVariantsKey =
     DecoderInstructionVariantsKey("LB/LW");
 
+fn reduced_lw_alignment_constraint<F: PrimeField>(
+    bit_0: Term<F>,
+    bit_1: Term<F>,
+    execute_family: Boolean,
+) -> Constraint<F> {
+    (bit_0 + bit_1) * execute_family.get_terms()
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LoadOp<const SUPPORT_SIGNED: bool, const SUPPORT_LESS_THAN_WORD: bool>;
 
@@ -72,6 +80,44 @@ impl<const SUPPORT_SIGNED: bool, const SUPPORT_LESS_THAN_WORD: bool> DecodableMa
         };
 
         Ok(params)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use field::Mersenne31Field;
+
+    use super::*;
+
+    fn reduced_lw_alignment_value(low_bits: u64, execute: bool) -> Option<u64> {
+        let bit_0 = low_bits & 1;
+        let bit_1 = (low_bits >> 1) & 1;
+        let mut constraint = reduced_lw_alignment_constraint::<Mersenne31Field>(
+            Term::from(bit_0),
+            Term::from(bit_1),
+            Boolean::Constant(execute),
+        );
+        constraint.normalize();
+        if constraint.terms.is_empty() {
+            None
+        } else {
+            Some(constraint.as_constant().as_u64_reduced())
+        }
+    }
+
+    #[test]
+    fn reduced_lw_alignment_constraint_allows_only_zero_low_bits_when_executed() {
+        assert_eq!(reduced_lw_alignment_value(0b00, true), None);
+        assert_eq!(reduced_lw_alignment_value(0b01, true), Some(1));
+        assert_eq!(reduced_lw_alignment_value(0b10, true), Some(1));
+        assert_eq!(reduced_lw_alignment_value(0b11, true), Some(2));
+    }
+
+    #[test]
+    fn reduced_lw_alignment_constraint_is_inactive_when_not_executed() {
+        for low_bits in 0..=0b11 {
+            assert_eq!(reduced_lw_alignment_value(low_bits, false), None);
+        }
     }
 }
 
@@ -398,9 +444,11 @@ impl<const SUPPORT_SIGNED: bool, const SUPPORT_LESS_THAN_WORD: bool>
                 TableType::MemoryOffsetGetBits.to_num(),
                 execute_family,
             );
-            cs.add_constraint(
-                (Term::from(bit_0) + Term::from(bit_1)) * execute_family.get_terms(),
-            );
+            cs.add_constraint(reduced_lw_alignment_constraint(
+                Term::from(bit_0),
+                Term::from(bit_1),
+                execute_family,
+            ));
 
             let [is_ram_range, address_high_bits_for_rom] = opt_ctx.append_lookup_relation(
                 cs,

--- a/cs/src/machine/ops/load.rs
+++ b/cs/src/machine/ops/load.rs
@@ -392,6 +392,16 @@ impl<const SUPPORT_SIGNED: bool, const SUPPORT_LESS_THAN_WORD: bool>
             let (unaligned_address, _of_flag) =
                 opt_ctx.append_add_relation(src1, imm, execute_family, cs);
 
+            let [bit_0, bit_1] = opt_ctx.append_lookup_relation(
+                cs,
+                &[unaligned_address.0[0].get_variable()],
+                TableType::MemoryOffsetGetBits.to_num(),
+                execute_family,
+            );
+            cs.add_constraint(
+                (Term::from(bit_0) + Term::from(bit_1)) * execute_family.get_terms(),
+            );
+
             let [is_ram_range, address_high_bits_for_rom] = opt_ctx.append_lookup_relation(
                 cs,
                 &[unaligned_address.0[1].get_variable()],

--- a/tools/verifier/src/main.rs
+++ b/tools/verifier/src/main.rs
@@ -187,9 +187,10 @@ unsafe fn workload() -> ! {
             // verify first proof & use it as the seed for the rolling hash
             //
             // the proof's outputs are as follows:
-            // output[0..8] - the actual output of the circuit
+            // output[0..7] - output words bound by the rolling hash
+            // output[7] - reserved SNARK-compatibility word; must be zero
             // output[8..16] - the verification key (should be the same across all proofs, checked inside merge_recursive_circuit_output)
-            // merging is done over inputs [0..8], whilst key is not modified (being copied over and over)
+            // merging is done over output[0..7], whilst key is not modified (being copied over and over)
             let mut rolling_hash = full_statement_verifier::verify_recursion_layer();
 
             // iterate over remaining circuits
@@ -218,16 +219,14 @@ unsafe fn workload() -> ! {
 /// TL;DR; Keccaks the two outputs together.
 ///
 /// Note, a proof is structured as follows:
-/// - first 8 u32s are the actual proof output
-/// - last 8 u32s are the verification key identifier (proving chain)
+/// - words 0 through 6 are output words bound by the rolling hash
+/// - word 7 is reserved for SNARK compatibility and must be zero
+/// - words 8 through 15 are the verification key identifier (proving chain)
 fn merge_recursive_circuit_output(first: [u32; 16], second: [u32; 16]) -> [u32; 16] {
     // Proving chain must be equal
     for i in 8..16 {
         assert_eq!(first[i], second[i], "Proving chains must be equal");
     }
-
-    // To make it compatible with our SNARK - we'll assume that last register (7th) is 0 (as snark ignores that too).
-    // and we'll actually shift them all by 1.
 
     assert_eq!(first[7], 0, "Recursive proof output word 7 must be zero");
     assert_eq!(second[7], 0, "Recursive proof output word 7 must be zero");

--- a/tools/verifier/src/main.rs
+++ b/tools/verifier/src/main.rs
@@ -246,8 +246,9 @@ fn merge_recursive_circuit_output(first: [u32; 16], second: [u32; 16]) -> [u32; 
     }
 
     let mut result = [0u32; 16];
-    // merged outputs
-    result[0..8].copy_from_slice(&hasher.finalize());
+    // merged outputs. Word 7 stays reserved for SNARK compatibility, so rolling merges keep the
+    // same shape as fresh recursive proof outputs.
+    result[0..7].copy_from_slice(&hasher.finalize()[0..7]);
     // same vk
     result[8..16].copy_from_slice(&first[8..16]);
 
@@ -256,7 +257,10 @@ fn merge_recursive_circuit_output(first: [u32; 16], second: [u32; 16]) -> [u32; 
 
 #[cfg(all(
     test,
-    any(feature = "universal_circuit", feature = "universal_circuit_no_delegation")
+    any(
+        feature = "universal_circuit",
+        feature = "universal_circuit_no_delegation"
+    )
 ))]
 mod tests {
     use super::*;
@@ -275,6 +279,23 @@ mod tests {
         let result = merge_recursive_circuit_output(first, second);
 
         assert_eq!(&result[8..16], &first[8..16]);
+        assert_eq!(result[7], 0);
+    }
+
+    #[test]
+    fn merge_recursive_circuit_output_can_chain_rolling_outputs() {
+        let mut first = recursive_output();
+        let mut second = recursive_output();
+        let mut third = recursive_output();
+        first[0] = 1;
+        second[0] = 2;
+        third[0] = 3;
+
+        let rolling_hash = merge_recursive_circuit_output(first, second);
+        let result = merge_recursive_circuit_output(rolling_hash, third);
+
+        assert_eq!(&result[8..16], &third[8..16]);
+        assert_eq!(result[7], 0);
     }
 
     #[test]

--- a/tools/verifier/src/main.rs
+++ b/tools/verifier/src/main.rs
@@ -254,6 +254,50 @@ fn merge_recursive_circuit_output(first: [u32; 16], second: [u32; 16]) -> [u32; 
     result
 }
 
+#[cfg(all(
+    test,
+    any(feature = "universal_circuit", feature = "universal_circuit_no_delegation")
+))]
+mod tests {
+    use super::*;
+
+    fn recursive_output() -> [u32; 16] {
+        let mut output = [0u32; 16];
+        output[8..16].copy_from_slice(&[11, 12, 13, 14, 15, 16, 17, 18]);
+        output
+    }
+
+    #[test]
+    fn merge_recursive_circuit_output_accepts_zero_word_7() {
+        let first = recursive_output();
+        let second = recursive_output();
+
+        let result = merge_recursive_circuit_output(first, second);
+
+        assert_eq!(&result[8..16], &first[8..16]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Recursive proof output word 7 must be zero")]
+    fn merge_recursive_circuit_output_rejects_nonzero_first_word_7() {
+        let mut first = recursive_output();
+        let second = recursive_output();
+        first[7] = 1;
+
+        merge_recursive_circuit_output(first, second);
+    }
+
+    #[test]
+    #[should_panic(expected = "Recursive proof output word 7 must be zero")]
+    fn merge_recursive_circuit_output_rejects_nonzero_second_word_7() {
+        let first = recursive_output();
+        let mut second = recursive_output();
+        second[7] = 1;
+
+        merge_recursive_circuit_output(first, second);
+    }
+}
+
 #[cfg(feature = "verifier_tests")]
 unsafe fn workload() -> ! {
     use core::mem::MaybeUninit;

--- a/tools/verifier/src/main.rs
+++ b/tools/verifier/src/main.rs
@@ -229,7 +229,9 @@ fn merge_recursive_circuit_output(first: [u32; 16], second: [u32; 16]) -> [u32; 
     // To make it compatible with our SNARK - we'll assume that last register (7th) is 0 (as snark ignores that too).
     // and we'll actually shift them all by 1.
 
-    // TODO: in the future, check explicitly that output1[7] && output2[7] == 0.
+    assert_eq!(first[7], 0, "Recursive proof output word 7 must be zero");
+    assert_eq!(second[7], 0, "Recursive proof output word 7 must be zero");
+
     let mut hasher = Keccak32::new();
     hasher.update(&[0u32]);
 
@@ -237,7 +239,6 @@ fn merge_recursive_circuit_output(first: [u32; 16], second: [u32; 16]) -> [u32; 
         hasher.update(&[*val]);
     }
 
-    // TODO: in the future, check explicitly that output1[7] && output2[7] == 0.
     hasher.update(&[0u32]);
 
     for val in &second[0..7] {


### PR DESCRIPTION
## What ❔

Fixes #314 and #315.

This rejects recursive proof outputs where word 7 is nonzero before merging outputs, matching the existing assumption used by the combiner.

It also constrains reduced `LW` word loads to aligned addresses by requiring the low address bits to be zero before the RAM query is accepted.

## Why ❔

The recursive combiner previously ignored output word 7 while assuming it was zero. Reduced `LW` constraints also accepted unaligned word reads. Both cases allowed proof data to satisfy constraints that the verifier logic intended to rule out.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.

Testing: `git diff --check` and targeted source review only. No local compile or tests; verification should run in CI.
