### PR TITLE
fix: verifier, decoder, and memory review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,19 +149,19 @@ jobs:
         run: |
           BIN="$PWD/examples/opcode_smoke/app.bin"
           TEXT="$PWD/examples/opcode_smoke/app.text"
-          verify_output="$(./target/release/cli verify --proof output/base.json --bin "$BIN" --text "$TEXT")"
+          verify_output="$(./target/release/cli verify --proof output/base.json --bin "$BIN" --text "$TEXT" --security-level ${{ matrix.security_level }} --target base)"
           echo "$verify_output"
           echo "$verify_output" | grep -F "output=[1330660171, 0, 0, 42, 2374183677, 305419896, 524296, 0"
       - name: Continue to recursion unified
         run: |
           BIN="$PWD/examples/opcode_smoke/app.bin"
           TEXT="$PWD/examples/opcode_smoke/app.text"
-          ./target/release/cli continue-proof --proof output/base.json --bin "$BIN" --text "$TEXT" --target recursion-unified --cpu-cycles-bound 16777216 --cpu-worker-threads 8 --output-dir output --output-file recursion_unified.json
+          ./target/release/cli continue-proof --proof output/base.json --bin "$BIN" --text "$TEXT" --security-level ${{ matrix.security_level }} --target recursion-unified --cpu-cycles-bound 16777216 --cpu-worker-threads 8 --output-dir output --output-file recursion_unified.json
       - name: Verify recursion unified
         run: |
           BIN="$PWD/examples/opcode_smoke/app.bin"
           TEXT="$PWD/examples/opcode_smoke/app.text"
-          verify_output="$(./target/release/cli verify --proof output/recursion_unified.json --bin "$BIN" --text "$TEXT")"
+          verify_output="$(./target/release/cli verify --proof output/recursion_unified.json --bin "$BIN" --text "$TEXT" --security-level ${{ matrix.security_level }} --target recursion-unified)"
           echo "$verify_output"
           echo "$verify_output" | grep -F "output=[1330660171, 0, 0, 42, 2374183677, 305419896, 524296, 0"
 

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -141,7 +141,9 @@ jobs:
           verify_output="$(zksync-airbender-cli/cli verify \
             --proof output/proof.json \
             --bin "$BIN" \
-            --text "$TEXT")"
+            --text "$TEXT" \
+            --security-level ${{ matrix.security_level }} \
+            --target recursion-unified)"
           echo "$verify_output"
           echo "$verify_output" | grep -F "output=[1330660171, 0, 0, 42, 2374183677, 305419896, 524296, 0"
 

--- a/common_constants/src/delegation_types/keccak_special5.rs
+++ b/common_constants/src/delegation_types/keccak_special5.rs
@@ -101,7 +101,7 @@ mod tests {
         let manifest_path = fixture_crate.join("Cargo.toml");
 
         let disassembly = run_command(&format!(
-            "cargo objdump --manifest-path {} --locked --lib --release --target {RISCV_TARGET} -- --disassemble --no-show-raw-insn",
+            "cargo objdump --manifest-path {} --offline --locked --lib --release --target {RISCV_TARGET} -- --disassemble --no-show-raw-insn",
             manifest_path.display()
         ));
 
@@ -116,8 +116,16 @@ mod tests {
     fn create_codegen_fixture() -> tempfile::TempDir {
         let fixture_dir = tempfile::tempdir().unwrap();
         let fixture_crate = fixture_dir.path();
+        let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("common_constants must live under the workspace root");
 
         fs::create_dir_all(fixture_crate.join("src")).unwrap();
+        fs::copy(
+            workspace_root.join("Cargo.lock"),
+            fixture_crate.join("Cargo.lock"),
+        )
+        .unwrap();
 
         // This fixture deliberately stays below the SHA3 layer. It exercises the
         // migrated ABI surface directly and leaves permutation correctness tests

--- a/cs/src/machine/ops/unrolled/decoder/shift_binop_csrrw.rs
+++ b/cs/src/machine/ops/unrolled/decoder/shift_binop_csrrw.rs
@@ -175,11 +175,12 @@ impl OpcodeFamilyDecoder for ShiftBinaryCsrrwDecoder {
                 validate_csr = true;
                 // also check that we only have rs1 == 0 or rd == 0, or both
                 if imm == NON_DETERMINISM_CSR {
-                    assert!(rs1_index == 0 || rs2_index == 0);
-                } else {
+                    if !(rs1_index == 0 || rd_index == 0) {
+                        return Err(());
+                    }
+                } else if !(rs1_index == 0 && rs2_index == 0 && rd_index == 0) {
                     // works for all our precompiles, and UNIMP opcode
-                    assert!(rs1_index == 0);
-                    assert!(rs2_index == 0);
+                    return Err(());
                 }
             }
             // (OPERATION_SYSTEM, 0b001, func7) if func7 & 0x40 == 0 => {

--- a/docs/end_to_end.md
+++ b/docs/end_to_end.md
@@ -46,7 +46,9 @@ Notes:
 ```shell
 cargo run --release -p cli -- verify \
   --proof /tmp/proof.json \
-  --bin examples/hashed_fibonacci/app.bin
+  --bin examples/hashed_fibonacci/app.bin \
+  --security-level 80 \
+  --target recursion-unified
 ```
 
 The verifier prints the public output on success. It should match the output from step 1.
@@ -66,6 +68,7 @@ cargo run --release -p cli -- prove \
 cargo run --release -p cli -- continue-proof \
   --proof /tmp/base.json \
   --bin examples/hashed_fibonacci/app.bin \
+  --security-level 80 \
   --target recursion-unified \
   --output-dir /tmp \
   --output-file proof.json

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -89,6 +89,7 @@ cargo run --release -p cli -- prove \
 cargo run --release -p cli -- continue-proof \
   --proof output/base.json \
   --bin examples/basic_fibonacci/app.bin \
+  --security-level 80 \
   --target recursion-unified \
   --output-dir output \
   --output-file recursion_unified.json
@@ -101,7 +102,11 @@ cargo run --release -p cli -- continue-proof \
 The CLI verifies a single proof artifact at a time:
 
 ```shell
-cargo run --release -p cli -- verify --proof output/proof.json --bin examples/basic_fibonacci/app.bin
+cargo run --release -p cli -- verify \
+  --proof output/proof.json \
+  --bin examples/basic_fibonacci/app.bin \
+  --security-level 80 \
+  --target recursion-unified
 ```
 
 Verification checks:

--- a/prover/src/tests/circuit/decoder_negative.rs
+++ b/prover/src/tests/circuit/decoder_negative.rs
@@ -11,7 +11,7 @@
 //! the decoder leaves the slot empty and produces the default witness data with opcode_family_bits == 0.
 //! Both bytecode_preprocessor.rs:53 propagates an Err(()) from define_decoder_subspace.
 
-use super::encoding::{encode_b, encode_i, encode_r, encode_r_system, encode_u};
+use super::encoding::{encode_b, encode_csrrw, encode_i, encode_r, encode_r_system, encode_u};
 use super::*;
 
 use cs::machine::ops::unrolled::decoder::{
@@ -201,6 +201,32 @@ fn test_shift_binop_rejects_invalid_csr_funct3() {
         SHIFT_IDX,
         enc,
         "Shift: SYSTEM funct3=0b010 (CSRRS, not CSRRW)",
+    );
+}
+
+#[test]
+fn test_shift_binop_rejects_illegal_non_determinism_csrrw_operands() {
+    let enc = encode_csrrw(1, 2, common_constants::NON_DETERMINISM_CSR);
+    assert_decoder_rejects(
+        Box::new(ShiftBinaryCsrrwDecoder),
+        SHIFT_IDX,
+        enc,
+        "Shift: CSRRW(non-determinism) with rd!=x0 and rs1!=x0",
+    );
+}
+
+#[test]
+fn test_shift_binop_rejects_illegal_delegation_csrrw_rd() {
+    let enc = encode_csrrw(
+        1,
+        0,
+        common_constants::delegation_types::blake2s_with_control::BLAKE2S_DELEGATION_CSR_REGISTER,
+    );
+    assert_decoder_rejects(
+        Box::new(ShiftBinaryCsrrwDecoder),
+        SHIFT_IDX,
+        enc,
+        "Shift: delegation CSRRW with rd!=x0",
     );
 }
 

--- a/prover/src/tests/circuit/shift_binop.rs
+++ b/prover/src/tests/circuit/shift_binop.rs
@@ -267,7 +267,10 @@ fn test_csrrw_non_determinism_read() {
 fn test_csrrw_rejects_unsupported_csr() {
     const UNSUPPORTED_CSR: u16 = 0xC00; // RV32I cycle CSR
 
-    let rd_reg: u8 = 1;
+    // Non-non-determinism CSRRW encodings are decoder-legal only in the
+    // delegation-style x0/x0 form. Use that shape here so this test still
+    // reaches the circuit and exercises the SpecialCSRProperties rejection.
+    let rd_reg: u8 = 0;
     let rs1_reg: u8 = 0;
 
     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -76,12 +76,18 @@ cargo run --release -p cli --features "gpu" -- prove \
 cargo run --release -p cli -- \
   verify \
   --proof output/proof.json \
-  --bin examples/basic_fibonacci/app.bin
+  --bin examples/basic_fibonacci/app.bin \
+  --security-level 80 \
+  --target recursion-unified
 ```
+
+For `verify` and `continue-proof`, treat `--security-level` and `--target` as trusted
+inputs from the caller. The artifact's embedded metadata is only checked against that
+policy; it is not itself authoritative.
 
 Verification checks:
 
-- security level consistency inside the artifact and the selected recursion layer,
+- caller-supplied security level and target consistency,
 - program hash binding (`program_bin_keccak`, `program_text_keccak`),
 - recursion chain hash consistency (for recursion targets),
 - proof validity in the selected layer.
@@ -101,18 +107,23 @@ cargo run --release -p cli -- prove \
 
 cargo run --release -p cli -- verify \
   --proof output/base.json \
-  --bin examples/basic_fibonacci/app.bin
+  --bin examples/basic_fibonacci/app.bin \
+  --security-level 80 \
+  --target base
 
 cargo run --release -p cli -- continue-proof \
   --proof output/base.json \
   --bin examples/basic_fibonacci/app.bin \
+  --security-level 80 \
   --target recursion-unified \
   --output-dir output \
   --output-file recursion_unified.json
 
 cargo run --release -p cli -- verify \
   --proof output/recursion_unified.json \
-  --bin examples/basic_fibonacci/app.bin
+  --bin examples/basic_fibonacci/app.bin \
+  --security-level 80 \
+  --target recursion-unified
 ```
 
 ## Prove Batch

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -137,6 +137,10 @@ enum Commands {
         bin: String,
         #[arg(long)]
         text: Option<String>,
+        // Continuation policy is part of the trust boundary and must be supplied
+        // explicitly rather than inherited from prover-controlled artifact metadata.
+        #[arg(long, value_enum)]
+        security_level: SecurityLevel,
         #[arg(long, default_value = "output")]
         output_dir: String,
         #[arg(long, default_value = "proof.json")]
@@ -158,6 +162,12 @@ enum Commands {
         bin: String,
         #[arg(long)]
         text: Option<String>,
+        // Verification policy is trusted caller input, so we require an explicit
+        // security level and target instead of defaulting or trusting the artifact.
+        #[arg(long, value_enum)]
+        security_level: SecurityLevel,
+        #[arg(long, value_enum)]
+        target: ProofTarget,
     },
     /// Run binary via the transpiler VM.
     Run {
@@ -392,6 +402,7 @@ fn main() {
             proof,
             bin,
             text,
+            security_level,
             output_dir,
             output_file,
             target,
@@ -401,9 +412,8 @@ fn main() {
         } => {
             let input_artifact: ProofArtifact = deserialize_from_file(&proof);
             let source = ProgramSource::from_paths(bin, text);
-            // Continuation inherits the security schedule from the persisted artifact.
             let prover_config = make_prover_config(
-                input_artifact.security_level,
+                security_level,
                 target,
                 Some(ProverBackend::Cpu),
                 cpu_cycles_bound,
@@ -420,11 +430,18 @@ fn main() {
 
             write_artifact(&artifact, &output_dir, &output_file);
         }
-        Commands::Verify { proof, bin, text } => {
+        Commands::Verify {
+            proof,
+            bin,
+            text,
+            security_level,
+            target,
+        } => {
             let artifact: ProofArtifact = deserialize_from_file(&proof);
             let source = ProgramSource::from_paths(bin, text);
-            let output = cli_lib::prover_utils::verify_artifact(&artifact, &source)
-                .unwrap_or_else(|e| panic!("Verification failed: {}", e));
+            let output =
+                cli_lib::prover_utils::verify_artifact(&artifact, &source, security_level, target)
+                    .unwrap_or_else(|e| panic!("Verification failed: {}", e));
             println!("PROOF IS VALID. output={:?}", output);
         }
         Commands::Run {
@@ -537,4 +554,109 @@ fn run_binary_with_decoder<D: DecodingOptions>(
     );
 
     (state.registers.map(|register| register.value), finished)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::error::ErrorKind;
+
+    #[test]
+    fn verify_requires_security_level() {
+        let err = match Cli::try_parse_from([
+            "cli",
+            "verify",
+            "--proof",
+            "proof.json",
+            "--bin",
+            "program.bin",
+            "--target",
+            "base",
+        ]) {
+            Ok(_) => panic!("verify must require a trusted security level"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+        assert!(
+            err.to_string().contains("--security-level"),
+            "unexpected clap error: {err}"
+        );
+    }
+
+    #[test]
+    fn verify_requires_target() {
+        let err = match Cli::try_parse_from([
+            "cli",
+            "verify",
+            "--proof",
+            "proof.json",
+            "--bin",
+            "program.bin",
+            "--security-level",
+            "80",
+        ]) {
+            Ok(_) => panic!("verify must require a trusted target"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+        assert!(
+            err.to_string().contains("--target"),
+            "unexpected clap error: {err}"
+        );
+    }
+
+    #[test]
+    fn continue_proof_requires_security_level() {
+        let err = match Cli::try_parse_from([
+            "cli",
+            "continue-proof",
+            "--proof",
+            "proof.json",
+            "--bin",
+            "program.bin",
+        ]) {
+            Ok(_) => panic!("continue-proof must require a trusted security level"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+        assert!(
+            err.to_string().contains("--security-level"),
+            "unexpected clap error: {err}"
+        );
+    }
+
+    #[test]
+    fn verify_accepts_explicit_trusted_policy() {
+        let cli = Cli::try_parse_from([
+            "cli",
+            "verify",
+            "--proof",
+            "proof.json",
+            "--bin",
+            "program.bin",
+            "--security-level",
+            "100",
+            "--target",
+            "recursion-unified",
+        ])
+        .expect("verify should accept explicit trusted policy flags");
+
+        match cli.command {
+            Commands::Verify {
+                security_level,
+                target,
+                ..
+            } => {
+                assert_eq!(security_level, SecurityLevel::Security100);
+                assert_eq!(target, ProofTarget::RecursionUnified);
+            }
+            other => panic!(
+                "expected verify command, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    }
 }

--- a/tools/cli/src/prover_utils.rs
+++ b/tools/cli/src/prover_utils.rs
@@ -589,7 +589,7 @@ pub fn verify_artifact(
                     security,
                 )
                 .map_err(|_| "recursion(unrolled over base) verification failed".to_string())?;
-                ensure_recursion_chain_binds_program(&output, &base_level.hash_chain)?;
+                ensure_unrolled_target_binds_program(&output, &unrolled_level.hash_chain)?;
                 Ok(output)
             } else if previous_end_params == unrolled_level.setup.end_params {
                 let output = verify_unrolled_layer_proof(
@@ -602,7 +602,7 @@ pub fn verify_artifact(
                 .map_err(|_| {
                     "recursion(unrolled over recursion-unrolled) verification failed".to_string()
                 })?;
-                ensure_recursion_chain_binds_program(&output, &unrolled_level.hash_chain)?;
+                ensure_unrolled_target_binds_program(&output, &unrolled_level.hash_chain)?;
                 Ok(output)
             } else {
                 Err("unable to infer previous layer for recursion-unrolled proof".to_string())
@@ -678,6 +678,19 @@ fn ensure_recursion_chain_binds_program(
         );
     }
     Ok(())
+}
+
+/// Bind a verified recursion-unrolled proof to the supplied program and target stage.
+///
+/// A `RecursionUnrolled` artifact must prove one unrolled-recursion wrapper around the
+/// supplied program's base layer, regardless of whether the wrapped proof came directly
+/// from the base layer or from a prior unrolled wrapper. In both cases, the authenticated
+/// output chain must therefore match the supplied program's unrolled recursion level.
+fn ensure_unrolled_target_binds_program(
+    verifier_output: &[u32; 16],
+    expected_unrolled_chain: &[u32; 8],
+) -> Result<(), String> {
+    ensure_recursion_chain_binds_program(verifier_output, expected_unrolled_chain)
 }
 
 fn make_artifact(
@@ -1172,5 +1185,42 @@ mod recursion_binding_tests {
 
         // And it still verifies against the program it was actually generated for.
         assert!(ensure_recursion_chain_binds_program(&proven_output, &chain_q).is_ok());
+    }
+
+    #[test]
+    fn rejects_base_chain_when_target_claims_recursion_unrolled() {
+        let base_end_params = [1, 2, 3, 4, 5, 6, 7, 8];
+        let unrolled_end_params = [11, 12, 13, 14, 15, 16, 17, 18];
+        let (base_chain, base_preimage) =
+            UnrolledProgramSetup::begin_recursion_chain(&base_end_params);
+        let (unrolled_chain, _) = UnrolledProgramSetup::continue_recursion_chain(
+            &unrolled_end_params,
+            &base_chain,
+            &base_preimage,
+        );
+
+        let base_output = verifier_output_with_chain(base_chain);
+        let err = ensure_unrolled_target_binds_program(&base_output, &unrolled_chain)
+            .expect_err("base output chain must not satisfy a recursion-unrolled target");
+        assert!(
+            err.contains("does not match the supplied program"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn accepts_unrolled_chain_for_recursion_unrolled_target() {
+        let base_end_params = [21, 22, 23, 24, 25, 26, 27, 28];
+        let unrolled_end_params = [31, 32, 33, 34, 35, 36, 37, 38];
+        let (base_chain, base_preimage) =
+            UnrolledProgramSetup::begin_recursion_chain(&base_end_params);
+        let (unrolled_chain, _) = UnrolledProgramSetup::continue_recursion_chain(
+            &unrolled_end_params,
+            &base_chain,
+            &base_preimage,
+        );
+
+        let unrolled_output = verifier_output_with_chain(unrolled_chain);
+        assert!(ensure_unrolled_target_binds_program(&unrolled_output, &unrolled_chain).is_ok());
     }
 }

--- a/tools/cli/src/prover_utils.rs
+++ b/tools/cli/src/prover_utils.rs
@@ -551,11 +551,14 @@ impl ProgramProver {
 pub fn verify_artifact(
     artifact: &ProofArtifact,
     source: &ProgramSource,
+    expected_security_level: SecurityLevel,
+    expected_target: ProofTarget,
 ) -> Result<[u32; 16], String> {
+    validate_trusted_verification_policy(artifact, expected_security_level, expected_target)?;
     let loaded = load_and_validate_program(source, artifact, None)?;
-    let security = artifact.security_level.model();
+    let security = expected_security_level.model();
 
-    match artifact.target {
+    match expected_target {
         ProofTarget::Base => {
             let base_level = make_base_level_data(&loaded);
             let output = verify_unrolled_layer_proof(
@@ -572,7 +575,7 @@ pub fn verify_artifact(
         ProofTarget::RecursionUnrolled => {
             let base_level = make_base_level_data(&loaded);
             let recursion_unrolled =
-                load_embedded_recursion_program(artifact.security_level, RecursionLayer::Unrolled);
+                load_embedded_recursion_program(expected_security_level, RecursionLayer::Unrolled);
             let unrolled_level =
                 make_unrolled_recursion_level_data(&base_level, &recursion_unrolled);
 
@@ -610,9 +613,9 @@ pub fn verify_artifact(
         }
         ProofTarget::RecursionUnified => {
             let loaded_unrolled =
-                load_embedded_recursion_program(artifact.security_level, RecursionLayer::Unrolled);
+                load_embedded_recursion_program(expected_security_level, RecursionLayer::Unrolled);
             let loaded_unified =
-                load_embedded_recursion_program(artifact.security_level, RecursionLayer::Unified);
+                load_embedded_recursion_program(expected_security_level, RecursionLayer::Unified);
 
             let base_level = make_base_level_data(&loaded);
             let unrolled_level = make_unrolled_recursion_level_data(&base_level, &loaded_unrolled);
@@ -629,11 +632,33 @@ pub fn verify_artifact(
             )
             .map_err(|_| "recursion(unified) verification failed".to_string())?;
             let (family_count, _, _) = artifact.proof.get_proof_counts();
-            ensure_unified_recursion_target_converged(artifact.security_level, family_count)?;
+            ensure_unified_recursion_target_converged(expected_security_level, family_count)?;
             ensure_recursion_chain_binds_program(&output, &unified_level.hash_chain)?;
             Ok(output)
         }
     }
+}
+
+fn validate_trusted_verification_policy(
+    artifact: &ProofArtifact,
+    expected_security_level: SecurityLevel,
+    expected_target: ProofTarget,
+) -> Result<(), String> {
+    if artifact.security_level != expected_security_level {
+        return Err(format!(
+            "proof security level ({:?}) does not match requested security level ({:?})",
+            artifact.security_level, expected_security_level
+        ));
+    }
+
+    if artifact.target != expected_target {
+        return Err(format!(
+            "proof target ({:?}) does not match requested target ({:?})",
+            artifact.target, expected_target
+        ));
+    }
+
+    Ok(())
 }
 
 fn validate_recursion_chain(proof: &UnrolledProgramProof) -> Result<[u32; 16], String> {
@@ -924,8 +949,8 @@ fn validate_artifact_against_program(
     expected_security_level: Option<SecurityLevel>,
 ) -> Result<(), String> {
     if let Some(expected_security_level) = expected_security_level {
-        // Continuation uses the requested security level as an explicit contract.
-        // Standalone verification instead trusts the persisted artifact metadata.
+        // Some callers also want this helper to enforce a trusted security-level
+        // contract in addition to program-hash binding.
         if artifact.security_level != expected_security_level {
             return Err(format!(
                 "proof security level ({:?}) does not match requested security level ({:?})",
@@ -1242,6 +1267,67 @@ mod recursion_binding_tests {
         assert!(ensure_unrolled_target_binds_program(&unrolled_output, &unrolled_chain).is_ok());
     }
 
+    fn minimal_artifact(security_level: SecurityLevel, target: ProofTarget) -> ProofArtifact {
+        ProofArtifact {
+            schema_version: 1,
+            security_level,
+            target,
+            backend: ProverBackend::Cpu,
+            batch_id: 0,
+            cycles: 0,
+            program_bin_keccak: [0u8; 32],
+            program_text_keccak: [0u8; 32],
+            timings_ms: ProofTimingsMs::default(),
+            proof_counts: ProofCounts::default(),
+            proof: UnrolledProgramProof {
+                final_pc: 0,
+                final_timestamp: 0,
+                circuit_families_proofs: Default::default(),
+                inits_and_teardowns_proofs: vec![],
+                delegation_proofs: Default::default(),
+                register_final_values: [trace_and_split::FinalRegisterValue {
+                    value: 0,
+                    last_access_timestamp: 0,
+                }; 32],
+                recursion_chain_preimage: None,
+                recursion_chain_hash: None,
+                pow_challenge: 0,
+            },
+        }
+    }
+
+    #[test]
+    fn rejects_verification_policy_with_mismatched_security_level() {
+        let artifact = minimal_artifact(SecurityLevel::Security80, ProofTarget::Base);
+        let err = validate_trusted_verification_policy(
+            &artifact,
+            SecurityLevel::Security100,
+            ProofTarget::Base,
+        )
+        .expect_err("verification must reject artifacts whose metadata disagrees with the trusted security level");
+        assert!(
+            err.contains("does not match requested security level"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_verification_policy_with_mismatched_target() {
+        let artifact = minimal_artifact(SecurityLevel::Security80, ProofTarget::Base);
+        let err = validate_trusted_verification_policy(
+            &artifact,
+            SecurityLevel::Security80,
+            ProofTarget::RecursionUnified,
+        )
+        .expect_err(
+            "verification must reject artifacts whose metadata disagrees with the trusted target",
+        );
+        assert!(
+            err.contains("does not match requested target"),
+            "unexpected error message: {err}"
+        );
+    }
+
     #[test]
     fn rejects_unified_target_before_security100_convergence() {
         let err = ensure_unified_recursion_target_converged(SecurityLevel::Security100, 1)
@@ -1254,8 +1340,6 @@ mod recursion_binding_tests {
 
     #[test]
     fn accepts_unified_target_after_security100_convergence() {
-        assert!(
-            ensure_unified_recursion_target_converged(SecurityLevel::Security100, 2).is_ok()
-        );
+        assert!(ensure_unified_recursion_target_converged(SecurityLevel::Security100, 2).is_ok());
     }
 }

--- a/tools/cli/src/prover_utils.rs
+++ b/tools/cli/src/prover_utils.rs
@@ -628,6 +628,8 @@ pub fn verify_artifact(
                 security,
             )
             .map_err(|_| "recursion(unified) verification failed".to_string())?;
+            let (family_count, _, _) = artifact.proof.get_proof_counts();
+            ensure_unified_recursion_target_converged(artifact.security_level, family_count)?;
             ensure_recursion_chain_binds_program(&output, &unified_level.hash_chain)?;
             Ok(output)
         }
@@ -691,6 +693,22 @@ fn ensure_unrolled_target_binds_program(
     expected_unrolled_chain: &[u32; 8],
 ) -> Result<(), String> {
     ensure_recursion_chain_binds_program(verifier_output, expected_unrolled_chain)
+}
+
+fn ensure_unified_recursion_target_converged(
+    security_level: SecurityLevel,
+    family_count: usize,
+) -> Result<(), String> {
+    if security_level.unified_recursion_has_converged(family_count) {
+        return Ok(());
+    }
+
+    Err(format!(
+        "recursion(unified) proof has not converged for {:?}: got {} family proof(s), need {}",
+        security_level,
+        family_count,
+        security_level.unified_recursion_target_family_proofs()
+    ))
 }
 
 fn make_artifact(
@@ -1222,5 +1240,22 @@ mod recursion_binding_tests {
 
         let unrolled_output = verifier_output_with_chain(unrolled_chain);
         assert!(ensure_unrolled_target_binds_program(&unrolled_output, &unrolled_chain).is_ok());
+    }
+
+    #[test]
+    fn rejects_unified_target_before_security100_convergence() {
+        let err = ensure_unified_recursion_target_converged(SecurityLevel::Security100, 1)
+            .expect_err("Security100 must require two unified family proofs");
+        assert!(
+            err.contains("has not converged"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn accepts_unified_target_after_security100_convergence() {
+        assert!(
+            ensure_unified_recursion_target_converged(SecurityLevel::Security100, 2).is_ok()
+        );
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes the accepted verifier and decoder review findings.

## What is fixed

### 1. CLI verification and continuation now use a trusted policy
Before this change, `verify` and parts of `continue-proof` relied on `security_level` and `target` embedded in the proof artifact. Those fields are prover-controlled metadata, so they are not a safe source of policy.

This PR makes the caller supply the trusted policy explicitly:
- `verify` now requires `--security-level` and `--target`
- `continue-proof` now requires `--security-level`
- verification checks that the artifact metadata matches the caller-supplied policy
- the verifier selects recursion binaries and verification flow from the trusted inputs, not from artifact metadata

This prevents a malformed artifact from steering verification or staged proving into a different security schedule or proof stage than the caller intended.

### 2. `recursion-unrolled` verification is bound to the wrapped stage
A `recursion-unrolled` artifact is supposed to represent one layer of unrolled recursion over the supplied program. The previous check only accepted that the proof chain was internally valid, but it did not enforce that the authenticated output chain matched the unrolled recursion stage for the supplied program.

That meant a proof whose authenticated chain still corresponded to the base layer could be accepted as a `recursion-unrolled` artifact under the right shape.

This PR makes verification require that the authenticated chain coming out of the verifier matches the expected unrolled-recursion chain for the supplied program, whether the wrapped proof came directly from base or from a previous unrolled step.

### 3. Unified recursion verification now enforces convergence for the selected security level
For unified recursion, the number of family proofs required to reach the terminal compressed artifact depends on the security level. Previously, the verifier accepted any proof that was valid in the unified layer, without also checking that the proof had actually converged to the required terminal shape.

This PR adds an explicit convergence check:
- security 80 requires the expected single unified family proof
- security 100 requires the expected two-step convergence

This prevents a partially compressed unified artifact from being accepted as if it were the final target artifact.

### 4. Illegal `CSRRW` operand combinations are rejected cleanly in the decoder
The shift/binop/CSR decoder accepted malformed `CSRRW` encodings too loosely for some supported CSR cases, and some bad combinations reached internal assertions instead of being rejected as invalid encodings.

This PR tightens those operand rules:
- the nondeterminism CSR only permits the supported operand patterns
- the other supported CSRs require the reserved operands to stay zero
- malformed encodings now return `Err(())` from the decoder instead of panicking

This turns malformed encodings into ordinary decode rejection and ensures the accepted instruction space matches the intended CSR contract.

## Regression coverage
This PR adds targeted regression tests for:
- trusted-policy enforcement in verifier helpers
- CLI parser requirements for `verify` and `continue-proof`
- recursion-unrolled binding
- unified-recursion convergence
- illegal `CSRRW` decoder encodings

## Testing
- `CARGO_PROFILE_DEV_DEBUG=0 cargo test -p cli recursion_binding_tests -- --nocapture`
- `CARGO_PROFILE_DEV_DEBUG=0 cargo test -p prover shift_binop_rejects_illegal -- --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p cli --bin cli tests:: -- --nocapture`
