### PR TITLE
refactor(gpu): LOG2-first domain-size constants and u32 log2 typing across the GPU stack

### DIFF
--- a/gpu/circuit_prover/src/prover/config.rs
+++ b/gpu/circuit_prover/src/prover/config.rs
@@ -54,7 +54,7 @@ fn config_for_supported_level(
     circuit_type: CircuitType,
     security_level: SecurityLevel,
 ) -> ProverConfig {
-    let domain_size_log_2 = circuit_type.get_domain_size().trailing_zeros() as usize;
+    let domain_size_log_2 = circuit_type.get_domain_size_log2();
     // CPU's `example_configs` only defines schedules for {20, 22, 24}; collapse
     // 23 onto 24 to match the previous GPU mapping.
     let schedule_log_2 = match domain_size_log_2 {

--- a/gpu/circuit_prover/src/prover/config.rs
+++ b/gpu/circuit_prover/src/prover/config.rs
@@ -67,7 +67,7 @@ fn config_for_supported_level(
             )
         }
     };
-    config_for_security_level_under_pessimistic_conjecture(schedule_log_2, security_level)
+    config_for_security_level_under_pessimistic_conjecture(schedule_log_2 as usize, security_level)
 }
 
 /// PoW bit count for the lookup challenges (`lookup_alpha`, `lookup_additive`),

--- a/gpu/circuit_prover/src/prover/gkr/backward/main_layer/extras.rs
+++ b/gpu/circuit_prover/src/prover/gkr/backward/main_layer/extras.rs
@@ -227,8 +227,8 @@ where
 pub(crate) fn derive_dimension_reducing_inputs(
     initial_layer_idx: usize,
     initial_output_map: &BTreeMap<OutputType, Vec<GKRAddress>>,
-    initial_trace_log_2: usize,
-    final_trace_log_2: usize,
+    initial_trace_log_2: u32,
+    final_trace_log_2: u32,
 ) -> BTreeMap<usize, BTreeMap<OutputType, DimensionReducingInputOutput>> {
     let mut result: BTreeMap<usize, BTreeMap<OutputType, DimensionReducingInputOutput>> =
         BTreeMap::new();

--- a/gpu/circuit_prover/src/prover/gkr/forward/dimension_reducing.rs
+++ b/gpu/circuit_prover/src/prover/gkr/forward/dimension_reducing.rs
@@ -30,8 +30,8 @@ pub(super) fn schedule_dimension_reduction_forward<E>(
     storage: &mut GpuGKRStorage<BF, E>,
     initial_layer_idx: usize,
     initial_output_map: BTreeMap<OutputType, Vec<GKRAddress>>,
-    initial_trace_log_2: usize,
-    final_trace_log_2: usize,
+    initial_trace_log_2: u32,
+    final_trace_log_2: u32,
     output_evaluations_slab: Option<ForwardOutputSlabTarget<E>>,
     tracing_ranges: &mut Vec<Range>,
     context: &ProverContext,
@@ -63,7 +63,7 @@ where
     // Phase 1: lower + commit every round sequentially so subsequent rounds can resolve inputs
     // from storage. Collect per-round per-slot output pointers for the later tower assembly.
     let mut per_round_slot_outputs: Vec<Vec<LoweredSlotOutput<E>>> =
-        Vec::with_capacity(total_rounds);
+        Vec::with_capacity(total_rounds as usize);
     let mut slot_initial_inputs: Option<Vec<LoweredSlotInitialInput<E>>> = None;
     let mut slot_output_types: Option<Vec<OutputType>> = None;
 
@@ -117,7 +117,7 @@ where
     let slot_output_types =
         slot_output_types.expect("non-zero rounds implies we captured slot output types");
     let slot_count = slot_initial_inputs.len();
-    let log_block = GKR_DIM_REDUCING_FORWARD_TOWER_LOG_BLOCK as usize;
+    let log_block = GKR_DIM_REDUCING_FORWARD_TOWER_LOG_BLOCK;
 
     let mut slot_idx = 0usize;
     while slot_idx < slot_count {
@@ -137,7 +137,7 @@ where
         for s in slot_idx..range_end {
             let mut cur_input = slot_initial_inputs[s];
             let mut cur_input_log_2 = initial_trace_log_2;
-            let mut r = 0usize;
+            let mut r = 0u32;
             while r < total_rounds {
                 let remaining = total_rounds - r;
                 let chunk_rounds = remaining.min(log_block);
@@ -154,7 +154,7 @@ where
                 r += chunk_rounds;
                 cur_input_log_2 -= chunk_rounds;
                 if r < total_rounds {
-                    let last_round = r - 1;
+                    let last_round = (r - 1) as usize;
                     cur_input = match per_round_slot_outputs[last_round][s] {
                         LoweredSlotOutput::PairwiseProduct { output } => {
                             LoweredSlotInitialInput::PairwiseProduct {
@@ -185,8 +185,8 @@ where
 fn dispatch_tower_slot_launch<E>(
     slot_input: LoweredSlotInitialInput<E>,
     slot_idx: usize,
-    chunk_start_round: usize,
-    chunk_rounds: usize,
+    chunk_start_round: u32,
+    chunk_rounds: u32,
     chunk_input_len: u32,
     per_round_slot_outputs: &[Vec<LoweredSlotOutput<E>>],
     stream: &era_cudart::stream::CudaStream,
@@ -199,9 +199,9 @@ where
             let mut batch = GpuGKRDimensionReducingForwardTowerPairwiseBatch::<E>::default();
             batch.input = input;
             batch.input_len = chunk_input_len;
-            batch.round_count = chunk_rounds as u32;
-            for local_r in 0..chunk_rounds {
-                let round_idx = chunk_start_round + local_r;
+            batch.round_count = chunk_rounds;
+            for local_r in 0..chunk_rounds as usize {
+                let round_idx = chunk_start_round as usize + local_r;
                 match per_round_slot_outputs[round_idx][slot_idx] {
                     LoweredSlotOutput::PairwiseProduct { output } => {
                         batch.round_outputs[local_r] = output;
@@ -219,9 +219,9 @@ where
             batch.input_num = num;
             batch.input_den = den;
             batch.input_len = chunk_input_len;
-            batch.round_count = chunk_rounds as u32;
-            for local_r in 0..chunk_rounds {
-                let round_idx = chunk_start_round + local_r;
+            batch.round_count = chunk_rounds;
+            for local_r in 0..chunk_rounds as usize {
+                let round_idx = chunk_start_round as usize + local_r;
                 match per_round_slot_outputs[round_idx][slot_idx] {
                     LoweredSlotOutput::LookupPair {
                         output_num,

--- a/gpu/circuit_prover/src/prover/gkr/forward/mod.rs
+++ b/gpu/circuit_prover/src/prover/gkr/forward/mod.rs
@@ -241,7 +241,7 @@ pub(crate) fn schedule_forward_pass<E>(
     // trivial (dummy) unified chunks. Values feed only constant terms in the
     // i&t initial-pair materialization; plan structure is invariant to them.
     inits_and_teardowns_top_bits: &[u32],
-    final_trace_size_log_2: usize,
+    final_trace_size_log_2: u32,
     output_evaluations_slab: Option<ForwardOutputSlabTarget<E>>,
     context: &ProverContext,
 ) -> CudaResult<GpuGKRForwardOutput<BF, E>>
@@ -287,7 +287,7 @@ where
     let storage_layout = std::sync::Arc::new(
         crate::prover::gkr::storage_layout::GpuGKRStorageLayout::from_artifact_with_tower(
             &compiled_circuit,
-            final_trace_size_log_2,
+            final_trace_size_log_2 as usize,
         ),
     );
     storage.set_layout(storage_layout);
@@ -352,7 +352,7 @@ where
             &mut storage,
             compiled_circuit.layers.len(),
             compiled_circuit.global_output_map.clone(),
-            trace_len.trailing_zeros() as usize,
+            trace_len.trailing_zeros(),
             final_trace_size_log_2,
             output_evaluations_slab,
             &mut tracing_ranges,

--- a/gpu/circuit_prover/src/prover/gkr/forward/tests/helpers.rs
+++ b/gpu/circuit_prover/src/prover/gkr/forward/tests/helpers.rs
@@ -124,8 +124,8 @@ pub(super) fn attach_test_dim_reducing_tower_layout(
     storage: &mut GpuGKRStorage<BF, E4>,
     initial_layer_idx: usize,
     initial_output_map: &BTreeMap<OutputType, Vec<GKRAddress>>,
-    initial_trace_log_2: usize,
-    final_trace_log_2: usize,
+    initial_trace_log_2: u32,
+    final_trace_log_2: u32,
 ) {
     use crate::prover::gkr::gkr_address_audit::AddressClass;
     use crate::prover::gkr::storage_layout::{
@@ -134,7 +134,7 @@ pub(super) fn attach_test_dim_reducing_tower_layout(
 
     let trace_len = 1usize << initial_trace_log_2;
     let total_rounds = initial_trace_log_2.saturating_sub(final_trace_log_2);
-    let total_layers = initial_layer_idx + total_rounds + 1;
+    let total_layers = initial_layer_idx + total_rounds as usize + 1;
     let mut layers = vec![GpuGKRLayerLayout::default(); total_layers];
 
     // Register the test fixture inputs at `initial_layer_idx`. The test

--- a/gpu/circuit_prover/src/prover/gkr/forward/tests/mod.rs
+++ b/gpu/circuit_prover/src/prover/gkr/forward/tests/mod.rs
@@ -767,8 +767,8 @@ fn dimension_reducing_forward_tower_matches_reference() {
     // initial_trace_log_2 = 11, final_trace_log_2 = 0 → 11 rounds total.
     // With log_block = 8: one 8-round body launch (grid 2^3 = 8) + one 3-round tail launch
     // (grid 1, parallel streams). Exercises both body and tail code paths.
-    let initial_trace_log_2 = 11usize;
-    let final_trace_log_2 = 0usize;
+    let initial_trace_log_2 = 11u32;
+    let final_trace_log_2 = 0u32;
     let initial_trace_len = 1usize << initial_trace_log_2;
     let current_layer_idx = 3usize;
 
@@ -881,7 +881,10 @@ fn dimension_reducing_forward_tower_matches_reference() {
     context.get_exec_stream().synchronize().unwrap();
 
     let total_rounds = initial_trace_log_2 - final_trace_log_2;
-    assert_eq!(final_layer_idx, current_layer_idx + total_rounds - 1);
+    assert_eq!(
+        final_layer_idx,
+        current_layer_idx + total_rounds as usize - 1
+    );
 
     // Walk every intermediate layer and compare against a fresh CPU reduction.
     let mut expected_read = read_values.clone();
@@ -900,7 +903,7 @@ fn dimension_reducing_forward_tower_matches_reference() {
         expected_generic = expected_lookup_pair_reduction(&expected_generic.0, &expected_generic.1);
 
         let layer_description = dim_reducing_inputs
-            .get(&(current_layer_idx + round_idx))
+            .get(&(current_layer_idx + round_idx as usize))
             .expect("dim reducing description present for round");
 
         let permutation_outputs = &layer_description[&OutputType::PermutationProduct].output;

--- a/gpu/circuit_prover/src/prover/pow.rs
+++ b/gpu/circuit_prover/src/prover/pow.rs
@@ -41,7 +41,7 @@ pub(crate) fn schedule_pow_verify_and_query_indexes(
     device_seed: &mut DeviceSlice<u32>,
     num_queries: usize,
     pow_bits: u32,
-    query_domain_log2: usize,
+    query_domain_log2: u32,
     nonce_slab_dst: &mut DeviceVariable<u64>,
     context: &ProverContext,
 ) -> CudaResult<PowAndQueryIndexesState> {
@@ -93,7 +93,7 @@ pub(crate) fn schedule_pow_verify_and_query_indexes(
     // + 1` already lands on a multiple of 8, advancing the transcript past the
     // CPU and diverging every subsequent Fiat-Shamir challenge (e.g. the WHIR
     // delinearization challenge) for that round.
-    let query_bits = num_queries * query_domain_log2;
+    let query_bits = num_queries * query_domain_log2 as usize;
     let required_words = query_bits.div_ceil(32);
     let padded_words = (required_words + 1).next_multiple_of(STATE_SIZE);
     let mut d_raw_bits: DeviceAllocation<u32> =

--- a/gpu/circuit_prover/src/prover/proof/layout/build_inputs.rs
+++ b/gpu/circuit_prover/src/prover/proof/layout/build_inputs.rs
@@ -11,7 +11,7 @@ pub(crate) fn build_proof_layout_inputs<E>(
     compiled_circuit: &GKRCircuitArtifact<BF>,
     external_challenges: &prover::gkr::prover::GKRExternalChallenges<BF, E>,
     whir_schedule: &WhirSchedule,
-    final_trace_size_log_2: usize,
+    final_trace_size_log_2: u32,
     memory_geometry: ProofLayoutBaseLayerGeometry,
     witness_geometry: ProofLayoutBaseLayerGeometry,
     setup_geometry: ProofLayoutBaseLayerGeometry,
@@ -29,7 +29,7 @@ where
     // L-1's `claim_idx` lookup. The clone is paid once per proof.
     let compiled_circuit =
         crate::prover::gkr::transform::normalize_compiled_circuit_for_gpu(compiled_circuit.clone());
-    let initial_trace_size_log_2 = compiled_circuit.trace_len.trailing_zeros() as usize;
+    let initial_trace_size_log_2 = compiled_circuit.trace_len.trailing_zeros();
     let dimension_reducing_inputs = crate::prover::gkr::backward::derive_dimension_reducing_inputs(
         compiled_circuit.layers.len(),
         &compiled_circuit.global_output_map,
@@ -52,7 +52,7 @@ where
             &main_layer_outputs,
         );
     assert!(initial_trace_size_log_2 >= final_trace_size_log_2);
-    let num_dim_reducing_layers = initial_trace_size_log_2 - final_trace_size_log_2;
+    let num_dim_reducing_layers = (initial_trace_size_log_2 - final_trace_size_log_2) as usize;
     let num_main_layers = compiled_circuit.layers.len();
     assert_eq!(
         dimension_reducing_inputs.len(),
@@ -102,7 +102,7 @@ where
     let mut backward_layers = Vec::with_capacity(num_dim_reducing_layers + num_main_layers);
     for slot in 0..num_dim_reducing_layers {
         let layer_idx = num_main_layers + num_dim_reducing_layers - 1 - slot;
-        let sumcheck_num_rounds = final_trace_size_log_2 + slot;
+        let sumcheck_num_rounds = final_trace_size_log_2 as usize + slot;
         let io_map = dimension_reducing_inputs
             .get(&layer_idx)
             .unwrap_or_else(|| {
@@ -131,7 +131,7 @@ where
     for layer_idx in (0..num_main_layers).rev() {
         backward_layers.push(BackwardLayerDims {
             layer_idx,
-            sumcheck_num_rounds: initial_trace_size_log_2,
+            sumcheck_num_rounds: initial_trace_size_log_2 as usize,
             final_step_eval_addresses: main_layer_input_addresses_per_layer[layer_idx].clone(),
             // Main-layer final step sends the single at-point evaluation; the
             // last coord is fixed in-loop at `last_r`.
@@ -158,7 +158,7 @@ where
     );
     let initial_values_per_leaf = 1usize << whir_schedule.whir_steps_schedule[0];
     let tree_cap_size = whir_schedule.cap_size;
-    let tree_cap_log2 = tree_cap_size.trailing_zeros() as usize;
+    let tree_cap_log2 = tree_cap_size.trailing_zeros();
     let initial_query_count = whir_schedule.whir_queries_schedule[0];
 
     let base_layer_dims = |g: ProofLayoutBaseLayerGeometry| -> WhirBaseLayerDims {
@@ -188,11 +188,11 @@ where
     let mut folded_trace_len_log2 = initial_trace_size_log_2;
     let mut intermediate = Vec::with_capacity(whir_schedule.whir_steps_lde_factors.len());
     for (oracle_idx, &lde_factor) in whir_schedule.whir_steps_lde_factors.iter().enumerate() {
-        folded_trace_len_log2 -= whir_schedule.whir_steps_schedule[oracle_idx];
+        folded_trace_len_log2 -= whir_schedule.whir_steps_schedule[oracle_idx] as u32;
         let values_per_leaf_log2 = whir_schedule.whir_steps_schedule[oracle_idx + 1];
-        let path_len = folded_trace_len_log2 + lde_factor.trailing_zeros() as usize
-            - values_per_leaf_log2
-            - tree_cap_log2;
+        let path_len = (folded_trace_len_log2 + lde_factor.trailing_zeros()
+            - values_per_leaf_log2 as u32
+            - tree_cap_log2) as usize;
         intermediate.push(WhirIntermediateDims {
             cap_digest_count: tree_cap_size,
             query_count: whir_schedule.whir_queries_schedule[oracle_idx + 1],
@@ -208,10 +208,10 @@ where
     // populates `WhirPolyCommitProof::final_monomials` from it.
     let total_folding_steps = whir_schedule.whir_steps_schedule.iter().sum::<usize>();
     assert!(
-        initial_trace_size_log_2 >= total_folding_steps,
+        initial_trace_size_log_2 as usize >= total_folding_steps,
         "whir_steps_schedule sum {total_folding_steps} exceeds initial_trace_size_log_2 {initial_trace_size_log_2}",
     );
-    let final_monomials_len = 1usize << (initial_trace_size_log_2 - total_folding_steps);
+    let final_monomials_len = 1usize << (initial_trace_size_log_2 as usize - total_folding_steps);
     let whir = WhirDims {
         setup: base_layer_dims(setup_geometry),
         memory: base_layer_dims(memory_geometry),

--- a/gpu/circuit_prover/src/prover/proof/mod.rs
+++ b/gpu/circuit_prover/src/prover/proof/mod.rs
@@ -44,7 +44,7 @@ pub fn prove<'a, A: GoodAllocator + 'a>(
     circuit_type: CircuitType,
     compiled_circuit: GKRCircuitArtifact<BF>,
     prover_config: &ProverConfig,
-    final_trace_size_log_2: usize,
+    final_trace_size_log_2: u32,
     inputs: GpuGKRProofTransfer<'a, A>,
     context: &ProverContext,
 ) -> CudaResult<GpuGKRProofJob<'a, A>> {

--- a/gpu/circuit_prover/src/prover/proof/orchestration/backward.rs
+++ b/gpu/circuit_prover/src/prover/proof/orchestration/backward.rs
@@ -40,7 +40,7 @@ pub(in crate::prover::proof) fn prepare_backward_handoff(
     forward_output: GpuGKRForwardOutput<BF, E4>,
     forward_setup: GpuGKRForwardSetup<E4>,
     mut d_seed: DeviceAllocation<u32>,
-    final_trace_size_log_2: usize,
+    final_trace_size_log_2: u32,
     context: &ProverContext,
 ) -> CudaResult<ForwardToBackwardHandoff> {
     let stream = context.get_exec_stream();
@@ -71,7 +71,7 @@ pub(in crate::prover::proof) fn prepare_backward_handoff(
             .transmute::<u32>()
     };
     crate::ops::blake2s::transcript_commit(&mut d_seed, d_flat_evals_u32, stream)?;
-    let num_challenges = final_trace_size_log_2 + 1;
+    let num_challenges = (final_trace_size_log_2 + 1) as usize;
     let mut d_evaluation_point_and_batching: DeviceAllocation<E4> =
         context.alloc(num_challenges, AllocationPlacement::BestFit)?;
     crate::ops::blake2s::transcript_squeeze_e4(
@@ -98,7 +98,7 @@ pub(in crate::prover::proof) fn prepare_backward_handoff(
     // scalars for the host-side workflow_state mirror.
     let poly_len = 1usize << final_trace_size_log_2;
     let mut eq_group_tables_for_init: DeviceAllocation<E4> = context.alloc(
-        eq_group_tables_len(final_trace_size_log_2).max(1),
+        eq_group_tables_len(final_trace_size_log_2 as usize).max(1),
         AllocationPlacement::Top,
     )?;
     let mut eq_values_for_init: DeviceAllocation<E4> =
@@ -106,7 +106,7 @@ pub(in crate::prover::proof) fn prepare_backward_handoff(
     launch_build_eq_values_from_point::<E4>(
         d_evaluation_point_and_batching.as_ptr(),
         0,
-        final_trace_size_log_2,
+        final_trace_size_log_2 as usize,
         eq_group_tables_for_init.as_mut_ptr(),
         eq_values_for_init.as_mut_ptr(),
         poly_len,

--- a/gpu/circuit_prover/src/prover/proof/orchestration/stage1_forward.rs
+++ b/gpu/circuit_prover/src/prover/proof/orchestration/stage1_forward.rs
@@ -54,7 +54,7 @@ pub(in crate::prover::proof) fn prepare_stage1_and_forward_setup<'a, A: GoodAllo
     compiled_circuit: &GKRCircuitArtifact<BF>,
     external_challenges: &GKRExternalChallenges<BF, E4>,
     prover_config: &ProverConfig,
-    final_trace_size_log_2: usize,
+    final_trace_size_log_2: u32,
     whir_schedule: &WhirSchedule,
     bundle: BundleDeviceRefs<'_, 'a>,
     tracing_data_transfer: Option<&TracingDataTransfer<'a, A>>,

--- a/gpu/circuit_prover/src/prover/proof/orchestration/whir.rs
+++ b/gpu/circuit_prover/src/prover/proof/orchestration/whir.rs
@@ -191,7 +191,7 @@ pub(in crate::prover::proof) fn schedule_whir_phase<'a>(
             whir_schedule.whir_steps_lde_factors.clone(),
             whir_schedule.whir_pow_schedule.clone(),
             whir_schedule.cap_size,
-            compiled_circuit.trace_len.trailing_zeros() as usize,
+            compiled_circuit.trace_len.trailing_zeros(),
             true, // use_hypercube_evals_for_batching
             proof_slab,
             proof_layout,

--- a/gpu/circuit_prover/src/prover/tests/basic_unrolled_parity.rs
+++ b/gpu/circuit_prover/src/prover/tests/basic_unrolled_parity.rs
@@ -443,13 +443,13 @@ fn run_basic_unrolled_workflow_input_parity_test() {
         );
     }
 
-    let final_trace_size_log_2 = 4;
+    let final_trace_size_log_2 = 4u32;
     let (initial_layer_for_sumcheck, dimension_reducing_inputs) =
         dimension_reduction::forward::evaluate_dimension_reduction_forward(
             &mut gkr_storage,
             &add_sub_circuit,
             trace_len.trailing_zeros() as usize,
-            final_trace_size_log_2,
+            final_trace_size_log_2 as usize,
             &worker,
         );
     let output_layer_for_sumcheck = &dimension_reducing_inputs[&initial_layer_for_sumcheck];

--- a/gpu/circuit_prover/src/prover/tests/basic_unrolled_parity.rs
+++ b/gpu/circuit_prover/src/prover/tests/basic_unrolled_parity.rs
@@ -6,7 +6,7 @@ use super::*;
 fn run_basic_unrolled_workflow_input_parity_test() {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    const TRACE_LEN_LOG2: usize =
+    const TRACE_LEN_LOG2: u32 =
         UnrolledNonMemoryCircuitType::AddSubLuiAuipcMop.get_domain_size_log2();
     const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
 
@@ -98,7 +98,7 @@ fn run_basic_unrolled_workflow_input_parity_test() {
         &|cs| add_sub_lui_auipc_mop_table_addition_fn(cs),
         &|cs| add_sub_lui_auipc_mop_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        TRACE_LEN_LOG2,
+        TRACE_LEN_LOG2 as usize,
     );
     let num_calls =
         counters.get_calls_to_circuit_family::<ADD_SUB_LUI_AUIPC_MOP_CIRCUIT_FAMILY_IDX>();

--- a/gpu/circuit_prover/src/prover/tests/commit_memory.rs
+++ b/gpu/circuit_prover/src/prover/tests/commit_memory.rs
@@ -9,7 +9,7 @@ fn test_commit_memory_matches_cpu() {
         &|cs| add_sub_lui_auipc_mop_table_addition_fn(cs),
         &|cs| add_sub_lui_auipc_mop_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        UnrolledNonMemoryCircuitType::AddSubLuiAuipcMop.get_domain_size_log2(),
+        UnrolledNonMemoryCircuitType::AddSubLuiAuipcMop.get_domain_size_log2() as usize,
     );
     assert_non_memory_commit_memory_matches_cpu_for_test::<ADD_SUB_LUI_AUIPC_MOP_CIRCUIT_FAMILY_IDX>(
         "examples/basic_fibonacci/app.bin",
@@ -29,7 +29,7 @@ fn test_jump_branch_slt_commit_memory_matches_cpu() {
         &|cs| jump_branch_slt_table_addition_fn(cs),
         &|cs| jump_branch_slt_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        UnrolledNonMemoryCircuitType::JumpBranchSlt.get_domain_size_log2(),
+        UnrolledNonMemoryCircuitType::JumpBranchSlt.get_domain_size_log2() as usize,
     );
     assert_non_memory_commit_memory_matches_cpu_for_test::<JUMP_BRANCH_SLT_CIRCUIT_FAMILY_IDX>(
         "examples/hashed_fibonacci/app.bin",
@@ -49,7 +49,7 @@ fn test_shift_binop_commit_memory_matches_cpu() {
         &|cs| shift_binop_table_addition_fn(cs),
         &|cs| shift_binop_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        UnrolledNonMemoryCircuitType::ShiftBinaryCsr.get_domain_size_log2(),
+        UnrolledNonMemoryCircuitType::ShiftBinaryCsr.get_domain_size_log2() as usize,
     );
     assert_non_memory_commit_memory_matches_cpu_for_test::<SHIFT_BINARY_CIRCUIT_FAMILY_IDX>(
         "examples/hashed_fibonacci/app.bin",

--- a/gpu/circuit_prover/src/prover/tests/delegation_asserts.rs
+++ b/gpu/circuit_prover/src/prover/tests/delegation_asserts.rs
@@ -319,13 +319,13 @@ pub(super) fn assert_delegation_workflow_matches_cpu<W, O, F>(
         );
     }
 
-    let final_trace_size_log_2 = 4;
+    let final_trace_size_log_2 = 4u32;
     let (initial_layer_for_sumcheck, dimension_reducing_inputs) =
         dimension_reduction::forward::evaluate_dimension_reduction_forward(
             &mut gkr_storage,
             &compiled_circuit,
             trace_len.trailing_zeros() as usize,
-            final_trace_size_log_2,
+            final_trace_size_log_2 as usize,
             &worker,
         );
     let output_layer_for_sumcheck = &dimension_reducing_inputs[&initial_layer_for_sumcheck];

--- a/gpu/circuit_prover/src/prover/tests/fixtures_helpers.rs
+++ b/gpu/circuit_prover/src/prover/tests/fixtures_helpers.rs
@@ -171,7 +171,7 @@ pub(super) fn finish_proof_fixture(
     BasicUnrolledFixture,
     Option<GKRProof<BF, E4, DefaultTreeConstructor>>,
 ) {
-    const FINAL_TRACE_SIZE_LOG_2: usize = 4;
+    const FINAL_TRACE_SIZE_LOG_2: u32 = 4;
     const HOST_POOL_SIZE_MB: usize = 1024;
     // Match the production-sized arena. Every consumer either runs a full
     // GPU prove on this context or hands the context off into a downstream
@@ -581,7 +581,7 @@ pub(super) fn finish_proof_fixture_memory(
     BasicUnrolledFixture,
     Option<GKRProof<BF, E4, DefaultTreeConstructor>>,
 ) {
-    const FINAL_TRACE_SIZE_LOG_2: usize = 4;
+    const FINAL_TRACE_SIZE_LOG_2: u32 = 4;
     const HOST_POOL_SIZE_MB: usize = 1024;
     let device_allocator_arena_bytes: usize = 64usize << 30;
 
@@ -1052,7 +1052,7 @@ pub(super) fn build_basic_unrolled_async_backward_fixture_from_base(
 
     commit_field_els::<BF, E4>(&mut seed, &gpu_evals_flattened);
     let mut challenges =
-        draw_random_field_els::<BF, E4>(&mut seed, base.final_trace_size_log_2 + 1);
+        draw_random_field_els::<BF, E4>(&mut seed, (base.final_trace_size_log_2 + 1) as usize);
     let batching_challenge = challenges.pop().unwrap();
     let evaluation_point = challenges;
 

--- a/gpu/circuit_prover/src/prover/tests/inits_and_teardowns.rs
+++ b/gpu/circuit_prover/src/prover/tests/inits_and_teardowns.rs
@@ -114,7 +114,7 @@ pub(super) fn prepare_inits_and_teardowns_proof_fixture(
 ) {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    const TRACE_LEN_LOG2: usize = UnrolledCircuitType::InitsAndTeardowns.get_domain_size_log2();
+    const TRACE_LEN_LOG2: u32 = UnrolledCircuitType::InitsAndTeardowns.get_domain_size_log2();
     const FINAL_TRACE_SIZE_LOG_2: usize = 4;
 
     let trace_len = 1usize << TRACE_LEN_LOG2;
@@ -158,7 +158,7 @@ pub(super) fn prepare_inits_and_teardowns_proof_fixture(
     let num_sets = compiled_circuit.memory_layout.teardown_sets.len();
     let (page_indices, values_packed, timestamps_packed) = build_inits_and_teardowns_pages_for_test(
         &sparse_inits_and_teardowns,
-        TRACE_LEN_LOG2 as u32,
+        TRACE_LEN_LOG2,
         num_sets as u32,
     );
     let mut it_columns = Vec::with_capacity(num_sets);
@@ -176,7 +176,7 @@ pub(super) fn prepare_inits_and_teardowns_proof_fixture(
     }
     ram.collect_inits_and_teardowns_into_columns::<BF, _>(
         &worker,
-        TRACE_LEN_LOG2,
+        TRACE_LEN_LOG2 as usize,
         0,
         &mut it_columns,
     );
@@ -333,7 +333,7 @@ pub(super) fn prepare_inits_and_teardowns_proof_fixture(
 fn standalone_inits_and_teardowns_gpu_workflow_matches_cpu() {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    const TRACE_LEN_LOG2: usize = UnrolledCircuitType::InitsAndTeardowns.get_domain_size_log2();
+    const TRACE_LEN_LOG2: u32 = UnrolledCircuitType::InitsAndTeardowns.get_domain_size_log2();
     const FINAL_TRACE_SIZE_LOG_2: usize = 4;
 
     let trace_len = 1usize << TRACE_LEN_LOG2;
@@ -375,7 +375,7 @@ fn standalone_inits_and_teardowns_gpu_workflow_matches_cpu() {
     let num_init_and_teardown_sets = compiled_circuit.memory_layout.teardown_sets.len();
     let (page_indices, values_packed, timestamps_packed) = build_inits_and_teardowns_pages_for_test(
         &sparse_inits_and_teardowns,
-        TRACE_LEN_LOG2 as u32,
+        TRACE_LEN_LOG2,
         num_init_and_teardown_sets as u32,
     );
     let mut inits_and_teardowns_columns = Vec::with_capacity(num_init_and_teardown_sets);
@@ -393,7 +393,7 @@ fn standalone_inits_and_teardowns_gpu_workflow_matches_cpu() {
     }
     ram.collect_inits_and_teardowns_into_columns::<BF, _>(
         &worker,
-        TRACE_LEN_LOG2,
+        TRACE_LEN_LOG2 as usize,
         0,
         &mut inits_and_teardowns_columns,
     );

--- a/gpu/circuit_prover/src/prover/tests/inits_and_teardowns.rs
+++ b/gpu/circuit_prover/src/prover/tests/inits_and_teardowns.rs
@@ -115,7 +115,7 @@ pub(super) fn prepare_inits_and_teardowns_proof_fixture(
     type CountersT = DelegationsAndFamiliesCounters;
 
     const TRACE_LEN_LOG2: u32 = UnrolledCircuitType::InitsAndTeardowns.get_domain_size_log2();
-    const FINAL_TRACE_SIZE_LOG_2: usize = 4;
+    const FINAL_TRACE_SIZE_LOG_2: u32 = 4;
 
     let trace_len = 1usize << TRACE_LEN_LOG2;
     let worker = Worker::new_with_num_threads(8);
@@ -334,7 +334,7 @@ fn standalone_inits_and_teardowns_gpu_workflow_matches_cpu() {
     type CountersT = DelegationsAndFamiliesCounters;
 
     const TRACE_LEN_LOG2: u32 = UnrolledCircuitType::InitsAndTeardowns.get_domain_size_log2();
-    const FINAL_TRACE_SIZE_LOG_2: usize = 4;
+    const FINAL_TRACE_SIZE_LOG_2: u32 = 4;
 
     let trace_len = 1usize << TRACE_LEN_LOG2;
     let worker = Worker::new_with_num_threads(8);
@@ -638,7 +638,7 @@ fn standalone_inits_and_teardowns_gpu_workflow_matches_cpu() {
                 &mut gkr_storage,
                 &compiled_circuit,
                 trace_len.trailing_zeros() as usize,
-                FINAL_TRACE_SIZE_LOG_2,
+                FINAL_TRACE_SIZE_LOG_2 as usize,
                 &worker,
             );
         let output_layer_for_sumcheck = &dimension_reducing_inputs[&initial_layer_for_sumcheck];

--- a/gpu/circuit_prover/src/prover/tests/memory_workflow.rs
+++ b/gpu/circuit_prover/src/prover/tests/memory_workflow.rs
@@ -73,7 +73,7 @@ pub(super) fn run_memory_workflow_input_parity_test<const FAMILY_IDX: u8>(
 ) {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    const FINAL_TRACE_SIZE_LOG_2: usize = 4;
+    const FINAL_TRACE_SIZE_LOG_2: u32 = 4;
 
     let trace_len: usize = compiled_circuit.trace_len;
     let num_cycles_per_chunk: usize = trace_len;
@@ -466,7 +466,7 @@ pub(super) fn run_memory_workflow_input_parity_test<const FAMILY_IDX: u8>(
             &mut gkr_storage,
             &compiled_circuit,
             trace_len.trailing_zeros() as usize,
-            FINAL_TRACE_SIZE_LOG_2,
+            FINAL_TRACE_SIZE_LOG_2 as usize,
             &worker,
         );
     let output_layer_for_sumcheck = &dimension_reducing_inputs[&initial_layer_for_sumcheck];

--- a/gpu/circuit_prover/src/prover/tests/memory_workflow.rs
+++ b/gpu/circuit_prover/src/prover/tests/memory_workflow.rs
@@ -35,7 +35,7 @@ pub(super) fn compile_mem_word_only_circuit_for_test(binary: &[u32]) -> GKRCircu
         },
         &|cs| mem_word_only_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        UnrolledMemoryCircuitType::LoadStoreWordOnly.get_domain_size_log2(),
+        UnrolledMemoryCircuitType::LoadStoreWordOnly.get_domain_size_log2() as usize,
     )
 }
 
@@ -51,7 +51,7 @@ pub(super) fn compile_mem_subword_only_circuit_for_test(binary: &[u32]) -> GKRCi
         },
         &|cs| mem_subword_only_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        UnrolledMemoryCircuitType::LoadStoreSubwordOnly.get_domain_size_log2(),
+        UnrolledMemoryCircuitType::LoadStoreSubwordOnly.get_domain_size_log2() as usize,
     )
 }
 

--- a/gpu/circuit_prover/src/prover/tests/mod.rs
+++ b/gpu/circuit_prover/src/prover/tests/mod.rs
@@ -444,7 +444,7 @@ fn schedule_forward_pass<E>(
     forward_setup: &mut super::gkr::setup::GpuGKRForwardSetup<E>,
     compiled_circuit: &GKRCircuitArtifact<BF>,
     external_challenges: &GKRExternalChallenges<BF, E>,
-    final_trace_size_log_2: usize,
+    final_trace_size_log_2: u32,
     context: &ProverContext,
 ) -> CudaResult<super::gkr::forward::GpuGKRForwardOutput<BF, E>>
 where
@@ -489,7 +489,7 @@ pub(crate) struct BasicUnrolledFixture {
     pub(crate) compiled_circuit: GKRCircuitArtifact<BF>,
     pub(crate) external_challenges: GKRExternalChallenges<BF, E4>,
     pub(crate) prover_config: ProverConfig,
-    pub(crate) final_trace_size_log_2: usize,
+    pub(crate) final_trace_size_log_2: u32,
     /// GPU setup (preprocessed) trace host. `None` for the standalone
     /// inits-and-teardowns circuit, which has a zero-width setup layout
     /// (`witness_layout.total_width == 0`) and is proven with `setup = None`

--- a/gpu/circuit_prover/src/prover/tests/stagewise.rs
+++ b/gpu/circuit_prover/src/prover/tests/stagewise.rs
@@ -10,7 +10,7 @@ fn run_basic_unrolled_stagewise_parity_test() {
     // layout and SSA forms, otherwise derived witness-gen functions may write into
     // invalid locations — so derive it from the circuit family's domain size
     // (mirrors the upstream `DOMAIN_SIZE_LOG2`) rather than hardcoding it.
-    const TRACE_LEN_LOG2: usize =
+    const TRACE_LEN_LOG2: u32 =
         UnrolledNonMemoryCircuitType::AddSubLuiAuipcMop.get_domain_size_log2();
     const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
 
@@ -140,7 +140,7 @@ fn run_basic_unrolled_stagewise_parity_test() {
         &|cs| add_sub_lui_auipc_mop_table_addition_fn(cs),
         &|cs| add_sub_lui_auipc_mop_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        TRACE_LEN_LOG2,
+        TRACE_LEN_LOG2 as usize,
     );
 
     let num_calls =

--- a/gpu/circuit_prover/src/prover/tests/stagewise.rs
+++ b/gpu/circuit_prover/src/prover/tests/stagewise.rs
@@ -429,13 +429,13 @@ fn run_basic_unrolled_stagewise_parity_test() {
         );
     }
 
-    let final_trace_size_log_2 = 4;
+    let final_trace_size_log_2 = 4u32;
     let (initial_layer_for_sumcheck, dimension_reducing_inputs) =
         dimension_reduction::forward::evaluate_dimension_reduction_forward(
             &mut gkr_storage,
             &add_sub_circuit,
             trace_len.trailing_zeros() as usize,
-            final_trace_size_log_2,
+            final_trace_size_log_2 as usize,
             &worker,
         );
     let output_layer_for_sumcheck = &dimension_reducing_inputs[&initial_layer_for_sumcheck];
@@ -526,7 +526,7 @@ fn run_basic_unrolled_stagewise_parity_test() {
     commit_field_els::<BF, E4>(&mut gpu_seed, &gpu_evals_flattened);
     assert_eq!(gpu_seed, seed_after_cpu_explicit_commit);
 
-    let num_challenges = final_trace_size_log_2 + 1;
+    let num_challenges = (final_trace_size_log_2 + 1) as usize;
     let mut challenges = draw_random_field_els::<BF, E4>(&mut seed, num_challenges);
     let expected_challenges = challenges.clone();
     let mut gpu_challenges = draw_random_field_els::<BF, E4>(&mut gpu_seed, num_challenges);
@@ -979,7 +979,7 @@ fn run_basic_unrolled_stagewise_parity_test() {
             &whir_schedule,
             &twiddles,
             seed.clone(),
-            trace_len.trailing_zeros() as usize,
+            trace_len.trailing_zeros(),
             &worker,
             &context,
         )

--- a/gpu/circuit_prover/src/prover/tests/unified_fixtures_helpers.rs
+++ b/gpu/circuit_prover/src/prover/tests/unified_fixtures_helpers.rs
@@ -13,7 +13,7 @@ const UNIFIED_LAYOUT_PATH: &str = "cs/compiled_circuits/unified_reduced_machine_
 const UNIFIED_BINARY_PATH: &str = "examples/multi_family_smoke/app_blake2_g_function.bin";
 const UNIFIED_TEXT_PATH: &str = "examples/multi_family_smoke/app_blake2_g_function.text";
 
-const TRACE_LEN_LOG2: usize = UnrolledCircuitType::Unified.get_domain_size_log2();
+const TRACE_LEN_LOG2: u32 = UnrolledCircuitType::Unified.get_domain_size_log2();
 const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
 
 // Delegation cycle counts mirror the (test-gated, hence inlined here) constants
@@ -129,7 +129,7 @@ pub(super) fn build_unified_full_trace_for_test(
     }
     ram.collect_inits_and_teardowns_into_columns::<BF, _>(
         worker,
-        TRACE_LEN_LOG2,
+        TRACE_LEN_LOG2 as usize,
         0,
         &mut unified_inits_and_teardowns,
     );
@@ -960,7 +960,7 @@ fn prepare_unified_fixture(
     // Sparse i/t triples -> page-based GPU wire format -> transfer host.
     let (page_indices, values_packed, timestamps_packed) = build_inits_and_teardowns_pages_for_test(
         &sparse_inits_and_teardowns,
-        TRACE_LEN_LOG2 as u32,
+        TRACE_LEN_LOG2,
         num_unified_teardown_sets as u32,
     );
     let inits_and_teardowns_host = build_inits_and_teardowns_trace_host_for_test(

--- a/gpu/circuit_prover/src/prover/tests/unified_fixtures_helpers.rs
+++ b/gpu/circuit_prover/src/prover/tests/unified_fixtures_helpers.rs
@@ -600,7 +600,7 @@ where
     O: cs::oracle::Oracle<BF>,
     W: crate::prover::trace::tracing_data::DelegationTracingDataHostSource,
 {
-    const FINAL_TRACE_SIZE_LOG_2: usize = 4;
+    const FINAL_TRACE_SIZE_LOG_2: u32 = 4;
     const HOST_POOL_SIZE_MB: usize = 1024;
     let device_allocator_arena_bytes: usize = 64usize << 30;
     let device_allocator_block_log_size = default_fixture_device_allocator_block_log_size();
@@ -723,7 +723,7 @@ pub(super) fn prepare_delegation_profiling_fixture<W>(
 where
     W: crate::prover::trace::tracing_data::DelegationTracingDataHostSource,
 {
-    const FINAL_TRACE_SIZE_LOG_2: usize = 4;
+    const FINAL_TRACE_SIZE_LOG_2: u32 = 4;
     const HOST_POOL_SIZE_MB: usize = 1024;
     let device_allocator_arena_bytes: usize = 64usize << 30;
     let device_allocator_block_log_size = default_fixture_device_allocator_block_log_size();
@@ -839,7 +839,7 @@ fn prepare_unified_fixture(
 ) {
     type CountersT = DelegationsAndUnifiedCounters;
 
-    const FINAL_TRACE_SIZE_LOG_2: usize = 4;
+    const FINAL_TRACE_SIZE_LOG_2: u32 = 4;
     const HOST_POOL_SIZE_MB: usize = 1024;
     let device_allocator_arena_bytes: usize = 64usize << 30;
     let device_allocator_block_log_size = default_fixture_device_allocator_block_log_size();

--- a/gpu/circuit_prover/src/prover/tests/unified_stagewise.rs
+++ b/gpu/circuit_prover/src/prover/tests/unified_stagewise.rs
@@ -9,7 +9,7 @@ use super::inits_and_teardowns::{
 #[ignore]
 fn run_unified_stagewise_parity_test() {
     type CountersT = DelegationsAndUnifiedCounters;
-    const TRACE_LEN_LOG2: usize = UnrolledCircuitType::Unified.get_domain_size_log2();
+    const TRACE_LEN_LOG2: u32 = UnrolledCircuitType::Unified.get_domain_size_log2();
     let trace_len: usize = 1 << TRACE_LEN_LOG2;
     let worker = Worker::new_with_num_threads(8);
 
@@ -119,7 +119,7 @@ fn run_unified_stagewise_parity_test() {
     // Build inits-and-teardowns device and transfer.
     let (page_indices, values_packed, timestamps_packed) = build_inits_and_teardowns_pages_for_test(
         &sparse_inits_and_teardowns,
-        TRACE_LEN_LOG2 as u32,
+        TRACE_LEN_LOG2,
         num_unified_teardown_sets as u32,
     );
     let it_host = build_inits_and_teardowns_trace_host_for_test(

--- a/gpu/circuit_prover/src/prover/tests/unified_stagewise.rs
+++ b/gpu/circuit_prover/src/prover/tests/unified_stagewise.rs
@@ -342,13 +342,13 @@ fn run_unified_stagewise_parity_test() {
         );
     }
 
-    let final_trace_size_log_2 = 4;
+    let final_trace_size_log_2 = 4u32;
     let (initial_layer_for_sumcheck, dimension_reducing_inputs) =
         dimension_reduction::forward::evaluate_dimension_reduction_forward(
             &mut gkr_storage,
             &compiled_circuit,
             trace_len.trailing_zeros() as usize,
-            final_trace_size_log_2,
+            final_trace_size_log_2 as usize,
             &worker,
         );
     let output_layer_for_sumcheck = &dimension_reducing_inputs[&initial_layer_for_sumcheck];
@@ -409,7 +409,7 @@ fn run_unified_stagewise_parity_test() {
     commit_field_els::<BF, E4>(&mut gpu_seed, &gpu_evals_flattened);
     assert_eq!(gpu_seed, seed_after_cpu_explicit_commit);
 
-    let num_challenges = final_trace_size_log_2 + 1;
+    let num_challenges = (final_trace_size_log_2 + 1) as usize;
     let mut challenges = draw_random_field_els::<BF, E4>(&mut seed, num_challenges);
     let expected_challenges = challenges.clone();
     let mut gpu_challenges = draw_random_field_els::<BF, E4>(&mut gpu_seed, num_challenges);

--- a/gpu/circuit_prover/src/prover/tests/whir_oracle_parity.rs
+++ b/gpu/circuit_prover/src/prover/tests/whir_oracle_parity.rs
@@ -11,7 +11,7 @@ use crate::prover::proof_layout::{
 /// CPU reference.
 fn build_whir_only_proof_layout_inputs(
     whir_schedule: &WhirSchedule,
-    initial_trace_size_log_2: usize,
+    initial_trace_size_log_2: u32,
     memory_holder: &TraceHolder<BF>,
     witness_holder: &TraceHolder<BF>,
     setup_holder: &TraceHolder<BF>,
@@ -30,7 +30,7 @@ fn build_whir_only_proof_layout_inputs(
     );
     let initial_values_per_leaf = 1usize << whir_schedule.whir_steps_schedule[0];
     let tree_cap_size = whir_schedule.cap_size;
-    let tree_cap_log2 = tree_cap_size.trailing_zeros() as usize;
+    let tree_cap_log2 = tree_cap_size.trailing_zeros();
     let initial_query_count = whir_schedule.whir_queries_schedule[0];
 
     let base_layer_dims = |holder: &TraceHolder<BF>| -> WhirBaseLayerDims {
@@ -55,11 +55,11 @@ fn build_whir_only_proof_layout_inputs(
     let mut folded_trace_len_log2 = initial_trace_size_log_2;
     let mut intermediate = Vec::with_capacity(whir_schedule.whir_steps_lde_factors.len());
     for (oracle_idx, &lde_factor) in whir_schedule.whir_steps_lde_factors.iter().enumerate() {
-        folded_trace_len_log2 -= whir_schedule.whir_steps_schedule[oracle_idx];
+        folded_trace_len_log2 -= whir_schedule.whir_steps_schedule[oracle_idx] as u32;
         let values_per_leaf_log2 = whir_schedule.whir_steps_schedule[oracle_idx + 1];
-        let path_len = folded_trace_len_log2 + lde_factor.trailing_zeros() as usize
-            - values_per_leaf_log2
-            - tree_cap_log2;
+        let path_len = (folded_trace_len_log2 + lde_factor.trailing_zeros()
+            - values_per_leaf_log2 as u32
+            - tree_cap_log2) as usize;
         intermediate.push(WhirIntermediateDims {
             cap_digest_count: tree_cap_size,
             query_count: whir_schedule.whir_queries_schedule[oracle_idx + 1],
@@ -69,7 +69,7 @@ fn build_whir_only_proof_layout_inputs(
     }
 
     let total_folding_steps = whir_schedule.whir_steps_schedule.iter().sum::<usize>();
-    let final_monomials_len = 1usize << (initial_trace_size_log_2 - total_folding_steps);
+    let final_monomials_len = 1usize << (initial_trace_size_log_2 - total_folding_steps as u32);
     let whir = WhirDims {
         setup: base_layer_dims(setup_holder),
         memory: base_layer_dims(memory_holder),
@@ -104,7 +104,7 @@ pub(super) fn assert_recursive_whir_oracle_parity_for_supported_path(
     whir_schedule: &WhirSchedule,
     twiddles: &Twiddles<BF, Global>,
     mut transcript_seed: Seed,
-    trace_len_log2: usize,
+    trace_len_log2: u32,
     worker: &Worker,
     context: &ProverContext,
 ) -> WhirPolyCommitProof<BF, E4, DefaultTreeConstructor> {
@@ -284,7 +284,7 @@ pub(super) fn assert_recursive_whir_oracle_parity_for_supported_path(
             );
         }
     }
-    poly_size_log2 -= num_initial_folding_rounds;
+    poly_size_log2 -= num_initial_folding_rounds as u32;
 
     let first_lde_factor = whir_steps_lde_factors.next().unwrap();
     let next_folding_steps = *whir_steps_schedule.peek().unwrap();
@@ -406,8 +406,8 @@ pub(super) fn assert_recursive_whir_oracle_parity_for_supported_path(
         gpu_initial_round_checkpoint.transcript_seed, transcript_seed,
         "initial WHIR transcript seed diverged before PoW",
     );
-    let rs_domain_log2 = trace_len_log2 + original_lde_factor.trailing_zeros() as usize;
-    let query_domain_log2 = rs_domain_log2 - num_initial_folding_rounds;
+    let rs_domain_log2 = trace_len_log2 + original_lde_factor.trailing_zeros();
+    let query_domain_log2 = rs_domain_log2 - num_initial_folding_rounds as u32;
     let query_domain_size = 1u64 << query_domain_log2;
     let query_domain_generator = domain_generator_for_size::<BF>(query_domain_size);
     let extended_generator = domain_generator_for_size::<BF>(1u64 << rs_domain_log2);
@@ -482,8 +482,8 @@ pub(super) fn assert_recursive_whir_oracle_parity_for_supported_path(
         let num_folding_steps = whir_steps_schedule.next().unwrap();
         let num_queries = whir_queries_schedule.next().unwrap();
         let pow_bits = whir_pow_schedule.next().unwrap();
-        let rs_domain_log2 = poly_size_log2 + cpu_rs_oracle.cosets.len().trailing_zeros() as usize;
-        let query_domain_log2 = rs_domain_log2 - num_folding_steps;
+        let rs_domain_log2 = poly_size_log2 + cpu_rs_oracle.cosets.len().trailing_zeros();
+        let query_domain_log2 = rs_domain_log2 - num_folding_steps as u32;
         let mut folding_challenges_in_round = Vec::with_capacity(num_folding_steps);
         for _ in 0..num_folding_steps {
             let (f0, f1, f_half) =
@@ -499,7 +499,7 @@ pub(super) fn assert_recursive_whir_oracle_parity_for_supported_path(
             fold_evaluation_form_for_test(&mut sumchecked_poly_evaluation_form, folding_challenge);
             fold_evaluation_form_for_test(&mut eq_poly, folding_challenge);
         }
-        poly_size_log2 -= num_folding_steps;
+        poly_size_log2 -= num_folding_steps as u32;
 
         let lde_factor = whir_steps_lde_factors.next().unwrap();
         let next_folding_steps = *whir_steps_schedule.peek().unwrap();
@@ -615,8 +615,8 @@ pub(super) fn assert_recursive_whir_oracle_parity_for_supported_path(
     let final_folding_steps = whir_steps_schedule.next().unwrap();
     let final_queries = whir_queries_schedule.next().unwrap();
     let final_pow_bits = whir_pow_schedule.next().unwrap();
-    let rs_domain_log2 = poly_size_log2 + cpu_rs_oracle.cosets.len().trailing_zeros() as usize;
-    let query_domain_log2 = rs_domain_log2 - final_folding_steps;
+    let rs_domain_log2 = poly_size_log2 + cpu_rs_oracle.cosets.len().trailing_zeros();
+    let query_domain_log2 = rs_domain_log2 - final_folding_steps as u32;
     let mut folding_challenges_in_round = Vec::with_capacity(final_folding_steps);
     for _ in 0..final_folding_steps {
         let (f0, f1, f_half) =

--- a/gpu/circuit_prover/src/prover/tests/workflow_parity.rs
+++ b/gpu/circuit_prover/src/prover/tests/workflow_parity.rs
@@ -6,8 +6,7 @@ use super::*;
 fn run_jump_branch_slt_workflow_input_parity_test() {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    const TRACE_LEN_LOG2: usize =
-        UnrolledNonMemoryCircuitType::JumpBranchSlt.get_domain_size_log2();
+    const TRACE_LEN_LOG2: u32 = UnrolledNonMemoryCircuitType::JumpBranchSlt.get_domain_size_log2();
     const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
 
     let trace_len: usize = 1 << TRACE_LEN_LOG2;
@@ -98,7 +97,7 @@ fn run_jump_branch_slt_workflow_input_parity_test() {
         &|cs| jump_branch_slt_table_addition_fn(cs),
         &|cs| jump_branch_slt_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        TRACE_LEN_LOG2,
+        TRACE_LEN_LOG2 as usize,
     );
     let num_calls = counters.get_calls_to_circuit_family::<JUMP_BRANCH_SLT_CIRCUIT_FAMILY_IDX>();
     assert!(
@@ -650,8 +649,7 @@ fn cached_main_layer_backward_plan_keeps_cache_inputs_layer_locality_test() {
 fn run_shift_binop_cached_lookup_parity_test() {
     type CountersT = DelegationsAndFamiliesCounters;
 
-    const TRACE_LEN_LOG2: usize =
-        UnrolledNonMemoryCircuitType::ShiftBinaryCsr.get_domain_size_log2();
+    const TRACE_LEN_LOG2: u32 = UnrolledNonMemoryCircuitType::ShiftBinaryCsr.get_domain_size_log2();
     const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
     const FINAL_TRACE_SIZE_LOG_2: usize = 4;
 
@@ -709,7 +707,7 @@ fn run_shift_binop_cached_lookup_parity_test() {
         &|cs| shift_binop_table_addition_fn(cs),
         &|cs| shift_binop_circuit_with_preprocessed_bytecode_for_gkr(cs),
         1 << 20,
-        TRACE_LEN_LOG2,
+        TRACE_LEN_LOG2 as usize,
     );
     let num_calls = counters.get_calls_to_circuit_family::<SHIFT_BINARY_CIRCUIT_FAMILY_IDX>();
     assert!(

--- a/gpu/circuit_prover/src/prover/tests/workflow_parity.rs
+++ b/gpu/circuit_prover/src/prover/tests/workflow_parity.rs
@@ -448,13 +448,13 @@ fn run_jump_branch_slt_workflow_input_parity_test() {
         );
     }
 
-    let final_trace_size_log_2 = 4;
+    let final_trace_size_log_2 = 4u32;
     let (initial_layer_for_sumcheck, dimension_reducing_inputs) =
         dimension_reduction::forward::evaluate_dimension_reduction_forward(
             &mut gkr_storage,
             &jump_branch_slt_circuit,
             trace_len.trailing_zeros() as usize,
-            final_trace_size_log_2,
+            final_trace_size_log_2 as usize,
             &worker,
         );
     let output_layer_for_sumcheck = &dimension_reducing_inputs[&initial_layer_for_sumcheck];
@@ -651,7 +651,7 @@ fn run_shift_binop_cached_lookup_parity_test() {
 
     const TRACE_LEN_LOG2: u32 = UnrolledNonMemoryCircuitType::ShiftBinaryCsr.get_domain_size_log2();
     const NUM_CYCLES_PER_CHUNK: usize = 1 << TRACE_LEN_LOG2;
-    const FINAL_TRACE_SIZE_LOG_2: usize = 4;
+    const FINAL_TRACE_SIZE_LOG_2: u32 = 4;
 
     let trace_len: usize = 1 << TRACE_LEN_LOG2;
     let worker = Worker::new_with_num_threads(8);
@@ -949,7 +949,7 @@ fn run_shift_binop_cached_lookup_parity_test() {
             &mut gkr_storage,
             &shift_binop_circuit,
             trace_len.trailing_zeros() as usize,
-            FINAL_TRACE_SIZE_LOG_2,
+            FINAL_TRACE_SIZE_LOG_2 as usize,
             &worker,
         );
     let output_layer_for_sumcheck = &dimension_reducing_inputs[&initial_layer_for_sumcheck];

--- a/gpu/circuit_prover/src/prover/whir/fold/schedule/mod.rs
+++ b/gpu/circuit_prover/src/prover/whir/fold/schedule/mod.rs
@@ -33,7 +33,7 @@ pub(crate) fn schedule_gpu_whir_fold_with_sources(
     whir_steps_lde_factors: Vec<usize>,
     whir_pow_schedule: Vec<u32>,
     tree_cap_size: usize,
-    trace_len_log2: usize,
+    trace_len_log2: u32,
     use_hypercube_evals_for_batching: bool,
     // slab + layout thread through so WHIR sub-phases route proof fields
     // (`pow_nonces`, caps, evals, queries, ood_samples, sumcheck_polys,
@@ -43,12 +43,9 @@ pub(crate) fn schedule_gpu_whir_fold_with_sources(
     context: &ProverContext,
 ) -> CudaResult<GpuWhirFoldScheduledExecution> {
     let trace_len = 1usize << trace_len_log2;
-    assert_eq!(memory_trace_holder.log_domain_size as usize, trace_len_log2);
-    assert_eq!(
-        witness_trace_holder.log_domain_size as usize,
-        trace_len_log2
-    );
-    assert_eq!(setup_trace_holder.log_domain_size as usize, trace_len_log2);
+    assert_eq!(memory_trace_holder.log_domain_size, trace_len_log2);
+    assert_eq!(witness_trace_holder.log_domain_size, trace_len_log2);
+    assert_eq!(setup_trace_holder.log_domain_size, trace_len_log2);
     assert_eq!(
         1usize << memory_trace_holder.log_lde_factor,
         original_lde_factor
@@ -226,7 +223,7 @@ pub(crate) fn schedule_gpu_whir_fold_with_sources(
             Range::new("gkr.whir.base_round.0.pow_and_query_indexes")?;
         pow_and_query_indexes_range.start(stream)?;
         let query_domain_log2 =
-            trace_len_log2 + original_lde_factor.trailing_zeros() as usize - num_folding_steps;
+            trace_len_log2 + original_lde_factor.trailing_zeros() - num_folding_steps as u32;
         let query_domain_size = 1u64 << query_domain_log2;
         let query_domain_generator = domain_generator_for_size::<BF>(query_domain_size);
         schedule_pow_and_query_indexes_phase(
@@ -540,8 +537,8 @@ pub(crate) fn schedule_gpu_whir_fold_with_sources(
         let pow_and_query_indexes_name = format!("{round_name}.pow_and_query_indexes");
         let pow_and_query_indexes_range = Range::new(&*pow_and_query_indexes_name)?;
         pow_and_query_indexes_range.start(stream)?;
-        let query_domain_log2 = state.current_len.trailing_zeros() as usize
-            + oracle_to_query.lde_factor().trailing_zeros() as usize;
+        let query_domain_log2 =
+            state.current_len.trailing_zeros() + oracle_to_query.lde_factor().trailing_zeros();
         let query_domain_size = 1u64 << query_domain_log2;
         let query_domain_generator = domain_generator_for_size::<BF>(query_domain_size);
         schedule_pow_and_query_indexes_phase(
@@ -700,7 +697,7 @@ pub(crate) fn schedule_gpu_whir_fold_with_sources(
         // equal `1 << (trace_len_log2 - sum(whir_steps_schedule))`.
         assert_eq!(
             state.current_len,
-            1usize << (trace_len_log2 - total_sumcheck_polys),
+            1usize << (trace_len_log2 - total_sumcheck_polys as u32),
             "WHIR final-fold current_len must match slab final_monomials_len",
         );
         // Transpose writes the pre-bitreverse
@@ -760,8 +757,8 @@ pub(crate) fn schedule_gpu_whir_fold_with_sources(
         }
 
         let mut oracle_to_query = rs_oracle.take().unwrap();
-        let query_domain_log2 = state.current_len.trailing_zeros() as usize
-            + oracle_to_query.lde_factor().trailing_zeros() as usize;
+        let query_domain_log2 =
+            state.current_len.trailing_zeros() + oracle_to_query.lde_factor().trailing_zeros();
         let pow_and_query_indexes_range = Range::new("gkr.whir.final_round.pow_and_query_indexes")?;
         pow_and_query_indexes_range.start(stream)?;
         schedule_pow_and_query_indexes_phase(

--- a/gpu/circuit_prover/src/prover/whir/fold/schedule/round_phases.rs
+++ b/gpu/circuit_prover/src/prover/whir/fold/schedule/round_phases.rs
@@ -125,7 +125,7 @@ pub(super) fn schedule_pow_and_query_indexes_phase(
     num_queries: usize,
     pow_bits: u32,
     pow_round_idx: usize,
-    query_domain_log2: usize,
+    query_domain_log2: u32,
     proof_slab: &DeviceAllocation<E4>,
     proof_layout: &ProofLayout,
     pow_round_state: &mut Vec<PowAndQueryIndexesState>,

--- a/gpu/circuit_prover/src/prover/whir/mod.rs
+++ b/gpu/circuit_prover/src/prover/whir/mod.rs
@@ -44,7 +44,7 @@ pub(crate) struct GpuWhirExtensionOracle {
     trace_holder: TraceHolder<BF>,
     values_per_leaf: usize,
     lde_factor: usize,
-    trace_len_log2: usize,
+    trace_len_log2: u32,
     packed_leaf_count: usize,
 }
 
@@ -150,11 +150,11 @@ impl GpuWhirExtensionOracle {
             "recursive WHIR oracles require LDE factor > 1"
         );
 
-        let trace_len_log2 = trace_len.trailing_zeros() as usize;
+        let trace_len_log2 = trace_len.trailing_zeros();
         let log_lde_factor = lde_factor.trailing_zeros() as u32;
         let log_values_per_leaf = values_per_leaf.trailing_zeros() as u32;
         let log_tree_cap_size = tree_cap_size.trailing_zeros();
-        assert!(trace_len_log2 >= log_values_per_leaf as usize);
+        assert!(trace_len_log2 >= log_values_per_leaf);
         let packed_leaf_count = trace_len / values_per_leaf;
         let packed_leaf_count_log2 = packed_leaf_count.trailing_zeros();
         let total_leaf_count_log2 = packed_leaf_count_log2 + log_lde_factor;
@@ -182,7 +182,7 @@ impl GpuWhirExtensionOracle {
             CapTarget::OwnAllocation => {
                 trace_holder.whir_lde_and_commit_all(
                     &inputs_matrix,
-                    trace_len_log2 as u32,
+                    trace_len_log2,
                     log_lde_factor,
                     log_values_per_leaf,
                     EXT4_DEGREE,
@@ -194,7 +194,7 @@ impl GpuWhirExtensionOracle {
                 trace_holder.whir_lde_and_commit_all_into(
                     &inputs_matrix,
                     dst_u32,
-                    trace_len_log2 as u32,
+                    trace_len_log2,
                     log_lde_factor,
                     log_values_per_leaf,
                     EXT4_DEGREE,
@@ -276,7 +276,7 @@ impl GpuWhirExtensionOracle {
         self.trace_holder.schedule_query_leaves_into_from_ntt(
             slab_indices_view,
             slab_leaves_dst_bf,
-            self.trace_len_log2 as u32,
+            self.trace_len_log2,
             natural_log_lde_factor,
             log_values_per_leaf,
             LOG_SRC_COLS_PER_COSET,
@@ -286,7 +286,7 @@ impl GpuWhirExtensionOracle {
             .schedule_query_merkle_paths_into_from_ntt(
                 slab_indices_view,
                 slab_paths_dst,
-                self.trace_len_log2 as u32,
+                self.trace_len_log2,
                 natural_log_lde_factor,
                 log_values_per_leaf,
                 LOG_SRC_COLS_PER_COSET,
@@ -339,7 +339,7 @@ impl GpuWhirExtensionOracle {
             self.trace_holder.schedule_query_leaves_into_from_ntt(
                 &device_tree_index,
                 &mut d_leafs[..],
-                self.trace_len_log2 as u32,
+                self.trace_len_log2,
                 natural_log_lde_factor,
                 log_values_per_leaf,
                 LOG_SRC_COLS_PER_COSET,
@@ -355,7 +355,7 @@ impl GpuWhirExtensionOracle {
             const LOG_SRC_COLS_PER_COSET: u32 = 2;
             self.trace_holder.get_query_merkle_paths_from_ntt(
                 &device_tree_index,
-                self.trace_len_log2 as u32,
+                self.trace_len_log2,
                 natural_log_lde_factor,
                 log_values_per_leaf,
                 LOG_SRC_COLS_PER_COSET,
@@ -548,7 +548,7 @@ pub(crate) mod tests {
                 self.trace_holder.schedule_query_leaves_into_from_ntt(
                     &device_tree_index,
                     &mut d_leafs[..],
-                    self.trace_len_log2 as u32,
+                    self.trace_len_log2,
                     natural_log_lde_factor,
                     log_values_per_leaf,
                     LOG_SRC_COLS_PER_COSET,
@@ -564,7 +564,7 @@ pub(crate) mod tests {
                 const LOG_SRC_COLS_PER_COSET: u32 = 2;
                 self.trace_holder.get_query_merkle_paths_from_ntt(
                     &device_tree_index,
-                    self.trace_len_log2 as u32,
+                    self.trace_len_log2,
                     natural_log_lde_factor,
                     log_values_per_leaf,
                     LOG_SRC_COLS_PER_COSET,
@@ -661,7 +661,7 @@ pub(crate) mod tests {
         twiddles: &Twiddles<BF, Global>,
         lde_factor: usize,
     ) -> Vec<(Box<[E4]>, BF)> {
-        let trace_len_log2 = monomial_coeffs.len().trailing_zeros() as usize;
+        let trace_len_log2 = monomial_coeffs.len().trailing_zeros();
         let next_root =
             domain_generator_for_size::<BF>(((1 << trace_len_log2) * lde_factor) as u64);
         let root_powers =
@@ -678,7 +678,7 @@ pub(crate) mod tests {
                 bitreverse_enumeration_inplace(&mut evals[..]);
                 fft::naive::serial_ct_ntt_bitreversed_to_natural(
                     &mut evals[..],
-                    trace_len_log2 as u32,
+                    trace_len_log2,
                     selected_twiddles,
                 );
                 (evals.into_boxed_slice(), offset)

--- a/gpu/circuit_prover/src/witness/circuit_type.rs
+++ b/gpu/circuit_prover/src/witness/circuit_type.rs
@@ -21,14 +21,15 @@ use common_constants::delegation_types::{
 
 const BIGINT_DOMAIN_SIZE_LOG2: usize =
     <BigIntDelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2 as usize;
-const BLAKE_DOMAIN_SIZE_LOG2: usize = <Blake2sWithCompressionDelegationCircuit as
-    DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2 as usize;
+const BLAKE_DOMAIN_SIZE_LOG2: usize =
+    <Blake2sWithCompressionDelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2
+        as usize;
 const BLAKE_G_FUNCTION_DOMAIN_SIZE_LOG2: usize =
     <Blake2sGFunctionDelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2
         as usize;
-const KECCAK_DOMAIN_SIZE_LOG2: usize =
-    <KeccakSpecial5DelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2
-        as usize;
+const KECCAK_DOMAIN_SIZE_LOG2: usize = <KeccakSpecial5DelegationCircuit as DelegationCircuit<
+    BabyBearField,
+>>::DOMAIN_SIZE_LOG2 as usize;
 
 const ADD_SUB_DOMAIN_SIZE_LOG2: usize =
     <AddSubLuiAuipcMopCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2

--- a/gpu/circuit_prover/src/witness/circuit_type.rs
+++ b/gpu/circuit_prover/src/witness/circuit_type.rs
@@ -19,37 +19,32 @@ use common_constants::delegation_types::{
     keccak_special5::KECCAK_SPECIAL5_CSR_REGISTER,
 };
 
-const BIGINT_DOMAIN_SIZE_LOG2: usize =
-    <BigIntDelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2 as usize;
-const BLAKE_DOMAIN_SIZE_LOG2: usize =
-    <Blake2sWithCompressionDelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2
-        as usize;
-const BLAKE_G_FUNCTION_DOMAIN_SIZE_LOG2: usize =
-    <Blake2sGFunctionDelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2
-        as usize;
-const KECCAK_DOMAIN_SIZE_LOG2: usize = <KeccakSpecial5DelegationCircuit as DelegationCircuit<
-    BabyBearField,
->>::DOMAIN_SIZE_LOG2 as usize;
+const BIGINT_DOMAIN_SIZE_LOG2: u32 =
+    <BigIntDelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2;
+const BLAKE_DOMAIN_SIZE_LOG2: u32 =
+    <Blake2sWithCompressionDelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2;
+const BLAKE_G_FUNCTION_DOMAIN_SIZE_LOG2: u32 =
+    <Blake2sGFunctionDelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2;
+const KECCAK_DOMAIN_SIZE_LOG2: u32 =
+    <KeccakSpecial5DelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2;
 
-const ADD_SUB_DOMAIN_SIZE_LOG2: usize =
-    <AddSubLuiAuipcMopCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2
-        as usize;
+const ADD_SUB_DOMAIN_SIZE_LOG2: u32 =
+    <AddSubLuiAuipcMopCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2;
 // No live upstream DOMAIN_SIZE_LOG2 trait const exists for the unified
 // reduced-machine circuit, so hard-code 24 to match the CPU trace_len_log2
 // (pinned by tests::unified_domain_size_is_two_pow_24).
-const UNIFIED_REDUCED_MACHINE_DOMAIN_SIZE_LOG2: usize = 24;
-const JUMP_BRANCH_DOMAIN_SIZE_LOG2: usize =
-    <JumpBranchSltCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2 as usize;
-const SHIFT_BINARY_DOMAIN_SIZE_LOG2: usize =
-    <ShiftBinaryCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2 as usize;
-const LOAD_STORE_WORD_DOMAIN_SIZE_LOG2: usize =
-    <LoadStoreWordOnlyCircuit as RiscVCycleCircuit<BabyBearField, true>>::DOMAIN_SIZE_LOG2 as usize;
-const LOAD_STORE_SUBWORD_DOMAIN_SIZE_LOG2: usize =
-    <LoadStoreSubwordOnlyCircuit as RiscVCycleCircuit<BabyBearField, true>>::DOMAIN_SIZE_LOG2
-        as usize;
-const INITS_AND_TEARDOWNS_DOMAIN_SIZE_LOG2: usize = inits_and_teardowns::TRACE_LEN_LOG2 as usize;
-const MUL_DIV_UNSIGNED_DOMAIN_SIZE_LOG2: usize =
-    <UnsignedMulDivCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2 as usize;
+const UNIFIED_REDUCED_MACHINE_DOMAIN_SIZE_LOG2: u32 = 24;
+const JUMP_BRANCH_DOMAIN_SIZE_LOG2: u32 =
+    <JumpBranchSltCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2;
+const SHIFT_BINARY_DOMAIN_SIZE_LOG2: u32 =
+    <ShiftBinaryCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2;
+const LOAD_STORE_WORD_DOMAIN_SIZE_LOG2: u32 =
+    <LoadStoreWordOnlyCircuit as RiscVCycleCircuit<BabyBearField, true>>::DOMAIN_SIZE_LOG2;
+const LOAD_STORE_SUBWORD_DOMAIN_SIZE_LOG2: u32 =
+    <LoadStoreSubwordOnlyCircuit as RiscVCycleCircuit<BabyBearField, true>>::DOMAIN_SIZE_LOG2;
+const INITS_AND_TEARDOWNS_DOMAIN_SIZE_LOG2: u32 = inits_and_teardowns::TRACE_LEN_LOG2;
+const MUL_DIV_UNSIGNED_DOMAIN_SIZE_LOG2: u32 =
+    <UnsignedMulDivCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum CircuitType {
@@ -64,7 +59,7 @@ impl CircuitType {
     }
 
     #[inline(always)]
-    pub const fn get_domain_size_log2(&self) -> usize {
+    pub const fn get_domain_size_log2(&self) -> u32 {
         match self {
             Self::Delegation(delegation_type) => delegation_type.get_domain_size_log2(),
             Self::Unrolled(unrolled_type) => unrolled_type.get_domain_size_log2(),
@@ -101,7 +96,7 @@ impl DelegationCircuitType {
     }
 
     #[inline(always)]
-    pub const fn get_domain_size_log2(&self) -> usize {
+    pub const fn get_domain_size_log2(&self) -> u32 {
         match self {
             Self::BigIntWithControl => BIGINT_DOMAIN_SIZE_LOG2,
             Self::Blake2WithCompression => BLAKE_DOMAIN_SIZE_LOG2,
@@ -196,7 +191,7 @@ impl UnrolledCircuitType {
     }
 
     #[inline(always)]
-    pub const fn get_domain_size_log2(&self) -> usize {
+    pub const fn get_domain_size_log2(&self) -> u32 {
         match self {
             Self::InitsAndTeardowns => INITS_AND_TEARDOWNS_DOMAIN_SIZE_LOG2,
             Self::Memory(circuit_type) => circuit_type.get_domain_size_log2(),
@@ -230,7 +225,7 @@ impl UnrolledMemoryCircuitType {
     }
 
     #[inline(always)]
-    pub const fn get_domain_size_log2(&self) -> usize {
+    pub const fn get_domain_size_log2(&self) -> u32 {
         match self {
             Self::LoadStoreSubwordOnly => LOAD_STORE_SUBWORD_DOMAIN_SIZE_LOG2,
             Self::LoadStoreWordOnly => LOAD_STORE_WORD_DOMAIN_SIZE_LOG2,
@@ -272,7 +267,7 @@ impl UnrolledNonMemoryCircuitType {
     }
 
     #[inline(always)]
-    pub const fn get_domain_size_log2(&self) -> usize {
+    pub const fn get_domain_size_log2(&self) -> u32 {
         match self {
             Self::AddSubLuiAuipcMop => ADD_SUB_DOMAIN_SIZE_LOG2,
             Self::JumpBranchSlt => JUMP_BRANCH_DOMAIN_SIZE_LOG2,

--- a/gpu/circuit_prover/src/witness/circuit_type.rs
+++ b/gpu/circuit_prover/src/witness/circuit_type.rs
@@ -19,32 +19,36 @@ use common_constants::delegation_types::{
     keccak_special5::KECCAK_SPECIAL5_CSR_REGISTER,
 };
 
-const BIGINT_DOMAIN_SIZE: usize =
-    1 << <BigIntDelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2;
-const BLAKE_DOMAIN_SIZE: usize = 1 << <Blake2sWithCompressionDelegationCircuit as
-    DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2;
-const BLAKE_G_FUNCTION_DOMAIN_SIZE: usize =
-    1 << <Blake2sGFunctionDelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2;
-const KECCAK_DOMAIN_SIZE: usize =
-    1 << <KeccakSpecial5DelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2;
+const BIGINT_DOMAIN_SIZE_LOG2: usize =
+    <BigIntDelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2 as usize;
+const BLAKE_DOMAIN_SIZE_LOG2: usize = <Blake2sWithCompressionDelegationCircuit as
+    DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2 as usize;
+const BLAKE_G_FUNCTION_DOMAIN_SIZE_LOG2: usize =
+    <Blake2sGFunctionDelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2
+        as usize;
+const KECCAK_DOMAIN_SIZE_LOG2: usize =
+    <KeccakSpecial5DelegationCircuit as DelegationCircuit<BabyBearField>>::DOMAIN_SIZE_LOG2
+        as usize;
 
-const ADD_SUB_DOMAIN_SIZE: usize =
-    1 << <AddSubLuiAuipcMopCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2;
+const ADD_SUB_DOMAIN_SIZE_LOG2: usize =
+    <AddSubLuiAuipcMopCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2
+        as usize;
 // No live upstream DOMAIN_SIZE_LOG2 trait const exists for the unified
-// reduced-machine circuit, so hard-code to 2^24 to match the CPU trace_len_log2
+// reduced-machine circuit, so hard-code 24 to match the CPU trace_len_log2
 // (pinned by tests::unified_domain_size_is_two_pow_24).
-const UNIFIED_REDUCED_MACHINE_DOMAIN_SIZE: usize = 1 << 24;
-const JUMP_BRANCH_DOMAIN_SIZE: usize =
-    1 << <JumpBranchSltCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2;
-const SHIFT_BINARY_DOMAIN_SIZE: usize =
-    1 << <ShiftBinaryCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2;
-const LOAD_STORE_WORD_DOMAIN_SIZE: usize =
-    1 << <LoadStoreWordOnlyCircuit as RiscVCycleCircuit<BabyBearField, true>>::DOMAIN_SIZE_LOG2;
-const LOAD_STORE_SUBWORD_DOMAIN_SIZE: usize =
-    1 << <LoadStoreSubwordOnlyCircuit as RiscVCycleCircuit<BabyBearField, true>>::DOMAIN_SIZE_LOG2;
-const INITS_AND_TEARDOWNS_DOMAIN_SIZE: usize = 1 << inits_and_teardowns::TRACE_LEN_LOG2;
-const MUL_DIV_UNSIGNED_DOMAIN_SIZE: usize =
-    1 << <UnsignedMulDivCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2;
+const UNIFIED_REDUCED_MACHINE_DOMAIN_SIZE_LOG2: usize = 24;
+const JUMP_BRANCH_DOMAIN_SIZE_LOG2: usize =
+    <JumpBranchSltCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2 as usize;
+const SHIFT_BINARY_DOMAIN_SIZE_LOG2: usize =
+    <ShiftBinaryCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2 as usize;
+const LOAD_STORE_WORD_DOMAIN_SIZE_LOG2: usize =
+    <LoadStoreWordOnlyCircuit as RiscVCycleCircuit<BabyBearField, true>>::DOMAIN_SIZE_LOG2 as usize;
+const LOAD_STORE_SUBWORD_DOMAIN_SIZE_LOG2: usize =
+    <LoadStoreSubwordOnlyCircuit as RiscVCycleCircuit<BabyBearField, true>>::DOMAIN_SIZE_LOG2
+        as usize;
+const INITS_AND_TEARDOWNS_DOMAIN_SIZE_LOG2: usize = inits_and_teardowns::TRACE_LEN_LOG2 as usize;
+const MUL_DIV_UNSIGNED_DOMAIN_SIZE_LOG2: usize =
+    <UnsignedMulDivCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2 as usize;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum CircuitType {
@@ -55,9 +59,14 @@ pub enum CircuitType {
 impl CircuitType {
     #[inline(always)]
     pub const fn get_domain_size(&self) -> usize {
+        1 << self.get_domain_size_log2()
+    }
+
+    #[inline(always)]
+    pub const fn get_domain_size_log2(&self) -> usize {
         match self {
-            Self::Delegation(delegation_type) => delegation_type.get_domain_size(),
-            Self::Unrolled(unrolled_type) => unrolled_type.get_domain_size(),
+            Self::Delegation(delegation_type) => delegation_type.get_domain_size_log2(),
+            Self::Unrolled(unrolled_type) => unrolled_type.get_domain_size_log2(),
         }
     }
 
@@ -87,11 +96,16 @@ impl DelegationCircuitType {
 
     #[inline(always)]
     pub const fn get_domain_size(&self) -> usize {
+        1 << self.get_domain_size_log2()
+    }
+
+    #[inline(always)]
+    pub const fn get_domain_size_log2(&self) -> usize {
         match self {
-            Self::BigIntWithControl => BIGINT_DOMAIN_SIZE,
-            Self::Blake2WithCompression => BLAKE_DOMAIN_SIZE,
-            Self::Blake2GFunction => BLAKE_G_FUNCTION_DOMAIN_SIZE,
-            Self::KeccakSpecial5 => KECCAK_DOMAIN_SIZE,
+            Self::BigIntWithControl => BIGINT_DOMAIN_SIZE_LOG2,
+            Self::Blake2WithCompression => BLAKE_DOMAIN_SIZE_LOG2,
+            Self::Blake2GFunction => BLAKE_G_FUNCTION_DOMAIN_SIZE_LOG2,
+            Self::KeccakSpecial5 => KECCAK_DOMAIN_SIZE_LOG2,
         }
     }
 
@@ -177,17 +191,17 @@ pub enum UnrolledCircuitType {
 impl UnrolledCircuitType {
     #[inline(always)]
     pub const fn get_domain_size(&self) -> usize {
-        match self {
-            Self::InitsAndTeardowns => INITS_AND_TEARDOWNS_DOMAIN_SIZE,
-            Self::Memory(circuit_type) => circuit_type.get_domain_size(),
-            Self::NonMemory(circuit_type) => circuit_type.get_domain_size(),
-            Self::Unified => UNIFIED_REDUCED_MACHINE_DOMAIN_SIZE,
-        }
+        1 << self.get_domain_size_log2()
     }
 
     #[inline(always)]
     pub const fn get_domain_size_log2(&self) -> usize {
-        self.get_domain_size().trailing_zeros() as usize
+        match self {
+            Self::InitsAndTeardowns => INITS_AND_TEARDOWNS_DOMAIN_SIZE_LOG2,
+            Self::Memory(circuit_type) => circuit_type.get_domain_size_log2(),
+            Self::NonMemory(circuit_type) => circuit_type.get_domain_size_log2(),
+            Self::Unified => UNIFIED_REDUCED_MACHINE_DOMAIN_SIZE_LOG2,
+        }
     }
 
     #[inline(always)]
@@ -211,15 +225,15 @@ pub enum UnrolledMemoryCircuitType {
 impl UnrolledMemoryCircuitType {
     #[inline(always)]
     pub const fn get_domain_size(&self) -> usize {
-        match self {
-            Self::LoadStoreSubwordOnly => LOAD_STORE_SUBWORD_DOMAIN_SIZE,
-            Self::LoadStoreWordOnly => LOAD_STORE_WORD_DOMAIN_SIZE,
-        }
+        1 << self.get_domain_size_log2()
     }
 
     #[inline(always)]
     pub const fn get_domain_size_log2(&self) -> usize {
-        self.get_domain_size().trailing_zeros() as usize
+        match self {
+            Self::LoadStoreSubwordOnly => LOAD_STORE_SUBWORD_DOMAIN_SIZE_LOG2,
+            Self::LoadStoreWordOnly => LOAD_STORE_WORD_DOMAIN_SIZE_LOG2,
+        }
     }
 
     #[inline(always)]
@@ -253,17 +267,17 @@ pub enum UnrolledNonMemoryCircuitType {
 impl UnrolledNonMemoryCircuitType {
     #[inline(always)]
     pub const fn get_domain_size(&self) -> usize {
-        match self {
-            Self::AddSubLuiAuipcMop => ADD_SUB_DOMAIN_SIZE,
-            Self::JumpBranchSlt => JUMP_BRANCH_DOMAIN_SIZE,
-            Self::MulDivUnsigned => MUL_DIV_UNSIGNED_DOMAIN_SIZE,
-            Self::ShiftBinaryCsr => SHIFT_BINARY_DOMAIN_SIZE,
-        }
+        1 << self.get_domain_size_log2()
     }
 
     #[inline(always)]
     pub const fn get_domain_size_log2(&self) -> usize {
-        self.get_domain_size().trailing_zeros() as usize
+        match self {
+            Self::AddSubLuiAuipcMop => ADD_SUB_DOMAIN_SIZE_LOG2,
+            Self::JumpBranchSlt => JUMP_BRANCH_DOMAIN_SIZE_LOG2,
+            Self::MulDivUnsigned => MUL_DIV_UNSIGNED_DOMAIN_SIZE_LOG2,
+            Self::ShiftBinaryCsr => SHIFT_BINARY_DOMAIN_SIZE_LOG2,
+        }
     }
 
     #[inline(always)]

--- a/gpu/execution_prover/src/workers/gpu.rs
+++ b/gpu/execution_prover/src/workers/gpu.rs
@@ -358,7 +358,7 @@ fn enqueue_phase_two<'a>(
     let prover_config =
         gpu_circuit_prover::prover::config::prover_config(circuit_type, state.security_level)
             .expect("ExecutionProverConfiguration validated GPU security level before GPU work");
-    let final_trace_size_log_2 = 4usize;
+    let final_trace_size_log_2 = 4u32;
     let compiled_circuit_arc = state.precomputations.compiled_circuit.clone();
 
     let job = match inputs {


### PR DESCRIPTION
## What ❔

Follow-up to #348 (merged); rebased onto its squash commit.

- Invert `circuit_type.rs` domain-size constants to LOG2-first: read the upstream `DOMAIN_SIZE_LOG2` trait consts directly and compute sizes as `1 << log2`, replacing the backwards `trailing_zeros()` derivations (incl. one in production `config.rs`).
- Type all log2 values as `u32` end-to-end inside the GPU stack (`get_domain_size_log2()` on all five circuit-type enums, ~19 production/test params like `final_trace_size_log_2` / `trace_len_log2` / `query_domain_log2`, the `execution_prover` origin, test consts). Casts remain only at genuine boundaries: upstream CPU APIs and `ProverConfig` usize fields, `gpu_gkr_model`'s host-side layout API, and slice indexing.

## Why ❔

The log2 authorities are `u32` (trait consts, `trailing_zeros()`), and GPU kernel params consume `u32` — the previous `usize` threading forced u32 → usize → u32 roundtrips (e.g. 9 casts in `whir/mod.rs` alone). Values are provably unchanged; the type now flows forward from the authority.

Validated: lib + test-target + `gpu_execution_prover`/`gpu_program_prover` compile; unit tests green; `run_jump_branch_slt_proof_parity_test` end-to-end on GPU (bit-identical proof vs CPU) at this exact tree.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

