### PR TITLE
test(gpu_circuit_prover): fix jump_branch_slt padding-PC drift and anchor test constants to upstream authorities

### DIFF
--- a/gpu/circuit_prover/src/prover/tests/basic_unrolled_parity.rs
+++ b/gpu/circuit_prover/src/prover/tests/basic_unrolled_parity.rs
@@ -134,7 +134,7 @@ fn run_basic_unrolled_workflow_input_parity_test() {
     let oracle = NonMemoryCircuitOracle {
         inner: &buffer[..],
         decoder_table: decoder_table_data,
-        default_pc_value_in_padding: 4,
+        default_pc_value_in_padding: common_constants::PC_STEP as u32,
     };
     let memory_trace = evaluate_gkr_memory_witness_for_executor_family::<BF, _, _, _>(
         &add_sub_circuit,

--- a/gpu/circuit_prover/src/prover/tests/basic_unrolled_parity.rs
+++ b/gpu/circuit_prover/src/prover/tests/basic_unrolled_parity.rs
@@ -6,7 +6,8 @@ use super::*;
 fn run_basic_unrolled_workflow_input_parity_test() {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    const TRACE_LEN_LOG2: usize = 24;
+    const TRACE_LEN_LOG2: usize =
+        UnrolledNonMemoryCircuitType::AddSubLuiAuipcMop.get_domain_size_log2();
     const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
 
     let trace_len: usize = 1 << TRACE_LEN_LOG2;

--- a/gpu/circuit_prover/src/prover/tests/commit_memory.rs
+++ b/gpu/circuit_prover/src/prover/tests/commit_memory.rs
@@ -35,7 +35,7 @@ fn test_jump_branch_slt_commit_memory_matches_cpu() {
         "examples/hashed_fibonacci/app.bin",
         "examples/hashed_fibonacci/app.text",
         &[15, 1],
-        0,
+        4, // jump_branch_slt default_pc_value_in_padding (== GPU PC_STEP)
         UnrolledNonMemoryCircuitType::JumpBranchSlt,
         compiled_circuit,
     );

--- a/gpu/circuit_prover/src/prover/tests/commit_memory.rs
+++ b/gpu/circuit_prover/src/prover/tests/commit_memory.rs
@@ -15,7 +15,7 @@ fn test_commit_memory_matches_cpu() {
         "examples/basic_fibonacci/app.bin",
         "examples/basic_fibonacci/app.text",
         &[],
-        4,
+        common_constants::PC_STEP as u32, // default_pc_value_in_padding
         UnrolledNonMemoryCircuitType::AddSubLuiAuipcMop,
         compiled_circuit,
     );
@@ -35,7 +35,7 @@ fn test_jump_branch_slt_commit_memory_matches_cpu() {
         "examples/hashed_fibonacci/app.bin",
         "examples/hashed_fibonacci/app.text",
         &[15, 1],
-        4, // jump_branch_slt default_pc_value_in_padding (== GPU PC_STEP)
+        common_constants::PC_STEP as u32, // default_pc_value_in_padding
         UnrolledNonMemoryCircuitType::JumpBranchSlt,
         compiled_circuit,
     );
@@ -55,7 +55,7 @@ fn test_shift_binop_commit_memory_matches_cpu() {
         "examples/hashed_fibonacci/app.bin",
         "examples/hashed_fibonacci/app.text",
         &[15, 1],
-        4,
+        common_constants::PC_STEP as u32, // default_pc_value_in_padding
         UnrolledNonMemoryCircuitType::ShiftBinaryCsr,
         compiled_circuit,
     );

--- a/gpu/circuit_prover/src/prover/tests/commit_memory.rs
+++ b/gpu/circuit_prover/src/prover/tests/commit_memory.rs
@@ -9,7 +9,7 @@ fn test_commit_memory_matches_cpu() {
         &|cs| add_sub_lui_auipc_mop_table_addition_fn(cs),
         &|cs| add_sub_lui_auipc_mop_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        24,
+        UnrolledNonMemoryCircuitType::AddSubLuiAuipcMop.get_domain_size_log2(),
     );
     assert_non_memory_commit_memory_matches_cpu_for_test::<ADD_SUB_LUI_AUIPC_MOP_CIRCUIT_FAMILY_IDX>(
         "examples/basic_fibonacci/app.bin",
@@ -29,7 +29,7 @@ fn test_jump_branch_slt_commit_memory_matches_cpu() {
         &|cs| jump_branch_slt_table_addition_fn(cs),
         &|cs| jump_branch_slt_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        24,
+        UnrolledNonMemoryCircuitType::JumpBranchSlt.get_domain_size_log2(),
     );
     assert_non_memory_commit_memory_matches_cpu_for_test::<JUMP_BRANCH_SLT_CIRCUIT_FAMILY_IDX>(
         "examples/hashed_fibonacci/app.bin",
@@ -49,7 +49,7 @@ fn test_shift_binop_commit_memory_matches_cpu() {
         &|cs| shift_binop_table_addition_fn(cs),
         &|cs| shift_binop_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        24,
+        UnrolledNonMemoryCircuitType::ShiftBinaryCsr.get_domain_size_log2(),
     );
     assert_non_memory_commit_memory_matches_cpu_for_test::<SHIFT_BINARY_CIRCUIT_FAMILY_IDX>(
         "examples/hashed_fibonacci/app.bin",
@@ -211,8 +211,6 @@ fn assert_non_memory_commit_memory_matches_cpu_for_test<const FAMILY_IDX: u8>(
     use prover::gkr::prover::stages::stage1::commit_trace_part;
     use prover::gkr::witness_gen::family_circuits::evaluate_gkr_memory_witness_for_executor_family;
 
-    const TRACE_LEN_LOG2: usize = 24;
-    const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
     const DEVICE_ALLOCATOR_ARENA_BYTES: usize = 64usize << 30;
     const HOST_POOL_SIZE_MB: usize = 1024;
     const DEVICE_ALLOCATOR_BLOCK_LOG_SIZE: u32 = 20;
@@ -313,7 +311,7 @@ fn assert_non_memory_commit_memory_matches_cpu_for_test<const FAMILY_IDX: u8>(
     let trace_len = compiled_circuit.trace_len;
     let cpu_memory_trace = evaluate_gkr_memory_witness_for_executor_family::<BF, _, _, _>(
         &compiled_circuit,
-        NUM_CYCLES_PER_CHUNK,
+        compiled_circuit.trace_len,
         &oracle,
         &worker,
         None,
@@ -409,8 +407,6 @@ fn assert_memory_commit_memory_matches_cpu_for_test<const FAMILY_IDX: u8>(
     use prover::gkr::prover::stages::stage1::commit_trace_part;
     use prover::gkr::witness_gen::family_circuits::evaluate_gkr_memory_witness_for_executor_family;
 
-    const TRACE_LEN_LOG2: usize = 24;
-    const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
     const DEVICE_ALLOCATOR_ARENA_BYTES: usize = 64usize << 30;
     const HOST_POOL_SIZE_MB: usize = 1024;
     const DEVICE_ALLOCATOR_BLOCK_LOG_SIZE: u32 = 20;
@@ -456,7 +452,7 @@ fn assert_memory_commit_memory_matches_cpu_for_test<const FAMILY_IDX: u8>(
         num_calls > 0,
         "selected workload must exercise family {FAMILY_IDX}",
     );
-    assert!(num_calls < NUM_CYCLES_PER_CHUNK);
+    assert!(num_calls < compiled_circuit.trace_len);
     let mut replay_state = snapshotter.initial_snapshot.state;
     let mut ram_log_buffers = snapshotter
         .reads_buffer
@@ -511,7 +507,7 @@ fn assert_memory_commit_memory_matches_cpu_for_test<const FAMILY_IDX: u8>(
     let trace_len = compiled_circuit.trace_len;
     let cpu_memory_trace = evaluate_gkr_memory_witness_for_executor_family::<BF, _, _, _>(
         &compiled_circuit,
-        NUM_CYCLES_PER_CHUNK,
+        compiled_circuit.trace_len,
         &oracle,
         &worker,
         None,

--- a/gpu/circuit_prover/src/prover/tests/fixtures_helpers.rs
+++ b/gpu/circuit_prover/src/prover/tests/fixtures_helpers.rs
@@ -171,8 +171,6 @@ pub(super) fn finish_proof_fixture(
     BasicUnrolledFixture,
     Option<GKRProof<BF, E4, DefaultTreeConstructor>>,
 ) {
-    const TRACE_LEN_LOG2: usize = 24;
-    const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
     const FINAL_TRACE_SIZE_LOG_2: usize = 4;
     const HOST_POOL_SIZE_MB: usize = 1024;
     // Match the production-sized arena. Every consumer either runs a full
@@ -180,7 +178,7 @@ pub(super) fn finish_proof_fixture(
     // fixture (`build_basic_unrolled_async_backward_fixture_from_base`).
     let device_allocator_arena_bytes: usize = 64usize << 30;
 
-    let trace_len: usize = 1 << TRACE_LEN_LOG2;
+    let trace_len: usize = compiled_circuit.trace_len;
 
     let memory_argument_alpha =
         E4::from_array_of_base([BF::new(2), BF::new(5), BF::new(42), BF::new(123)]);
@@ -244,7 +242,7 @@ pub(super) fn finish_proof_fixture(
 
         let memory_trace = evaluate_gkr_memory_witness_for_executor_family::<BF, _, _, _>(
             &compiled_circuit,
-            NUM_CYCLES_PER_CHUNK,
+            trace_len,
             &oracle,
             &worker,
             None,
@@ -254,7 +252,7 @@ pub(super) fn finish_proof_fixture(
         let full_trace = evaluate_gkr_witness_for_executor_family::<BF, _, _, _>(
             &compiled_circuit,
             witness_eval_fn,
-            NUM_CYCLES_PER_CHUNK,
+            trace_len,
             &oracle,
             &table_driver,
             &worker,
@@ -443,7 +441,6 @@ pub(super) fn extract_memory_family<const FAMILY_IDX: u8>(
 ) -> ExtractedFamily {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    const TRACE_LEN_LOG2: usize = 24;
     let cycles_bound = 1 << 20;
 
     let binary = std::fs::read(test_artifact_path(binary_path)).unwrap();
@@ -510,7 +507,6 @@ pub(super) fn extract_memory_family<const FAMILY_IDX: u8>(
         num_calls > 0,
         "selected workload must exercise memory family {FAMILY_IDX}",
     );
-    assert!(num_calls < (1 << TRACE_LEN_LOG2));
     let mut replay_state = snapshotter.initial_snapshot.state;
     let mut ram_log_buffers = snapshotter
         .reads_buffer
@@ -585,13 +581,12 @@ pub(super) fn finish_proof_fixture_memory(
     BasicUnrolledFixture,
     Option<GKRProof<BF, E4, DefaultTreeConstructor>>,
 ) {
-    const TRACE_LEN_LOG2: usize = 24;
-    const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
     const FINAL_TRACE_SIZE_LOG_2: usize = 4;
     const HOST_POOL_SIZE_MB: usize = 1024;
     let device_allocator_arena_bytes: usize = 64usize << 30;
 
-    let trace_len: usize = 1 << TRACE_LEN_LOG2;
+    let trace_len: usize = compiled_circuit.trace_len;
+    assert!(buffer.len() < trace_len);
 
     let memory_argument_alpha =
         E4::from_array_of_base([BF::new(2), BF::new(5), BF::new(42), BF::new(123)]);
@@ -654,7 +649,7 @@ pub(super) fn finish_proof_fixture_memory(
 
         let memory_trace = evaluate_gkr_memory_witness_for_executor_family::<BF, _, _, _>(
             &compiled_circuit,
-            NUM_CYCLES_PER_CHUNK,
+            trace_len,
             &oracle,
             &worker,
             None,
@@ -664,7 +659,7 @@ pub(super) fn finish_proof_fixture_memory(
         let full_trace = evaluate_gkr_witness_for_executor_family::<BF, _, _, _>(
             &compiled_circuit,
             witness_eval_fn,
-            NUM_CYCLES_PER_CHUNK,
+            trace_len,
             &oracle,
             &table_driver,
             &worker,

--- a/gpu/circuit_prover/src/prover/tests/fixtures_helpers.rs
+++ b/gpu/circuit_prover/src/prover/tests/fixtures_helpers.rs
@@ -856,7 +856,7 @@ pub(super) fn prepare_basic_unrolled_fixture(
         build_config.circuit_type,
         compiled_circuit,
         buffer,
-        4, // add_sub default_pc_value_in_padding
+        common_constants::PC_STEP as u32, // add_sub default_pc_value_in_padding
         add_sub_lui_auipc_mod::witness_eval_fn,
         table_driver,
         ex.decoder_table_data,

--- a/gpu/circuit_prover/src/prover/tests/inits_and_teardowns.rs
+++ b/gpu/circuit_prover/src/prover/tests/inits_and_teardowns.rs
@@ -114,7 +114,7 @@ pub(super) fn prepare_inits_and_teardowns_proof_fixture(
 ) {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    const TRACE_LEN_LOG2: usize = 24;
+    const TRACE_LEN_LOG2: usize = UnrolledCircuitType::InitsAndTeardowns.get_domain_size_log2();
     const FINAL_TRACE_SIZE_LOG_2: usize = 4;
 
     let trace_len = 1usize << TRACE_LEN_LOG2;
@@ -333,7 +333,7 @@ pub(super) fn prepare_inits_and_teardowns_proof_fixture(
 fn standalone_inits_and_teardowns_gpu_workflow_matches_cpu() {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    const TRACE_LEN_LOG2: usize = 24;
+    const TRACE_LEN_LOG2: usize = UnrolledCircuitType::InitsAndTeardowns.get_domain_size_log2();
     const FINAL_TRACE_SIZE_LOG_2: usize = 4;
 
     let trace_len = 1usize << TRACE_LEN_LOG2;

--- a/gpu/circuit_prover/src/prover/tests/memory_workflow.rs
+++ b/gpu/circuit_prover/src/prover/tests/memory_workflow.rs
@@ -35,7 +35,7 @@ pub(super) fn compile_mem_word_only_circuit_for_test(binary: &[u32]) -> GKRCircu
         },
         &|cs| mem_word_only_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        24,
+        UnrolledMemoryCircuitType::LoadStoreWordOnly.get_domain_size_log2(),
     )
 }
 
@@ -51,7 +51,7 @@ pub(super) fn compile_mem_subword_only_circuit_for_test(binary: &[u32]) -> GKRCi
         },
         &|cs| mem_subword_only_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        24,
+        UnrolledMemoryCircuitType::LoadStoreSubwordOnly.get_domain_size_log2(),
     )
 }
 
@@ -73,11 +73,10 @@ pub(super) fn run_memory_workflow_input_parity_test<const FAMILY_IDX: u8>(
 ) {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    const TRACE_LEN_LOG2: usize = 24;
-    const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
     const FINAL_TRACE_SIZE_LOG_2: usize = 4;
 
-    let trace_len: usize = 1 << TRACE_LEN_LOG2;
+    let trace_len: usize = compiled_circuit.trace_len;
+    let num_cycles_per_chunk: usize = trace_len;
     let worker = Worker::new_with_num_threads(8);
 
     let binary = read_test_words(binary_path);
@@ -113,7 +112,7 @@ pub(super) fn run_memory_workflow_input_parity_test<const FAMILY_IDX: u8>(
         num_calls > 0,
         "expected selected workload to exercise the {family_label} family"
     );
-    assert!(num_calls < NUM_CYCLES_PER_CHUNK);
+    assert!(num_calls < num_cycles_per_chunk);
 
     let mut expected_final_state = state;
     expected_final_state.counters = Default::default();
@@ -171,7 +170,7 @@ pub(super) fn run_memory_workflow_input_parity_test<const FAMILY_IDX: u8>(
     populate_table_driver(&mut table_driver, &binary);
     let memory_trace = evaluate_gkr_memory_witness_for_executor_family::<BF, _, _, _>(
         &compiled_circuit,
-        NUM_CYCLES_PER_CHUNK,
+        num_cycles_per_chunk,
         &oracle,
         &worker,
         None,
@@ -181,7 +180,7 @@ pub(super) fn run_memory_workflow_input_parity_test<const FAMILY_IDX: u8>(
     let full_trace = evaluate_gkr_witness_for_executor_family::<BF, _, _, _>(
         &compiled_circuit,
         witness_eval_fn,
-        NUM_CYCLES_PER_CHUNK,
+        num_cycles_per_chunk,
         &oracle,
         &table_driver,
         &worker,
@@ -298,7 +297,7 @@ pub(super) fn run_memory_workflow_input_parity_test<const FAMILY_IDX: u8>(
         let first_mismatch = describe_first_trace_holder_column_mismatch(
             &stage1_output.memory_trace_holder,
             &full_trace.column_major_memory_trace,
-            NUM_CYCLES_PER_CHUNK,
+            num_cycles_per_chunk,
             &context,
         )
         .unwrap_or_else(|| "no flat-column mismatch found despite cap divergence".to_string());
@@ -320,7 +319,7 @@ pub(super) fn run_memory_workflow_input_parity_test<const FAMILY_IDX: u8>(
             &stage1_output.witness_trace_holder,
             &full_trace.column_major_witness_trace,
             generic_lookup_multiplicities_range.clone(),
-            NUM_CYCLES_PER_CHUNK,
+            num_cycles_per_chunk,
             &context,
         );
         assert!(
@@ -339,7 +338,7 @@ pub(super) fn run_memory_workflow_input_parity_test<const FAMILY_IDX: u8>(
         let first_mismatch = describe_first_trace_holder_column_mismatch(
             &stage1_output.witness_trace_holder,
             &full_trace.column_major_witness_trace,
-            NUM_CYCLES_PER_CHUNK,
+            num_cycles_per_chunk,
             &context,
         )
         .unwrap_or_else(|| "no flat-column mismatch found despite cap divergence".to_string());

--- a/gpu/circuit_prover/src/prover/tests/proof_matrix.rs
+++ b/gpu/circuit_prover/src/prover/tests/proof_matrix.rs
@@ -159,7 +159,7 @@ fn run_jump_branch_slt_profile_test() {
 fn prepare_shift_binop_proof_fixture() -> BasicUnrolledProofFixture {
     let (base, p) = prepare_unrolled_non_memory_proof_fixture::<SHIFT_BINARY_CIRCUIT_FAMILY_IDX>(
         &[15, 1],
-        4,
+        common_constants::PC_STEP as u32, // default_pc_value_in_padding
         UnrolledNonMemoryCircuitType::ShiftBinaryCsr,
         SHIFT_BINOP_LAYOUT_PATH,
         shift_binop_mod::witness_eval_fn,
@@ -175,7 +175,7 @@ fn prepare_shift_binop_proof_fixture() -> BasicUnrolledProofFixture {
 fn prepare_shift_binop_profiling_fixture() -> BasicUnrolledFixture {
     prepare_unrolled_non_memory_proof_fixture::<SHIFT_BINARY_CIRCUIT_FAMILY_IDX>(
         &[15, 1],
-        4,
+        common_constants::PC_STEP as u32, // default_pc_value_in_padding
         UnrolledNonMemoryCircuitType::ShiftBinaryCsr,
         SHIFT_BINOP_LAYOUT_PATH,
         shift_binop_mod::witness_eval_fn,
@@ -213,7 +213,7 @@ fn run_shift_binop_profile_test() {
 fn prepare_mul_div_proof_fixture() -> BasicUnrolledProofFixture {
     let (base, p) = prepare_unrolled_non_memory_proof_fixture::<MUL_DIV_CIRCUIT_FAMILY_IDX>(
         &[15, 1],
-        4,
+        common_constants::PC_STEP as u32, // default_pc_value_in_padding
         UnrolledNonMemoryCircuitType::MulDivUnsigned,
         UNSIGNED_MUL_DIV_LAYOUT_PATH,
         unsigned_mul_div_mod::witness_eval_fn,
@@ -229,7 +229,7 @@ fn prepare_mul_div_proof_fixture() -> BasicUnrolledProofFixture {
 fn prepare_mul_div_profiling_fixture() -> BasicUnrolledFixture {
     prepare_unrolled_non_memory_proof_fixture::<MUL_DIV_CIRCUIT_FAMILY_IDX>(
         &[15, 1],
-        4,
+        common_constants::PC_STEP as u32, // default_pc_value_in_padding
         UnrolledNonMemoryCircuitType::MulDivUnsigned,
         UNSIGNED_MUL_DIV_LAYOUT_PATH,
         unsigned_mul_div_mod::witness_eval_fn,

--- a/gpu/circuit_prover/src/prover/tests/proof_matrix.rs
+++ b/gpu/circuit_prover/src/prover/tests/proof_matrix.rs
@@ -105,7 +105,7 @@ fn run_add_sub_profile_test() {
 fn prepare_jump_branch_slt_proof_fixture() -> BasicUnrolledProofFixture {
     let (base, p) = prepare_unrolled_non_memory_proof_fixture::<JUMP_BRANCH_SLT_CIRCUIT_FAMILY_IDX>(
         &[15, 1],
-        4, // jump_branch_slt default_pc_value_in_padding (== GPU PC_STEP)
+        common_constants::PC_STEP as u32, // default_pc_value_in_padding
         UnrolledNonMemoryCircuitType::JumpBranchSlt,
         JUMP_BRANCH_SLT_LAYOUT_PATH,
         jump_branch_slt_mod::witness_eval_fn,
@@ -121,7 +121,7 @@ fn prepare_jump_branch_slt_proof_fixture() -> BasicUnrolledProofFixture {
 fn prepare_jump_branch_slt_profiling_fixture() -> BasicUnrolledFixture {
     prepare_unrolled_non_memory_proof_fixture::<JUMP_BRANCH_SLT_CIRCUIT_FAMILY_IDX>(
         &[15, 1],
-        4, // jump_branch_slt default_pc_value_in_padding (== GPU PC_STEP)
+        common_constants::PC_STEP as u32, // default_pc_value_in_padding
         UnrolledNonMemoryCircuitType::JumpBranchSlt,
         JUMP_BRANCH_SLT_LAYOUT_PATH,
         jump_branch_slt_mod::witness_eval_fn,

--- a/gpu/circuit_prover/src/prover/tests/stagewise.rs
+++ b/gpu/circuit_prover/src/prover/tests/stagewise.rs
@@ -179,7 +179,7 @@ fn run_basic_unrolled_stagewise_parity_test() {
     let oracle = NonMemoryCircuitOracle {
         inner: &buffer[..],
         decoder_table: decoder_table_data,
-        default_pc_value_in_padding: 4,
+        default_pc_value_in_padding: common_constants::PC_STEP as u32,
     };
 
     let memory_trace = evaluate_gkr_memory_witness_for_executor_family::<BF, _, _, _>(

--- a/gpu/circuit_prover/src/prover/tests/stagewise.rs
+++ b/gpu/circuit_prover/src/prover/tests/stagewise.rs
@@ -6,10 +6,12 @@ use super::*;
 fn run_basic_unrolled_stagewise_parity_test() {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    // NOTE: these constants must match with ones used in CS crate to produce
+    // NOTE: the trace length must match the one used in the CS crate to produce
     // layout and SSA forms, otherwise derived witness-gen functions may write into
-    // invalid locations
-    const TRACE_LEN_LOG2: usize = 24;
+    // invalid locations — so derive it from the circuit family's domain size
+    // (mirrors the upstream `DOMAIN_SIZE_LOG2`) rather than hardcoding it.
+    const TRACE_LEN_LOG2: usize =
+        UnrolledNonMemoryCircuitType::AddSubLuiAuipcMop.get_domain_size_log2();
     const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
 
     let trace_len: usize = 1 << TRACE_LEN_LOG2;

--- a/gpu/circuit_prover/src/prover/tests/unified_fixtures_helpers.rs
+++ b/gpu/circuit_prover/src/prover/tests/unified_fixtures_helpers.rs
@@ -13,7 +13,7 @@ const UNIFIED_LAYOUT_PATH: &str = "cs/compiled_circuits/unified_reduced_machine_
 const UNIFIED_BINARY_PATH: &str = "examples/multi_family_smoke/app_blake2_g_function.bin";
 const UNIFIED_TEXT_PATH: &str = "examples/multi_family_smoke/app_blake2_g_function.text";
 
-const TRACE_LEN_LOG2: usize = 24;
+const TRACE_LEN_LOG2: usize = UnrolledCircuitType::Unified.get_domain_size_log2();
 const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
 
 // Delegation cycle counts mirror the (test-gated, hence inlined here) constants
@@ -839,7 +839,6 @@ fn prepare_unified_fixture(
 ) {
     type CountersT = DelegationsAndUnifiedCounters;
 
-    const TRACE_LEN_LOG2: usize = 24;
     const FINAL_TRACE_SIZE_LOG_2: usize = 4;
     const HOST_POOL_SIZE_MB: usize = 1024;
     let device_allocator_arena_bytes: usize = 64usize << 30;
@@ -950,7 +949,7 @@ fn prepare_unified_fixture(
         GpuGKRSetupHost::precompute_from_cpu_setup(
             &setup,
             whir_schedule.base_lde_factor.trailing_zeros(),
-            1,
+            whir_schedule.whir_steps_schedule[0] as u32,
             whir_schedule.cap_size.trailing_zeros(),
             &context,
         )

--- a/gpu/circuit_prover/src/prover/tests/unified_stagewise.rs
+++ b/gpu/circuit_prover/src/prover/tests/unified_stagewise.rs
@@ -9,7 +9,7 @@ use super::inits_and_teardowns::{
 #[ignore]
 fn run_unified_stagewise_parity_test() {
     type CountersT = DelegationsAndUnifiedCounters;
-    const TRACE_LEN_LOG2: usize = 24;
+    const TRACE_LEN_LOG2: usize = UnrolledCircuitType::Unified.get_domain_size_log2();
     let trace_len: usize = 1 << TRACE_LEN_LOG2;
     let worker = Worker::new_with_num_threads(8);
 

--- a/gpu/circuit_prover/src/prover/tests/workflow_parity.rs
+++ b/gpu/circuit_prover/src/prover/tests/workflow_parity.rs
@@ -6,7 +6,8 @@ use super::*;
 fn run_jump_branch_slt_workflow_input_parity_test() {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    const TRACE_LEN_LOG2: usize = 24;
+    const TRACE_LEN_LOG2: usize =
+        UnrolledNonMemoryCircuitType::JumpBranchSlt.get_domain_size_log2();
     const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
 
     let trace_len: usize = 1 << TRACE_LEN_LOG2;
@@ -649,7 +650,8 @@ fn cached_main_layer_backward_plan_keeps_cache_inputs_layer_locality_test() {
 fn run_shift_binop_cached_lookup_parity_test() {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    const TRACE_LEN_LOG2: usize = 24;
+    const TRACE_LEN_LOG2: usize =
+        UnrolledNonMemoryCircuitType::ShiftBinaryCsr.get_domain_size_log2();
     const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
     const FINAL_TRACE_SIZE_LOG_2: usize = 4;
 

--- a/gpu/circuit_prover/src/prover/tests/workflow_parity.rs
+++ b/gpu/circuit_prover/src/prover/tests/workflow_parity.rs
@@ -137,7 +137,7 @@ fn run_jump_branch_slt_workflow_input_parity_test() {
     let oracle = NonMemoryCircuitOracle {
         inner: &buffer[..],
         decoder_table: decoder_table_data,
-        default_pc_value_in_padding: 0,
+        default_pc_value_in_padding: 4, // == GPU PC_STEP for jump_branch_slt
     };
     let mut table_driver = TableDriver::new();
     jump_branch_slt_table_driver_fn(&mut table_driver);

--- a/gpu/circuit_prover/src/prover/tests/workflow_parity.rs
+++ b/gpu/circuit_prover/src/prover/tests/workflow_parity.rs
@@ -137,7 +137,7 @@ fn run_jump_branch_slt_workflow_input_parity_test() {
     let oracle = NonMemoryCircuitOracle {
         inner: &buffer[..],
         decoder_table: decoder_table_data,
-        default_pc_value_in_padding: 4, // == GPU PC_STEP for jump_branch_slt
+        default_pc_value_in_padding: common_constants::PC_STEP as u32,
     };
     let mut table_driver = TableDriver::new();
     jump_branch_slt_table_driver_fn(&mut table_driver);
@@ -764,7 +764,7 @@ fn run_shift_binop_cached_lookup_parity_test() {
     let oracle = NonMemoryCircuitOracle {
         inner: &buffer[..],
         decoder_table: decoder_table_data,
-        default_pc_value_in_padding: 4,
+        default_pc_value_in_padding: common_constants::PC_STEP as u32,
     };
     let mut table_driver = TableDriver::new();
     shift_binop_table_driver_fn(&mut table_driver);

--- a/gpu/circuit_prover/src/witness/circuit_type.rs
+++ b/gpu/circuit_prover/src/witness/circuit_type.rs
@@ -186,6 +186,11 @@ impl UnrolledCircuitType {
     }
 
     #[inline(always)]
+    pub const fn get_domain_size_log2(&self) -> usize {
+        self.get_domain_size().trailing_zeros() as usize
+    }
+
+    #[inline(always)]
     pub const fn get_family_idx(&self) -> u8 {
         match self {
             Self::InitsAndTeardowns => INITS_AND_TEARDOWNS_FORMAL_CIRCUIT_FAMILY_IDX,
@@ -210,6 +215,11 @@ impl UnrolledMemoryCircuitType {
             Self::LoadStoreSubwordOnly => LOAD_STORE_SUBWORD_DOMAIN_SIZE,
             Self::LoadStoreWordOnly => LOAD_STORE_WORD_DOMAIN_SIZE,
         }
+    }
+
+    #[inline(always)]
+    pub const fn get_domain_size_log2(&self) -> usize {
+        self.get_domain_size().trailing_zeros() as usize
     }
 
     #[inline(always)]
@@ -249,6 +259,11 @@ impl UnrolledNonMemoryCircuitType {
             Self::MulDivUnsigned => MUL_DIV_UNSIGNED_DOMAIN_SIZE,
             Self::ShiftBinaryCsr => SHIFT_BINARY_DOMAIN_SIZE,
         }
+    }
+
+    #[inline(always)]
+    pub const fn get_domain_size_log2(&self) -> usize {
+        self.get_domain_size().trailing_zeros() as usize
     }
 
     #[inline(always)]

--- a/gpu/circuit_prover/src/witness/circuit_type.rs
+++ b/gpu/circuit_prover/src/witness/circuit_type.rs
@@ -296,11 +296,13 @@ impl UnrolledNonMemoryCircuitType {
 
     /// Final-PC value substituted into padding rows of the memory columns.
     /// Must equal the `PC_STEP` the CPU setups pass to
-    /// `make_setup_for_non_mem_circuit` for every family — the GPU proof-parity
-    /// fixtures thread THIS value into their CPU oracle, so a stale entry here
-    /// is invisible to the parity suite (it diverged for JumpBranchSlt until
-    /// the gpu_program_prover base-layer verify e2e caught it) — hence the arms
-    /// reference the upstream constant directly instead of a literal.
+    /// `make_setup_for_non_mem_circuit` for every family. The GPU test fixtures
+    /// anchor their CPU oracles to `common_constants::PC_STEP` directly — NOT
+    /// to this accessor — so a stale arm here diverges from the fixtures and
+    /// the parity suite catches it. Keep that separation: threading this
+    /// accessor into a CPU oracle makes the GPU-vs-CPU comparison tautological
+    /// (fixtures once did exactly that, and a stale JumpBranchSlt value stayed
+    /// invisible until the gpu_program_prover base-layer verify e2e caught it).
     #[inline(always)]
     pub const fn get_default_pc_value_in_padding(&self) -> u32 {
         match self {


### PR DESCRIPTION
## What ❔

- Fix `test_jump_branch_slt_commit_memory_matches_cpu` (and its `workflow_parity` sibling): the CPU reference oracle used `default_pc_value_in_padding = 0` while the GPU uses `PC_STEP` (= 4) — memory-tree caps diverged. The GPU was correct; the fixtures were stale.
- Anchor all 14 test padding-PC sites to `common_constants::PC_STEP` (deliberately not `get_default_pc_value_in_padding()`, which would make GPU-vs-CPU parity tautological — rationale now documented on the accessor).
- Derive test `TRACE_LEN_LOG2` / trace lengths from the circuit-type authority instead of hardcoded literals.

Follow-up type refactor (LOG2-first constants, u32 log2 typing) is split out into the stacked PR #349.

## Why ❔

A stale hardcoded copy of a production constant in a test oracle diverges silently (wrong caps, no panic). Anchoring tests to the upstream authorities eliminates the drift class while keeping parity assertions diagnostic.

Validated: both jump_branch_slt tests green under GPU lock; `cargo check -p gpu_circuit_prover` + unit tests green; independent review findings (4 missed fixture sites, stale comment) addressed.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

