### PR TITLE
[WIP] perf(gpu_prover): Improved L2 persistence for whir commitments

### DIFF
--- a/gpu/circuit_prover/src/prover/context.rs
+++ b/gpu/circuit_prover/src/prover/context.rs
@@ -54,6 +54,7 @@ pub struct ProverContext {
     #[allow(dead_code)]
     scheduler_host_allocator: SchedulerHostAllocator,
     exec_stream: CudaStream,
+    side_stream: CudaStream,
     h2d_stream: CudaStream,
     d2h_stream: CudaStream,
     device_allocator_mem_size: usize,
@@ -82,6 +83,7 @@ impl ProverContext {
         let allocator_block_log_size = config.allocator_block_log_size;
         let device_context = DeviceContext::create(config.powers_of_w_coarse_log_count)?;
         let exec_stream = CudaStream::create()?;
+        let side_stream = CudaStream::create()?;
         let h2d_stream = CudaStream::create()?;
         let d2h_stream = CudaStream::create()?;
         let mut device_blocks_count =
@@ -151,6 +153,7 @@ impl ProverContext {
             host_allocator,
             scheduler_host_allocator,
             exec_stream,
+            side_stream,
             h2d_stream,
             d2h_stream,
             device_allocator_mem_size,
@@ -167,6 +170,10 @@ impl ProverContext {
 
     pub fn get_exec_stream(&self) -> &CudaStream {
         &self.exec_stream
+    }
+
+    pub fn get_side_stream(&self) -> &CudaStream {
+        &self.side_stream
     }
 
     /// The NTT twiddle/triangle `DeviceContext` owned for the prover's lifetime.

--- a/gpu/circuit_prover/src/prover/trace/holder/mod.rs
+++ b/gpu/circuit_prover/src/prover/trace/holder/mod.rs
@@ -1,9 +1,10 @@
 use blake2s_u32::BLAKE2S_DIGEST_SIZE_U32_WORDS;
+use era_cudart::event::{CudaEvent, CudaEventCreateFlags};
 #[cfg(test)]
 use era_cudart::memory::memory_copy_async;
 use era_cudart::result::CudaResult;
 use era_cudart::slice::DeviceSlice;
-use era_cudart::stream::CudaStream;
+use era_cudart::stream::{CudaStream, CudaStreamWaitEventFlags};
 
 use crate::allocator::tracker::AllocationPlacement;
 #[cfg(test)]
@@ -17,8 +18,7 @@ use crate::ops::blake2s::{
     gather_leaf_rows, gather_merkle_paths_device, gather_merkle_paths_from_rows,
 };
 use crate::ops::ntt::{
-    bitreversed_monomials_to_natural_evals_multi_coset,
-    bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range,
+    bitreversed_monomials_to_natural_evals_multi_coset, lde_with_coset_range,
     hypercube_x1_msb_evals_to_x1_msb_monomials, log_size_supports_transposed_monomials,
     transform_whir_leaves_from_ntt_in_place_multi_coset,
 };
@@ -1315,7 +1315,6 @@ pub(crate) fn commit_trace_from_ntt_single_tree(
     assert!(log_tree_cap_size <= total_leaf_count_log2);
     let layers_count = total_leaf_count_log2 + 1 - log_tree_cap_size;
     let (leaves, nodes) = trees_backing.split_at_mut(total_leaf_count);
-    let stream = context.get_exec_stream();
 
     let device_properties = context.get_device_properties();
     let ntt_ctx = context.ntt_device_context();
@@ -1332,80 +1331,127 @@ pub(crate) fn commit_trace_from_ntt_single_tree(
     };
 
     let total_cosets = 1 << natural_log_lde_factor;
+    // Default: no L2 chunking
+    let mut cosets_in_tile_chunk = total_cosets;
+    let mut num_streams = 1;
+    // Deactivate chunking for log_trace_len < 14 because it doesn't play well
+    // with the small dit kernels.
+    // TODO: extend chunk-friendly kernels to smaller sizes
     let l2_bytes = device_properties.l2_cache_size_bytes;
     let single_bf_col_bytes = std::mem::size_of::<BF>() << log_trace_len;
     let single_coset_bytes = src_cols_per_coset * single_bf_col_bytes;
-    // Deactivate chunking for log_trace_len < 18 because it doesn't play well
-    // with the small dit kernels.
-    // TODO: investigate
-    let cosets_in_tile_chunk = if l2_bytes >= single_coset_bytes && log_trace_len >= 18 {
-        let nearest = l2_bytes / single_coset_bytes;
-        if nearest.is_power_of_two() {
-            nearest
+    if log_trace_len >= 14 {
+        let half_l2_bytes = l2_bytes >> 1;
+        if single_coset_bytes > half_l2_bytes {
+            cosets_in_tile_chunk = 1;
         } else {
-            nearest.next_power_of_two() >> 1
+            let nearest = half_l2_bytes / single_coset_bytes;
+            if nearest.is_power_of_two() {
+                cosets_in_tile_chunk = nearest;
+                num_streams = 2;
+            } else {
+                cosets_in_tile_chunk = nearest.next_power_of_two() >> 1;
+                num_streams = 2;
+            }
         }
-    } else {
-        // don't bother with chunking
-        total_cosets
-    };
+    }
+
     if total_cosets > cosets_in_tile_chunk {
         assert_eq!(total_cosets % cosets_in_tile_chunk, 0);
     }
 
     let mut ntt_output_matrix = DeviceMatrixMut::new(ntt_output, trace_len);
 
-    for coset_index_base in (0..total_cosets).step_by(cosets_in_tile_chunk) {
-        let cosets_in_tile = std::cmp::min(cosets_in_tile_chunk, total_cosets - coset_index_base);
-        // The NTT and hashing APIs don't internally apply an offset for coset_index_base,
-        // so for them we have to manually select the start in ntt_output.
-        let offset = src_cols_per_coset * trace_len * coset_index_base;
-        let scratch_opt = d_scratch.as_mut().map(|s| &mut s[..]);
-        bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range(
-            inputs_matrix,
-            &mut (ntt_output_matrix.slice_mut())[offset..],
-            log_trace_len as usize,
-            natural_log_lde_factor as usize,
-            cosets_in_tile,
-            coset_index_base,
-            src_cols_per_coset,
-            false,
-            ntt_ctx,
-            scratch_opt,
-            stream,
-            device_properties,
-        )?;
+    let (start_event, end_event) = if num_streams > 1 {
+        (
+            Some(CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?),
+            Some(CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?),
+        )
+    } else {
+        (None, None)
+    };
+
+    let mut occupancy_hint_numerator = 1;
+    let mut occupancy_hint_denominator = 1;
+    let exec_stream = context.get_exec_stream();
+    let side_stream = context.get_side_stream();
+    let streams = [exec_stream, side_stream];
+    if num_streams > 1 {
+        occupancy_hint_numerator = 5;
+        occupancy_hint_denominator = 8;
+        start_event.as_ref().unwrap().record(exec_stream)?;
+        side_stream.wait_event(start_event.as_ref().unwrap(), CudaStreamWaitEventFlags::DEFAULT)?;
+    }
+
+    for coset_index_base in (0..total_cosets).step_by(num_streams * cosets_in_tile_chunk) {
+        let mut helpers_per_stream = Vec::with_capacity(2);
+        for i in 0..num_streams {
+            let coset_index_base_this_stream = coset_index_base + i * cosets_in_tile_chunk;
+            if coset_index_base_this_stream < total_cosets {
+                let cosets_in_tile = std::cmp::min(cosets_in_tile_chunk, total_cosets - coset_index_base_this_stream);
+                let offset = src_cols_per_coset * trace_len * coset_index_base_this_stream;
+                helpers_per_stream.push((coset_index_base_this_stream, cosets_in_tile, offset));
+            }
+        }
+        // If we're using two streams, dispatch with breadth-first ping pong pattern
+        for (i, &(coset_index_base_this_stream, cosets_in_tile, offset)) in helpers_per_stream.iter().enumerate() {
+           let scratch_opt = d_scratch.as_mut().map(|s| &mut s[..]);
+           lde_with_coset_range(
+               inputs_matrix,
+               &mut (ntt_output_matrix.slice_mut())[offset..],
+               log_trace_len as usize,
+               natural_log_lde_factor as usize,
+               cosets_in_tile,
+               coset_index_base_this_stream,
+               src_cols_per_coset,
+               occupancy_hint_numerator,
+               occupancy_hint_denominator,
+               ntt_ctx,
+               scratch_opt,
+               streams[i],
+               device_properties,
+           )?;
+        }
         if transform_leaves_to_multilinear_coeffs {
-            transform_whir_leaves_from_ntt_in_place_multi_coset(
-                &mut ntt_output_matrix,
-                log_trace_len,
-                natural_log_lde_factor,
+            for (i, &(coset_index_base_this_stream, cosets_in_tile, _offset)) in helpers_per_stream.iter().enumerate() {
+                transform_whir_leaves_from_ntt_in_place_multi_coset(
+                    &mut ntt_output_matrix,
+                    log_trace_len,
+                    natural_log_lde_factor,
+                    log_values_per_leaf,
+                    coset_index_base_this_stream as u32,
+                    cosets_in_tile as u32,
+                    src_cols_per_coset as u32,
+                    streams[i],
+                )?;
+            }
+        }
+        for (i, &(coset_index_base_this_stream, cosets_in_tile, offset)) in helpers_per_stream.iter().enumerate() {
+            crate::ops::blake2s::launch_leaves_kernel_from_ntt_multi_coset(
+                &(ntt_output_matrix.slice())[offset..],
+                leaves,
                 log_values_per_leaf,
-                coset_index_base as u32,
-                cosets_in_tile as u32,
                 src_cols_per_coset as u32,
-                stream,
+                natural_log_lde_factor,
+                coset_index_base_this_stream as u32,
+                cosets_in_tile,
+                packed_leaf_count,
+                trace_len as u32,
+                streams[i],
             )?;
         }
-        crate::ops::blake2s::launch_leaves_kernel_from_ntt_multi_coset(
-            &(ntt_output_matrix.slice())[offset..],
-            leaves,
-            log_values_per_leaf,
-            src_cols_per_coset as u32,
-            natural_log_lde_factor,
-            coset_index_base as u32,
-            cosets_in_tile,
-            packed_leaf_count,
-            trace_len as u32,
-            stream,
-        )?;
+    }
+
+    if num_streams > 1 {
+        end_event.as_ref().unwrap().record(side_stream)?;
+        exec_stream.wait_event(end_event.as_ref().unwrap(), CudaStreamWaitEventFlags::DEFAULT)?;
     }
 
     // Single-tree node layers: build_merkle_tree_nodes operates on a flat
     // `[leaves | nodes]` slab. `layers_count - 1` because the leaf layer is
     // already written; the function builds the remaining `layers_count - 1`
     // node layers.
-    crate::ops::blake2s::build_merkle_tree_nodes(leaves, nodes, layers_count - 1, stream)
+    crate::ops::blake2s::build_merkle_tree_nodes(leaves, nodes, layers_count - 1, exec_stream)
 }
 
 /// Multi-coset variant of `commit_trace_with_partial_tree`: takes one big

--- a/gpu/circuit_prover/src/prover/whir/mod.rs
+++ b/gpu/circuit_prover/src/prover/whir/mod.rs
@@ -874,6 +874,12 @@ pub(crate) mod tests {
 
     #[test]
     #[serial]
+    fn recursive_oracle_lde_matches_cpu_intermediate() {
+        recursive_oracle_lde_matches_cpu_impl(&[17], &[32], false, false);
+    }
+
+    #[test]
+    #[serial]
     #[ignore]
     fn recursive_oracle_lde_matches_cpu_large() {
         recursive_oracle_lde_matches_cpu_impl(&[23], &[32], false, false);
@@ -883,6 +889,12 @@ pub(crate) mod tests {
     #[serial]
     fn recursive_oracle_lde_with_transform_matches_cpu_small_sweep() {
         recursive_oracle_lde_matches_cpu_impl(&[6, 7, 8, 9], &[2, 4, 8], true, true);
+    }
+
+    #[test]
+    #[serial]
+    fn recursive_oracle_lde_with_transform_matches_cpu_intermediate() {
+        recursive_oracle_lde_matches_cpu_impl(&[17], &[32], true, false);
     }
 
     #[test]

--- a/gpu/ntt/native/CMakeLists.txt
+++ b/gpu/ntt/native/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(gpu_ntt_native STATIC
         hypercube.cu
         hypercube_evals_to_monomials_three_pass.cu
         hypercube_evals_to_monomials_two_pass.cu
+        lde_intermediate_first_pass.cu
         monomials_to_evals_compact.cu
         monomials_to_evals_smem_packed.cu
         monomials_to_evals_subwarp.cu

--- a/gpu/ntt/native/context.cu
+++ b/gpu/ntt/native/context.cu
@@ -17,3 +17,6 @@ __device__ __constant__ base_field ab_inv_cmem_twiddles_finest_11[1 << 11];
 // Use swizzled twiddles for stages where consecutive threads access them with a strided pattern.
 __device__ __constant__ const base_field *ab_fwd_gmem_twiddles_coarse;
 __device__ __constant__ const base_field *ab_inv_gmem_twiddles_coarse;
+
+// Use fully precomputed twiddles for LDEs with log_n <= 18.
+__device__ __constant__ const base_field *ab_fully_precomputed_bitrev_twiddles;

--- a/gpu/ntt/native/context.cuh
+++ b/gpu/ntt/native/context.cuh
@@ -50,6 +50,9 @@ EXTERN __device__ __constant__ base_field ab_inv_cmem_twiddles_finest_11[1 << 11
 EXTERN __device__ __constant__ const base_field *ab_fwd_gmem_twiddles_coarse;
 EXTERN __device__ __constant__ const base_field *ab_inv_gmem_twiddles_coarse;
 
+// Use fully precomputed twiddles for LDEs with log_n <= 18.
+EXTERN __device__ __constant__ const base_field *ab_fully_precomputed_bitrev_twiddles;
+
 namespace airbender::ntt {
 
 DEVICE_FORCEINLINE bf get_power_from_layers(const powers_data_2_layer &data, const unsigned idx) {

--- a/gpu/ntt/native/lde_intermediate_first_pass.cu
+++ b/gpu/ntt/native/lde_intermediate_first_pass.cu
@@ -1,0 +1,311 @@
+#include "ntt.cuh"
+
+namespace airbender::ntt {
+
+DEVICE_FORCEINLINE void shfl_for_exchange(bf *vals, const unsigned lane_mask) {
+  constexpr unsigned WARP_MASK = 0xffffffff;
+  // The following non-divergent shfl pattern avoids deadlocks on architectures
+  // with a program counter shared across the warp (Pascal and earlier):
+  const bool is_odd = threadIdx.x & lane_mask;
+  const unsigned val_to_publish = is_odd ? vals[0].limb : vals[1].limb;
+  const unsigned val_received = __shfl_xor_sync(WARP_MASK, val_to_publish, lane_mask);
+  if (is_odd)
+    vals[0].limb = val_received;
+  else
+    vals[1].limb = val_received;
+  // For Volta and later, with independent PCs per thread, the following would also be fine:
+  // if (threadIdx.x & lane_mask)
+  //   vals[0] = __shfl_xor_sync(WARP_MASK, vals[0], lane_mask);
+  // else
+  //   vals[1] = __shfl_xor_sync(WARP_MASK, vals[1], lane_mask);
+}
+
+// First-K-stages LDE for intermediate sizes.
+// Reuses twiddles, monomials, and coset adjustments across cosets.
+template <unsigned THREADS_PER_BLOCK, unsigned STAGES>
+DEVICE_FORCEINLINE void lde_first_k_stages_impl(bf_matrix_getter<ld_modifier::cg> gmem_in,
+                                                 bf_matrix_setter<st_modifier::cg> gmem_out_base,
+                                                 const unsigned log_n,
+                                                 const unsigned coset_index_base,
+                                                 const unsigned coset_factor_shift,
+                                                 const unsigned num_cols_per_coset,
+                                                 const unsigned num_cosets_in_tile) {
+  constexpr unsigned VALS_PER_THREAD = 2;
+  constexpr unsigned VALS_PER_WARP = 64;
+  constexpr unsigned VALS_PER_BLOCK = THREADS_PER_BLOCK * VALS_PER_THREAD;
+
+  const unsigned gid = threadIdx.x + blockIdx.x * blockDim.x;
+
+  const unsigned gmem_block_offset = blockIdx.x * VALS_PER_BLOCK;
+  gmem_in.add_row(gmem_block_offset);
+  gmem_out_base.add_row(gmem_block_offset);
+
+  __shared__ bf smem[VALS_PER_BLOCK + THREADS_PER_BLOCK];
+  bf *twiddles = smem + VALS_PER_BLOCK;
+  const bf first_twiddle = ab_fully_precomputed_bitrev_twiddles[gid];
+  // Cooperatively loads THREADS_PER_BLOCK - 1 twiddles for remaining stages with minimal divergence. Pain.
+  // Stages are ordered in reverse in the shared memory chunk, ie
+  // [...[twiddles for stage 8] [twiddles for stage 9] [ twiddles for stage 10]]
+  {
+    const unsigned lz = __clz(threadIdx.x); // ranges from 32 to 32 - (STAGES - 1) inclusive
+    const unsigned stage = STAGES - (32 - lz); // ranges from STAGES to 1 inclusive
+    const unsigned exchg_region_offset = blockIdx.x * (VALS_PER_BLOCK >> (stage + 1));
+    const unsigned global_bitrev_exchg_region = (threadIdx.x ^ (1 << (31 - lz))) + exchg_region_offset;
+    if (threadIdx.x > 0)
+      twiddles[threadIdx.x] = ab_fully_precomputed_bitrev_twiddles[global_bitrev_exchg_region];
+  }
+
+  __syncthreads();
+
+  const unsigned base_coset_this_block = coset_index_base + blockIdx.z;
+  bf coset_deltas[2];
+  bf initial_adjustments[2];
+  const unsigned global_bitrev_idx = (VALS_PER_THREAD * threadIdx.x) + blockIdx.x * VALS_PER_BLOCK;
+#pragma unroll
+  for (unsigned i = 0; i < 2; i++) {
+    const unsigned global_natural_idx = bitrev(global_bitrev_idx + i, log_n);
+    coset_deltas[i] = get_power_from_layers(::ab_ntt_forward_powers, gridDim.z * (global_natural_idx << coset_factor_shift));
+    if (base_coset_this_block > 0)
+      initial_adjustments[i] = get_forward_twiddle_power((global_natural_idx << coset_factor_shift) * base_coset_this_block);
+  }
+
+  // inter-warp reshuffling helpers
+  const unsigned warp_id = threadIdx.x >> 5;
+  const unsigned lane_id = threadIdx.x & 31;
+
+  gmem_in.add_col(blockIdx.y);
+  gmem_out_base.add_col(blockIdx.y + num_cols_per_coset * blockIdx.z);
+
+  // This loop lets the caller balance occupancy and twiddle/adjustment amortization by playing with gridDim.y.
+#pragma unroll 1
+  for (unsigned monomial_col = blockIdx.y;
+       monomial_col < num_cols_per_coset;
+       monomial_col += gridDim.y, gmem_in.add_col(gridDim.y), gmem_out_base.add_col(gridDim.y)) {
+    auto gmem_out = gmem_out_base.copy();
+
+    const uint2 monomials_data = *(reinterpret_cast<uint2 *>(gmem_in.ptr) + threadIdx.x);
+    bf monomials[2] = {bf{monomials_data.x}, bf{monomials_data.y}};
+
+    if (base_coset_this_block > 0) {
+      monomials[0] = bf::mul(initial_adjustments[0], monomials[0]);
+      monomials[1] = bf::mul(initial_adjustments[1], monomials[1]);
+    }
+
+#pragma unroll 1
+    for (unsigned coset = blockIdx.z; coset < num_cosets_in_tile; coset += gridDim.z) {
+      bf vals[2] = {monomials[0], monomials[1]};
+
+      exchg_dif(vals[0], vals[1], first_twiddle);
+
+      const bf *twiddles_this_stage = twiddles + THREADS_PER_BLOCK;
+
+      // 5 intrawarp exchanges
+      unsigned lane_mask = 1;
+#pragma unroll
+      // for (unsigned stage = 1; stage < 6; stage++, lane_mask <<= 1) {
+      for (unsigned stage = 1; stage < 6; stage++, lane_mask <<= 1) {
+        shfl_for_exchange(vals, lane_mask);
+        twiddles_this_stage -= THREADS_PER_BLOCK >> stage;
+        const unsigned exchg_region = threadIdx.x >> stage;
+        const bf twiddle = twiddles_this_stage[exchg_region];
+        exchg_dif(vals[0], vals[1], twiddle);
+      }
+
+      // Reshuffle data between warps
+      smem[VALS_PER_WARP * warp_id + lane_id] = vals[0];
+      smem[VALS_PER_WARP * warp_id + lane_id + 32] = vals[1];
+      __syncthreads();
+
+      // We could use intrawarp tiling and shuffles to avoid some __syncthreads here,
+      // but the pattern is simple and good enough.
+#pragma unroll
+      for (unsigned stage = 6; stage < STAGES - 1; stage++) {
+        twiddles_this_stage -= THREADS_PER_BLOCK >> stage;
+        const unsigned exchg_region = threadIdx.x >> stage;
+        const unsigned exchg_stride = 1 << stage;
+        const unsigned lane_in_region = threadIdx.x & (exchg_stride - 1);
+        const unsigned idx0 = 2 * exchg_region * exchg_stride + lane_in_region;
+        const unsigned idx1 = idx0 + exchg_stride;
+        vals[0] = smem[idx0];
+        vals[1] = smem[idx1];
+        const bf twiddle = twiddles_this_stage[exchg_region];
+        exchg_dif(vals[0], vals[1], twiddle);
+        smem[idx0] = vals[0];
+        smem[idx1] = vals[1];
+        __syncthreads();
+      }
+
+      // Final stage
+      vals[0] = smem[threadIdx.x];
+      vals[1] = smem[threadIdx.x + blockDim.x];
+      // Protect reads from the next coset iteration
+      if ((monomial_col + gridDim.y < num_cols_per_coset) || (coset + gridDim.z < num_cosets_in_tile))
+        __syncthreads();
+
+      exchg_dif(vals[0], vals[1], twiddles[1]);
+
+      gmem_out.set_at_row(threadIdx.x, vals[0]);
+      gmem_out.set_at_row(threadIdx.x + blockDim.x, vals[1]);
+
+      if (coset + gridDim.z < num_cosets_in_tile) {
+        gmem_out.add_col(num_cols_per_coset * gridDim.z);
+
+#pragma unroll
+        for (unsigned j = 0; j < 2; j++)
+          monomials[j] = bf::mul(coset_deltas[j], monomials[j]);
+      }
+    }
+  }
+}
+
+EXTERN __launch_bounds__(512, 3)
+__global__ void ab_lde_first_10_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in,
+                                       bf_matrix_setter<st_modifier::cg> gmem_out,
+                                       const unsigned log_n,
+                                       const unsigned coset_index_base,
+                                       const unsigned coset_factor_shift,
+                                       const unsigned num_cols_per_coset,
+                                       const unsigned num_cosets_in_tile) {
+  lde_first_k_stages_impl<512, 10>(gmem_in, gmem_out, log_n, coset_index_base, coset_factor_shift, num_cols_per_coset, num_cosets_in_tile);
+}
+
+EXTERN __launch_bounds__(256, 6)
+__global__ void ab_lde_first_9_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in,
+                                       bf_matrix_setter<st_modifier::cg> gmem_out,
+                                       const unsigned log_n,
+                                       const unsigned coset_index_base,
+                                       const unsigned coset_factor_shift,
+                                       const unsigned num_cols_per_coset,
+                                       const unsigned num_cosets_in_tile) {
+  lde_first_k_stages_impl<256, 9>(gmem_in, gmem_out, log_n, coset_index_base, coset_factor_shift, num_cols_per_coset, num_cosets_in_tile);
+}
+
+EXTERN __launch_bounds__(128, 12)
+__global__ void ab_lde_first_8_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in,
+                                       bf_matrix_setter<st_modifier::cg> gmem_out,
+                                       const unsigned log_n,
+                                       const unsigned coset_index_base,
+                                       const unsigned coset_factor_shift,
+                                       const unsigned num_cols_per_coset,
+                                       const unsigned num_cosets_in_tile) {
+  lde_first_k_stages_impl<128, 8>(gmem_in, gmem_out, log_n, coset_index_base, coset_factor_shift, num_cols_per_coset, num_cosets_in_tile);
+}
+
+EXTERN __launch_bounds__(64, 24)
+__global__ void ab_lde_first_7_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in,
+                                       bf_matrix_setter<st_modifier::cg> gmem_out,
+                                       const unsigned log_n,
+                                       const unsigned coset_index_base,
+                                       const unsigned coset_factor_shift,
+                                       const unsigned num_cols_per_coset,
+                                       const unsigned num_cosets_in_tile) {
+  lde_first_k_stages_impl<64, 7>(gmem_in, gmem_out, log_n, coset_index_base, coset_factor_shift, num_cols_per_coset, num_cosets_in_tile);
+}
+
+// First-K-stages LDE for intermediate sizes.
+// Reuses twiddles, monomials, and coset adjustments across cosets.
+EXTERN __launch_bounds__(128, 12)
+__global__ void ab_lde_first_6_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in,
+                                             bf_matrix_setter<st_modifier::cg> gmem_out_base,
+                                             const unsigned log_n,
+                                             const unsigned coset_index_base,
+                                             const unsigned coset_factor_shift,
+                                             const unsigned num_cols_per_coset,
+                                             const unsigned num_cosets_in_tile) {
+  constexpr unsigned WARPS_PER_BLOCK = 4;
+  constexpr unsigned THREADS_PER_BLOCK = WARPS_PER_BLOCK * 32;
+  constexpr unsigned STAGES = 6;
+  constexpr unsigned VALS_PER_THREAD = 2;
+  constexpr unsigned VALS_PER_WARP = 64;
+
+  const unsigned lane_id = threadIdx.x & 31;
+  const unsigned warp_id = threadIdx.x >> 5;
+  const unsigned warp_gid = blockIdx.x * WARPS_PER_BLOCK + warp_id;
+
+  const unsigned gid = threadIdx.x + blockIdx.x * blockDim.x;
+
+  const unsigned gmem_warp_offset = warp_gid * VALS_PER_WARP;
+  gmem_in.add_row(gmem_warp_offset);
+  gmem_out_base.add_row(gmem_warp_offset);
+
+  __shared__ bf smem[THREADS_PER_BLOCK];
+  bf *twiddles = smem + 32 * warp_id;
+  const bf first_twiddle = ab_fully_precomputed_bitrev_twiddles[gid];
+  // Cooperatively loads 31 twiddles for remaining stages with minimal divergence. Pain.
+  // Stages are ordered in reverse in the shared memory chunk, ie
+  // [...[twiddles for stage 8] [twiddles for stage 9] [ twiddles for stage 10]]
+  {
+    const unsigned lz = __clz(lane_id); // ranges from 32 to 32 - (STAGES - 1) inclusive
+    const unsigned stage = STAGES - (32 - lz); // ranges from STAGES to 1 inclusive
+    const unsigned exchg_region_offset = warp_gid * (VALS_PER_WARP >> (stage + 1));
+    const unsigned global_bitrev_exchg_region = (lane_id ^ (1 << (31 - lz))) + exchg_region_offset;
+    if (lane_id > 0)
+      twiddles[lane_id] = ab_fully_precomputed_bitrev_twiddles[global_bitrev_exchg_region];
+  }
+
+  __syncthreads();
+
+  const unsigned base_coset_this_block = coset_index_base + blockIdx.z;
+  bf coset_deltas[2];
+  bf initial_adjustments[2];
+  const unsigned global_bitrev_idx = VALS_PER_THREAD * lane_id + warp_gid * VALS_PER_WARP;
+#pragma unroll
+  for (unsigned i = 0; i < 2; i++) {
+    const unsigned global_natural_idx = bitrev(global_bitrev_idx + i, log_n);
+    coset_deltas[i] = get_power_from_layers(::ab_ntt_forward_powers, gridDim.z * (global_natural_idx << coset_factor_shift));
+    if (base_coset_this_block > 0)
+      initial_adjustments[i] = get_forward_twiddle_power((global_natural_idx << coset_factor_shift) * base_coset_this_block);
+  }
+
+  gmem_in.add_col(blockIdx.y);
+  gmem_out_base.add_col(blockIdx.y + num_cols_per_coset * blockIdx.z);
+
+  // This loop lets the caller balance occupancy and twiddle/adjustment amortization by playing with gridDim.y.
+#pragma unroll 1
+  for (unsigned monomial_col = blockIdx.y;
+       monomial_col < num_cols_per_coset;
+       monomial_col += gridDim.y, gmem_in.add_col(gridDim.y), gmem_out_base.add_col(gridDim.y)) {
+    auto gmem_out = gmem_out_base.copy();
+
+    const uint2 monomials_data = *(reinterpret_cast<uint2 *>(gmem_in.ptr) + lane_id);
+    bf monomials[2] = {bf{monomials_data.x}, bf{monomials_data.y}};
+
+    if (base_coset_this_block > 0) {
+      monomials[0] = bf::mul(initial_adjustments[0], monomials[0]);
+      monomials[1] = bf::mul(initial_adjustments[1], monomials[1]);
+    }
+
+#pragma unroll 1
+    for (unsigned coset = blockIdx.z; coset < num_cosets_in_tile; coset += gridDim.z) {
+      bf vals[2] = {monomials[0], monomials[1]};
+
+      exchg_dif(vals[0], vals[1], first_twiddle);
+
+      const bf *twiddles_this_stage = twiddles + 32;
+
+      // 5 intrawarp exchanges
+      unsigned lane_mask = 1;
+#pragma unroll
+      for (unsigned stage = 1; stage < 6; stage++, lane_mask <<= 1) {
+        shfl_for_exchange(vals, lane_mask);
+        twiddles_this_stage -= 32 >> stage;
+        const unsigned exchg_region = lane_id >> stage;
+        const bf twiddle = twiddles_this_stage[exchg_region];
+        exchg_dif(vals[0], vals[1], twiddle);
+      }
+
+      gmem_out.set_at_row(lane_id, vals[0]);
+      gmem_out.set_at_row(lane_id + 32, vals[1]);
+
+      if (coset + gridDim.z < num_cosets_in_tile) {
+        gmem_out.add_col(num_cols_per_coset * gridDim.z);
+
+#pragma unroll
+        for (unsigned j = 0; j < 2; j++)
+          monomials[j] = bf::mul(coset_deltas[j], monomials[j]);
+      }
+    }
+  }
+}
+
+} // namespace airbender::ntt

--- a/gpu/ntt/src/ntt/mod.rs
+++ b/gpu/ntt/src/ntt/mod.rs
@@ -46,8 +46,7 @@ mod strategy;
 #[allow(dead_code)]
 pub use ntt::{
     bitreversed_monomials_to_natural_evals, bitreversed_monomials_to_natural_evals_multi_coset,
-    bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range,
-    natural_evals_to_bitreversed_monomials,
+    lde_with_coset_range, natural_evals_to_bitreversed_monomials,
 };
 #[cfg(test)]
 pub use ntt::{

--- a/gpu/ntt/src/ntt/ntt.rs
+++ b/gpu/ntt/src/ntt/ntt.rs
@@ -157,6 +157,24 @@ monomials_to_evals_compact!(ab_monomials_to_evals_first_10_stages_compact_kernel
 monomials_to_evals_compact!(ab_monomials_to_evals_first_11_stages_compact_kernel);
 monomials_to_evals_compact!(ab_monomials_to_evals_first_12_stages_compact_kernel);
 
+cuda_kernel!(
+    LdeIntermediate,
+    lde_intermediate,
+    inputs_matrix: PtrAndStride<BF>,
+    outputs_matrix: MutPtrAndStride<BF>,
+    log_n: u32,
+    coset_index_base: u32,
+    coset_factor_shift: u32,
+    num_cols_per_coset: u32,
+    num_cosets_in_tile: u32,
+);
+
+lde_intermediate!(ab_lde_first_10_stages_kernel);
+lde_intermediate!(ab_lde_first_9_stages_kernel);
+lde_intermediate!(ab_lde_first_8_stages_kernel);
+lde_intermediate!(ab_lde_first_7_stages_kernel);
+lde_intermediate!(ab_lde_first_6_stages_kernel);
+
 pub fn evals_to_monomials_3_pass(
     inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
     outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
@@ -1212,12 +1230,183 @@ pub fn monomials_to_evals_2_pass(
     Ok(())
 }
 
+// Computes grid dimensions for high-degree LDE kernels, targeting fractional occupancy.
+// num_cols_per_coset and cosets_in_tile are not required to be powers of 2.
+// The resulting grid prioritizes monomial reuse, because monomials are unique gmem data.
+// However, the grid is not guaranteed to yield good occupancy or load balancing
+// by itself. It's meant to work with an external multistream ping-ping approach,
+// where 2 grids in flight compensate for each other's tail effects.
+fn get_lde_grid_dims_for_occupancy_hint(
+    n: usize,
+    cosets_in_tile: usize,
+    num_cols_per_coset: usize,
+    func: &impl KernelFunction,
+    block_dim_x: usize,
+    vals_per_block: usize,
+    occupancy_hint_numerator: usize,
+    occupancy_hint_denominator: usize,
+    device_properties: &DeviceProperties
+) -> CudaResult<Dim3> {
+    assert!(n >= vals_per_block);
+    assert_eq!(n % vals_per_block, 0);
+
+    let max_blocks_per_sm = era_cudart::occupancy::max_active_blocks_per_multiprocessor(
+        func,
+        block_dim_x as i32,
+        0, // dynamic_smem_size
+    )?;
+    let max_blocks_per_sm = max_blocks_per_sm as usize;
+
+    let full_occupancy = max_blocks_per_sm * device_properties.sm_count;
+    let target_blocks =
+        (full_occupancy * occupancy_hint_numerator).div_ceil(occupancy_hint_denominator);
+
+    let grid_dim_x = n / vals_per_block;
+
+    // First, if laying out blocks across n gives enough occupancy, we're done.
+    if grid_dim_x >= target_blocks {
+        let grid: Dim3 = (grid_dim_x as u32, 1, 1).into();
+        return Ok(grid);
+    }
+
+    // Second, see if we can achieve target occupancy by parallelizing over columns
+    // within each coset. Expose the parallelism via blockDim.y.
+    let grid_dim_y;
+    if grid_dim_x * num_cols_per_coset >= target_blocks {
+        grid_dim_y = target_blocks.div_ceil(grid_dim_x);
+        assert!(grid_dim_x * grid_dim_y >= target_blocks);
+        let grid = (grid_dim_x as u32, grid_dim_y as u32, 1).into();
+        return Ok(grid);
+    } else {
+        // Max out parallelism over columns within each coset (prioritize monomial reuse)
+        grid_dim_y = num_cols_per_coset;
+    }
+
+    // As a last resort, split the coset tile. Expose the parallelism via blockDim.z.
+    let xy_blocks = grid_dim_x * grid_dim_y;
+    let grid_dim_z = target_blocks.div_ceil(xy_blocks);
+    assert!(xy_blocks * grid_dim_z >= target_blocks);
+    // Technically, grid_dim_z can be > cosets_in_tile without affecting correctness.
+    // The grid would just include a bunch of spurious no-op blocks.
+    // But it would indicate a weird, non-performant geometry we don't expect in production.
+    assert!(grid_dim_z <= cosets_in_tile);
+    let grid = (grid_dim_x as u32, grid_dim_y as u32, grid_dim_z as u32).into();
+    return Ok(grid)
+}
+
+fn get_lde_config_for_log_n(log_n: usize) -> (usize, usize) {
+    let (block_dim_x, vals_per_block) = match log_n {
+        18 => (512, 1024),
+        17 => (256, 512),
+        16 => (128, 256),
+        15 => (64, 128),
+        14 => (128, 256),
+        _ => unimplemented!(),
+    };
+    (block_dim_x, vals_per_block)
+}
+
+pub fn lde_intermediate_size_with_coset_range(
+    inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    outputs: &mut DeviceSlice<BF>,
+    log_n: usize,
+    log_lde_factor: usize,
+    cosets_in_tile: usize,
+    coset_index_base: usize,
+    num_cols_per_coset_stride: usize,
+    occupancy_target_numerator: usize,
+    occupancy_target_denominator: usize,
+    device_properties: &DeviceProperties,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    let trace_len = 1 << log_n;
+    assert_eq!(inputs_matrix.rows(), trace_len);
+    assert_eq!(inputs_matrix.cols(), num_cols_per_coset_stride);
+    assert!(outputs.len() >= trace_len * num_cols_per_coset_stride * cosets_in_tile);
+    let coset_factor_shift = (OMEGA_LOG_ORDER as usize - log_n - log_lde_factor) as u32;
+    let mut outputs_matrix = DeviceMatrixMut::new(outputs, trace_len);
+    let inputs_matrix = inputs_matrix.as_ptr_and_stride();
+    let outputs_matrix_const = outputs_matrix.as_ptr_and_stride();
+    let outputs_matrix_mut = outputs_matrix.as_mut_ptr_and_stride();
+    let log_k = log_n - 8;
+    let (block_dim_x, vals_per_block) = get_lde_config_for_log_n(log_n);
+    // let grid_dim_x = (1 << log_n) / vals_per_block;
+    // let grid_dim_y = num_cols_per_coset_stride;
+    // let grid_dim: Dim3 = (grid_dim_x as u32, grid_dim_y as u32).into();
+    let first_pass_function = match log_n {
+        18 => LdeIntermediateFunction(ab_lde_first_10_stages_kernel),
+        17 => LdeIntermediateFunction(ab_lde_first_9_stages_kernel),
+        16 => LdeIntermediateFunction(ab_lde_first_8_stages_kernel),
+        15 => LdeIntermediateFunction(ab_lde_first_7_stages_kernel),
+        14 => LdeIntermediateFunction(ab_lde_first_6_stages_kernel),
+        _ => unimplemented!(),
+    };
+    let grid_dim: Dim3 = get_lde_grid_dims_for_occupancy_hint(
+        trace_len,
+        cosets_in_tile,
+        num_cols_per_coset_stride,
+        &first_pass_function,
+        block_dim_x,
+        vals_per_block,
+        occupancy_target_numerator,
+        occupancy_target_denominator,
+        device_properties
+    )?;
+    println!("coset_factor_shift {} grid_dim.y {} grid_dim.z {} cosets_in_tile {} outputs.len() {}",
+             coset_factor_shift, grid_dim.y, grid_dim.z, cosets_in_tile, outputs.len());
+    let config = CudaLaunchConfig::basic(grid_dim, block_dim_x as u32, stream);
+    let args = LdeIntermediateArguments::new(
+        inputs_matrix,
+        outputs_matrix_mut,
+        log_n as u32,
+        coset_index_base as u32,
+        coset_factor_shift as u32,
+        num_cols_per_coset_stride as u32,
+        cosets_in_tile as u32,
+    );
+    first_pass_function.launch(&config, &args)?;
+    // Pass 2: noninitial_8 with start_stage = log_k.
+    assert!(
+        cosets_in_tile.is_power_of_two(),
+        "cosets_in_tile must be a power of 2 (got {cosets_in_tile})"
+    );
+    let log_cosets_in_tile = cosets_in_tile.trailing_zeros();
+    let threads_pass2 = 512;
+    let bf_vals_per_block_pass2 = 1 << 13;
+    let start_stage = log_k;
+    let num_block_exchg_regions = trace_len >> (start_stage + 8);
+    let block_exchg_region_size = 1 << (start_stage + 8);
+    let blocks_per_exchg_region = block_exchg_region_size / bf_vals_per_block_pass2;
+    assert_eq!(
+        blocks_per_exchg_region * num_block_exchg_regions,
+        trace_len / bf_vals_per_block_pass2
+    );
+    let cols_in_chunk = num_cols_per_coset_stride;
+    let grid_dim_pass2: Dim3 = (blocks_per_exchg_region as u32
+        * num_block_exchg_regions as u32
+        * cosets_in_tile as u32
+        * cols_in_chunk as u32)
+        .into();
+    let config_pass2 =
+        CudaLaunchConfig::basic(grid_dim_pass2, threads_pass2 as u32, stream);
+    let args_pass2 = StridedTilesStagesArguments::new(
+        outputs_matrix_const,
+        outputs_matrix_mut,
+        log_n as i32,
+        start_stage as i32,
+        cols_in_chunk as i32,
+        log_cosets_in_tile as i32,
+    );
+    StridedTilesStagesFunction(ab_monomials_to_evals_noninitial_8_stages_kernel)
+        .launch(&config_pass2, &args_pass2)
+}
+
 /// Multi-coset variant of `bitreversed_monomials_to_natural_evals`.
 ///
 /// Runs the same forward NTT across the full power-of-two LDE: all
 /// `num_cosets = 1 << log_lde_factor` cosets, starting at coset 0. Use
-/// [`bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range`] to
-/// process a caller-selected power-of-two coset subrange.
+/// [`lde_with_coset_range`] to process a caller-selected power-of-two
+/// coset subrange.
 ///
 /// For the compact 1-pass range (`log_n <= 12`) all cosets are batched into one
 /// launch via `gridDim.x`, eliminating the per-coset launch overhead that
@@ -1271,7 +1460,7 @@ pub fn bitreversed_monomials_to_natural_evals_multi_coset(
 /// powers of two, and the selected range must fit within the full LDE coset
 /// domain.
 #[allow(dead_code)]
-pub fn bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range(
+pub fn lde_with_coset_range(
     inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
     outputs: &mut DeviceSlice<BF>,
     log_n: usize,
@@ -1279,7 +1468,8 @@ pub fn bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range(
     num_cosets: usize,
     coset_index_base: usize,
     num_cols_per_coset_stride: usize,
-    transposed_monomials: bool,
+    occupancy_hint_numerator: usize,
+    occupancy_hint_denominator: usize,
     ntt_ctx: &crate::ntt_twiddles::DeviceContext,
     d_table_scratch: Option<&mut DeviceSlice<BF>>,
     stream: &CudaStream,
@@ -1289,10 +1479,24 @@ pub fn bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range(
         num_cosets.is_power_of_two(),
         "num_cosets must be a power of 2 (got {num_cosets})"
     );
-    // assert!(
-    //     (coset_index_base == 0) || coset_index_base.is_power_of_two(),
-    //     "coset_index_base must be a power of 2 (got {coset_index_base})"
-    // );
+    // Temporary for testing
+    if (log_n <= 18) && (log_n >= 14) {
+        println!("Calling lde_intermediate");
+        let result = lde_intermediate_size_with_coset_range(
+            inputs_matrix,
+            outputs,
+            log_n,
+            log_lde_factor,
+            num_cosets,
+            coset_index_base,
+            num_cols_per_coset_stride,
+            occupancy_hint_numerator,
+            occupancy_hint_denominator, 
+            device_properties,
+            stream,
+        );
+        return result;
+    }
     bitreversed_monomials_to_natural_evals_multi_coset_impl(
         inputs_matrix,
         outputs,
@@ -1301,7 +1505,7 @@ pub fn bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range(
         num_cosets,
         coset_index_base,
         num_cols_per_coset_stride,
-        transposed_monomials,
+        /*transposed_monomials=*/false,
         ntt_ctx,
         d_table_scratch,
         stream,

--- a/gpu/ntt/src/ntt/tests/mod.rs
+++ b/gpu/ntt/src/ntt/tests/mod.rs
@@ -779,7 +779,7 @@ fn run_multi_coset_monomials_to_evals_parity_for_range(
     };
     use super::{
         bitreversed_monomials_to_natural_evals, bitreversed_monomials_to_natural_evals_multi_coset,
-        bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range,
+        lde_with_coset_range,
     };
     use crate::ntt_twiddles::OMEGA_LOG_ORDER;
     use gpu_core::primitives::device_structures::{DeviceMatrixChunk, DeviceMatrixChunkMut};
@@ -834,7 +834,7 @@ fn run_multi_coset_monomials_to_evals_parity_for_range(
             )
             .unwrap();
         } else {
-            bitreversed_monomials_to_natural_evals_multi_coset_with_coset_range(
+            lde_with_coset_range(
                 &inputs_matrix,
                 &mut candidate_device[..],
                 log_n,
@@ -842,7 +842,8 @@ fn run_multi_coset_monomials_to_evals_parity_for_range(
                 num_cosets,
                 coset_index_base,
                 NUM_COLS,
-                false,
+                1,
+                1,
                 context.device_context(),
                 scratch_opt,
                 stream,
@@ -977,7 +978,42 @@ multi_coset_range_parity_test!(
     4
 );
 multi_coset_range_parity_test!(
-    multi_coset_monomials_to_evals_log_n_8_cosets_23_base_4,
+    multi_coset_monomials_to_evals_log_n_18_cosets_8_base_8,
+    18,
+    9,
+    8,
+    8
+);
+multi_coset_range_parity_test!(
+    multi_coset_monomials_to_evals_log_n_17_cosets_16_base_16,
+    17,
+    10,
+    16,
+    16
+);
+multi_coset_range_parity_test!(
+    multi_coset_monomials_to_evals_log_n_16_cosets_32_base_32,
+    16,
+    11,
+    32,
+    32
+);
+multi_coset_range_parity_test!(
+    multi_coset_monomials_to_evals_log_n_15_cosets_64_base_64,
+    15,
+    12,
+    64,
+    64
+);
+multi_coset_range_parity_test!(
+    multi_coset_monomials_to_evals_log_n_14_cosets_128_base_128,
+    14,
+    12,
+    128,
+    128
+);
+multi_coset_range_parity_test!(
+    multi_coset_monomials_to_evals_log_n_23_cosets_8_base_8,
     23,
     4,
     4,

--- a/gpu/ntt/src/ntt_twiddles.rs
+++ b/gpu/ntt/src/ntt_twiddles.rs
@@ -21,6 +21,7 @@ pub const LENGTH_CMEM_COARSE: usize = 1 << CMEM_COARSE_LOG_COUNT;
 pub const CMEM_FINE_LOG_COUNT: usize = CMEM_LOG_ORDER - CMEM_COARSE_LOG_COUNT - 1;
 pub const GMEM_COARSE_LOG_COUNT: usize = 13;
 pub const LENGTH_GMEM_COARSE: usize = 1 << GMEM_COARSE_LOG_COUNT;
+pub const MAX_FULLY_PRECOMPUTED_SIZE: usize = 1 << 18;
 
 #[repr(C)]
 struct PowersLayerData {
@@ -83,6 +84,7 @@ cuda_struct_and_stub! { static ab_fwd_cmem_twiddles_finest_11: [BF; 1 << 11]; }
 cuda_struct_and_stub! { static ab_inv_cmem_twiddles_finest_11: [BF; 1 << 11]; }
 cuda_struct_and_stub! { static ab_fwd_gmem_twiddles_coarse: *const BF; }
 cuda_struct_and_stub! { static ab_inv_gmem_twiddles_coarse: *const BF; }
+cuda_struct_and_stub! { static ab_fully_precomputed_bitrev_twiddles: *const BF; }
 
 unsafe fn copy_to_symbols(
     powers_of_w_fine: *const BF,
@@ -94,6 +96,7 @@ unsafe fn copy_to_symbols(
     inv_sizes_host: [BF; OMEGA_LOG_ORDER as usize + 1],
     fwd_gmem_twiddles_coarse: *const BF,
     inv_gmem_twiddles_coarse: *const BF,
+    fully_precomputed_bitrev_twiddles: *const BF,
     fwd_cmem_twiddles_coarse: [BF; 1 << CMEM_COARSE_LOG_COUNT],
     inv_cmem_twiddles_coarse: [BF; 1 << CMEM_COARSE_LOG_COUNT],
     fwd_cmem_twiddles_fine: [BF; 1 << CMEM_FINE_LOG_COUNT],
@@ -124,6 +127,7 @@ unsafe fn copy_to_symbols(
     memcpy_to_symbol(&ab_inv_sizes, &inv_sizes_host)?;
     memcpy_to_symbol(&ab_fwd_gmem_twiddles_coarse, &fwd_gmem_twiddles_coarse)?;
     memcpy_to_symbol(&ab_inv_gmem_twiddles_coarse, &inv_gmem_twiddles_coarse)?;
+    memcpy_to_symbol(&ab_fully_precomputed_bitrev_twiddles, &fully_precomputed_bitrev_twiddles)?;
     memcpy_to_symbol(&ab_fwd_cmem_twiddles_coarse, &fwd_cmem_twiddles_coarse)?;
     memcpy_to_symbol(&ab_inv_cmem_twiddles_coarse, &inv_cmem_twiddles_coarse)?;
     memcpy_to_symbol(&ab_fwd_cmem_twiddles_fine, &fwd_cmem_twiddles_fine)?;
@@ -184,6 +188,7 @@ pub struct DeviceContext {
     _powers_of_w_inv_coarse_for_ntt: DeviceAllocation<BF>,
     _fwd_gmem_twiddles_coarse: DeviceAllocation<BF>,
     _inv_gmem_twiddles_coarse: DeviceAllocation<BF>,
+    _fully_precomputed_bitrev_twiddles: DeviceAllocation<BF>,
     /// The fixed, indexed set of DIT butterfly-triangle buffers, precomputed
     /// on-device at `create` and read-only afterward.
     dit_triangles: DitTriangles,
@@ -231,6 +236,19 @@ impl DeviceContext {
             coarse_base_inv,
             &mut powers_of_w_inv_coarse_for_ntt,
             false,
+            false,
+        )?;
+
+        // Specialized power tables for small and intermediate-size LDEs twiddles.
+        // These greatly simplify the LDE kernels.
+        let fully_precomputed_base =
+            domain_generator_for_size::<BF>(MAX_FULLY_PRECOMPUTED_SIZE as u64);
+        let mut fully_precomputed_bitrev_twiddles =
+            DeviceAllocation::<BF>::alloc(MAX_FULLY_PRECOMPUTED_SIZE >> 1)?;
+        generate_powers_dev(
+            fully_precomputed_base,
+            &mut fully_precomputed_bitrev_twiddles,
+            true,
             false,
         )?;
 
@@ -305,6 +323,7 @@ impl DeviceContext {
                 inv_sizes_host,
                 fwd_gmem_twiddles_coarse.as_ptr(),
                 inv_gmem_twiddles_coarse.as_ptr(),
+                fully_precomputed_bitrev_twiddles.as_ptr(),
                 fwd_cmem_twiddles_coarse,
                 inv_cmem_twiddles_coarse,
                 fwd_cmem_twiddles_fine,
@@ -332,6 +351,7 @@ impl DeviceContext {
             _powers_of_w_inv_coarse_for_ntt: powers_of_w_inv_coarse_for_ntt,
             _fwd_gmem_twiddles_coarse: fwd_gmem_twiddles_coarse,
             _inv_gmem_twiddles_coarse: inv_gmem_twiddles_coarse,
+            _fully_precomputed_bitrev_twiddles: fully_precomputed_bitrev_twiddles,
             dit_triangles,
         })
     }


### PR DESCRIPTION
Closing (added diffs to https://github.com/matter-labs/zksync-airbender/pull/335 instead)

-----------------------------------------------------------

## What ❔

- Adds L2-persistence-friendly LDE kernels for 14 <= log_n <= 18
- Adds L2 chunking heuristics that allow callers to choose persistent chunk size and target occupancy
- Adds two-stream ping-pong approach to reduce tail effects in the persistent LDE->leaf transform->leaf hash sequence

Without leaf transforms enabled, saves about 3 ms e2e for the first 2 whir stages.
With transforms enabled, saves about 6 ms e2e for the first 2 whir stages.

We can probably gain another 4ish ms by extending the approach to the remaining whir stages, but that will require adding another kernel for 8 <= log_n <= 18.
 
## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.