### PR TITLE
test(gpu): fix the stale Sec100 rejection test and the zero-column bootstrap fixture

### DIFF
--- a/gpu/circuit_prover/src/prover/gkr/setup/tests.rs
+++ b/gpu/circuit_prover/src/prover/gkr/setup/tests.rs
@@ -537,9 +537,14 @@ fn bootstrap_storage_without_uploaded_setup_leaves_virtual_setup_unmaterialized(
         log_tree_cap_size,
         &context,
     );
+    // A real (single-column) witness: committing a zero-column holder is not
+    // a legal gpu_hash input (the kernel would emit raw init-state digests).
+    let witness_values = (0..trace_len)
+        .map(|i| BF::from_u32_unchecked(i as u32 + 7))
+        .collect_vec();
     let witness_trace_holder = materialize_trace_holder_from_values(
-        &[],
-        0,
+        &witness_values,
+        1,
         trace_len,
         log_lde_factor,
         log_rows_per_leaf,

--- a/gpu/execution_prover/src/prover/tests.rs
+++ b/gpu/execution_prover/src/prover/tests.rs
@@ -196,18 +196,21 @@ fn test_execution_prover_unified() {
     assert_delegation_proofs_present(&result, DelegationCircuitType::Blake2WithCompression);
 }
 
+/// Every upstream `SecurityLevel` is currently GPU-supported; this fails the
+/// moment upstream adds a level the GPU stack does not handle, forcing an
+/// explicit decision instead of a silent `validate()` rejection at runtime.
 #[test]
-fn rejects_unsupported_security_level_in_configuration() {
-    let mut configuration = ExecutionProverConfiguration::default();
-    configuration.security_level = SecurityLevel::Sec100;
-
-    let err = ExecutionProver::with_configuration(configuration)
-        .err()
-        .expect("Sec100 should be rejected before GPU prover construction");
-
-    assert_eq!(err.requested, SecurityLevel::Sec100);
+fn all_security_levels_supported_in_configuration() {
     assert_eq!(
         ExecutionProverConfiguration::supported_security_levels(),
-        &[SecurityLevel::Sec80],
+        SecurityLevel::ALL,
     );
+    for &level in SecurityLevel::ALL {
+        let mut configuration = ExecutionProverConfiguration::default();
+        configuration.security_level = level;
+        assert!(
+            configuration.validate().is_ok(),
+            "{level:?} must pass configuration validation"
+        );
+    }
 }


### PR DESCRIPTION
## What ❔

- `gpu_circuit_prover`: the bootstrap-storage test committed a zero-column witness holder, tripping `gpu_hash`'s `cols_count >= 1` launcher assert (#350 hardening). The fixture now uses a real single-column witness.
- `gpu_execution_prover`: the Sec100 rejection test has been failing since #335 shipped Sec100 support; it now pins `supported_security_levels() == SecurityLevel::ALL` and validates each level.

## Why ❔

Both were stale-test artifacts, red on every full-suite run (GPU suites don't run in CI); red tests mask real regressions.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
