### PR TITLE
feat(gpu): add eval_leaves feature to select eval-form WHIR leaf commit

### DIFF
--- a/gpu/circuit_prover/Cargo.toml
+++ b/gpu/circuit_prover/Cargo.toml
@@ -52,6 +52,11 @@ log_gpu_mem_usage = []
 security_80 = ["verifier_common/security_80"]
 security_100 = ["verifier_common/security_100"]
 test_no_inline = ["field/no_inline"]
+# Commit recursive WHIR oracle leaves in evaluation form instead of the default
+# coefficient form (#279). PROTOCOL-level: the generated verifier must be built
+# with the matching encoding (verifier_generator `eval_leaves`). circuit_prover
+# local — the GPU commit transform is native, independent of `prover`/`gpu_hash`.
+eval_leaves = []
 
 [build-dependencies]
 gpu_native_build = { workspace = true }

--- a/gpu/circuit_prover/src/prover/whir/fold/schedule/round_phases.rs
+++ b/gpu/circuit_prover/src/prover/whir/fold/schedule/round_phases.rs
@@ -45,7 +45,10 @@ pub(super) fn schedule_commit_next_oracle_phase(
         lde_factor,
         1 << next_folding_steps,
         tree_cap_size,
-        true, // transform_leaves_to_multilinear_coeffs (CPU #279 commits recursive WHIR oracles in coeff form)
+        // transform_leaves_to_multilinear_coeffs: coeff form by default (CPU #279
+        // commits recursive WHIR oracles in coeff form); the `eval_leaves` feature
+        // selects eval form to mirror the CPU prover's recursive-oracle encoding.
+        !cfg!(feature = "eval_leaves"),
         &mut cap_dst_u32,
         context,
     )?;

--- a/gpu/execution_prover/Cargo.toml
+++ b/gpu/execution_prover/Cargo.toml
@@ -46,6 +46,7 @@ default = ["security_80", "deterministic_pow"]
 security_80 = ["gpu_circuit_prover/security_80"]
 security_100 = ["gpu_circuit_prover/security_100"]
 deterministic_pow = ["gpu_circuit_prover/deterministic_pow"]
+eval_leaves = ["gpu_circuit_prover/eval_leaves"]
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/gpu/program_prover/Cargo.toml
+++ b/gpu/program_prover/Cargo.toml
@@ -42,6 +42,7 @@ default = ["security_80", "deterministic_pow"]
 security_80 = ["gpu_execution_prover/security_80", "gpu_circuit_prover/security_80"]
 security_100 = ["gpu_execution_prover/security_100", "gpu_circuit_prover/security_100"]
 deterministic_pow = ["gpu_execution_prover/deterministic_pow"]
+eval_leaves = ["gpu_execution_prover/eval_leaves", "gpu_circuit_prover/eval_leaves"]
 # Pulls in the embedded verifier circuits so proofs can be verified natively.
 # Non-default: mirrors prover_examples' gating — the verifier build is heavy.
 verifiers = [

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -78,3 +78,6 @@ security_100 = [
 debug_logs = ["prover/debug_logs", "prover_examples/debug_logs"]
 # if enabled - allow GPU for proving.
 gpu = ["dep:gpu_execution_prover", "dep:gpu_program_prover"]
+# Commit recursive WHIR oracle leaves in eval form (see gpu_circuit_prover); the
+# verifier must be generated with the matching encoding. No-op without `gpu`.
+eval_leaves = ["gpu_execution_prover?/eval_leaves", "gpu_program_prover?/eval_leaves"]


### PR DESCRIPTION
## What ❔

Adds an off-by-default `eval_leaves` Cargo feature to the GPU prover stack. When enabled it flips the sole production recursive-WHIR-oracle commit from coefficient form (#279 default) to evaluation form, mirroring the CPU `prover` / `verifier_generator` feature of the same name. Base-layer commits are unchanged (always eval form).

The feature is relayed `gpu_circuit_prover → gpu_execution_prover → gpu_program_prover → cli`, since Cargo cannot enable a feature on an indirect dependency — matching the existing `security_80` / `deterministic_pow` forwarding.

## Why ❔

The GPU prover hard-coded coefficient-form recursive-oracle leaves with no way to produce eval-form proofs, unlike the CPU prover/verifier. This restores encoding parity so the GPU stack can target either form.

Note: `eval_leaves` is protocol-level — a verifier generated with the matching encoding is required to verify eval-form proofs.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
