### PR TITLE
refactor(gpu_core): hardening deep-clean (ABI drift guards, hygiene, clippy-clean)

### DIFF
--- a/gpu/AGENTS.md
+++ b/gpu/AGENTS.md
@@ -33,6 +33,18 @@ helper, a build-dependency only).
   kernels — only a bench-gated `gpu_core_bench_native` archive (`native/bench/field.cu`,
   built solely under the `bench` feature for `benches/field.rs`).
   To keep it lean, `circuit_type` was relocated → `circuit_prover::witness` (it pulled `setups`).
+  **Completeness policy — `native_headers/` is a library, not a minimal set.**
+  gpu_core's base CUDA headers implement *complete* primitive families on
+  purpose, kept available for kernel/perf work; **"unused in-project" is NOT a
+  deletion signal here.** The deliberate complete families are: the PTX
+  cache-operator set (`ld_modifier`/`st_modifier` + the `load_*`/`store_*`
+  wrappers), the u32 **and** u64 carry-chain arithmetic in `ptx.cuh`, the field
+  operations (incl. `e6`), and the type×shape×access accessor matrix
+  (`{bf,e2,e4,e6}` × vector/matrix × getter/setter/getter_setter). Do not prune
+  these on usage; consumer kernel crates (gpu_ops, …) wrap only what they
+  dispatch, and the completeness lives here in core. This protects the complete
+  families specifically — genuine broken/incomplete vestiges (e.g. a
+  never-initialized global) are still fair game to remove.
 - **`gpu_ntt`** = the NTT subsystem (`ntt` launchers + `ntt_twiddles` + `native/ntt`
   CUDA), with its OWN `CMakeLists.txt` + `build.rs` producing a device-linked
   `gpu_ntt_native`; `circuit_prover` drops `gpu_prover_ntt` and links gpu_ntt's

--- a/gpu/core/native_headers/common.cuh
+++ b/gpu/core/native_headers/common.cuh
@@ -1,5 +1,9 @@
 #pragma once
 
+// gpu_core native_headers = a complete-surface primitives LIBRARY: the field
+// ops, PTX cache-operator + carry-chain sets, and accessor matrix are
+// intentionally complete — do NOT prune on in-project usage (see gpu/AGENTS.md).
+
 #include <cstdint>
 #include <cstdio>
 #include <cuda_runtime.h>

--- a/gpu/core/native_headers/primitives/field.cuh
+++ b/gpu/core/native_headers/primitives/field.cuh
@@ -831,6 +831,13 @@ struct __align__(8) e6 {
   }
 };
 
+// ABI drift guards for the by-value field PODs (must match the Rust field types
+// they are passed as / reinterpreted to across the kernel boundary).
+static_assert(sizeof(bf) == 4 && alignof(bf) == 4, "bf ABI");
+static_assert(sizeof(e2) == 8 && alignof(e2) == 8, "e2 ABI");
+static_assert(sizeof(e4) == 16 && alignof(e4) == 16, "e4 ABI");
+static_assert(sizeof(e6) == 24 && alignof(e6) == 8, "e6 ABI");
+
 using namespace memory;
 
 template <ld_modifier LD_MODIFIER = ld_modifier::none> struct bf_vector_getter : vector_getter<bf, LD_MODIFIER> {};

--- a/gpu/core/native_headers/primitives/memory.cuh
+++ b/gpu/core/native_headers/primitives/memory.cuh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 #include "../common.cuh"
 #include "ptx.cuh"
 
@@ -517,4 +519,34 @@ template <typename T> struct wrapping_matrix_getter_setter : wrapping_matrix_acc
     this->internal.set(row % this->rows, col % this->cols, value);
   }
 };
+
+// --- ABI drift guards -----------------------------------------------------
+// Keep these kernel-arg accessor layouts byte-compatible with the Rust
+// descriptors in gpu/core/src/primitives/device_structures.rs:
+//   matrix_accessor          <-> PtrAndStride            (ptr + stride)
+//   wrapping_matrix_accessor <-> PtrAndStrideWrappingMatrix (inner + rows + cols)
+// The layout is element-type independent, so a representative instantiation
+// pins the ABI. offsetof on these types is conditionally-supported (they are
+// non-standard-layout: `ptr` lives in the vector_accessor base), but the
+// layout is deterministic; the pedantic host (-Winvalid-offsetof) and device
+// (#1427) diagnostics are suppressed narrowly, for these assertions only.
+static_assert(sizeof(matrix_accessor<unsigned>) == 16, "PtrAndStride size");
+static_assert(alignof(matrix_accessor<unsigned>) == 8, "PtrAndStride align");
+static_assert(sizeof(wrapping_matrix_accessor<matrix_getter<unsigned>>) == 24, "WrappingMatrix size");
+static_assert(alignof(wrapping_matrix_accessor<matrix_getter<unsigned>>) == 8, "WrappingMatrix align");
+#ifdef __CUDACC__
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 1427
+#endif
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+static_assert(offsetof(matrix_accessor<unsigned>, stride) == 8, "stride offset");
+static_assert(offsetof(wrapping_matrix_accessor<matrix_getter<unsigned>>, internal) == 0, "internal offset");
+static_assert(offsetof(wrapping_matrix_accessor<matrix_getter<unsigned>>, rows) == 16, "rows offset");
+static_assert(offsetof(wrapping_matrix_accessor<matrix_getter<unsigned>>, cols) == 20, "cols offset");
+#pragma GCC diagnostic pop
+#ifdef __CUDACC__
+#pragma nv_diagnostic pop
+#endif
+// --------------------------------------------------------------------------
 } // namespace airbender::primitives::memory

--- a/gpu/core/native_headers/primitives/memory.cuh
+++ b/gpu/core/native_headers/primitives/memory.cuh
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <cstddef>
+#include <type_traits>
 
 #include "../common.cuh"
 #include "ptx.cuh"
 
 namespace airbender::primitives::memory {
 
-using namespace std;
 namespace ptx = ::airbender::primitives::ptx;
 
 using ptx::u32x8;
@@ -142,7 +142,7 @@ DEVICE_FORCEINLINE void transpose_tile(unsigned mask, T *u, const unsigned lane_
 template <class T, typename U, ld_modifier MODIFIER, unsigned STRIDE> static constexpr DEVICE_FORCEINLINE T ld(const T *address, const unsigned offset) {
   static_assert(alignof(T) % alignof(U) == 0);
   static_assert(sizeof(T) % sizeof(U) == 0);
-  constexpr size_t count = sizeof(T) / sizeof(U);
+  constexpr std::size_t count = sizeof(T) / sizeof(U);
   T result;
   auto pa = reinterpret_cast<const U *>(address) + offset;
   auto pr = reinterpret_cast<U *>(&result);
@@ -161,7 +161,7 @@ template <class T, typename U, st_modifier MODIFIER, unsigned STRIDE>
 static constexpr DEVICE_FORCEINLINE void st(T *address, const T &value, const unsigned offset) {
   static_assert(alignof(T) % alignof(U) == 0);
   static_assert(sizeof(T) % sizeof(U) == 0);
-  constexpr size_t count = sizeof(T) / sizeof(U);
+  constexpr std::size_t count = sizeof(T) / sizeof(U);
   auto pa = reinterpret_cast<U *>(address) + offset;
   auto pv = reinterpret_cast<const U *>(&value);
 #ifdef __CUDA_ARCH__
@@ -200,7 +200,7 @@ template <class T, typename U, unsigned LOG_WARP_SIZE, ld_modifier MODIFIER, boo
 DEVICE_FORCEINLINE T ld_warp(const T *address, const unsigned offset, const unsigned lane_id) {
   static_assert(alignof(T) % alignof(U) == 0);
   static_assert(sizeof(T) % (sizeof(U) << LOG_WARP_SIZE) == 0);
-  constexpr size_t count = sizeof(T) / (sizeof(U) << LOG_WARP_SIZE);
+  constexpr std::size_t count = sizeof(T) / (sizeof(U) << LOG_WARP_SIZE);
   constexpr unsigned threads_count = 1u << LOG_WARP_SIZE;
   const unsigned l = lane_id & (threads_count - 1);
   T result;
@@ -233,7 +233,7 @@ template <class T, typename U, unsigned LOG_WARP_SIZE, st_modifier MODIFIER, boo
 DEVICE_FORCEINLINE void st_warp(T *address, const unsigned offset, const T &value, const unsigned lane_id) {
   static_assert(alignof(T) % alignof(U) == 0);
   static_assert(sizeof(T) % (sizeof(U) << LOG_WARP_SIZE) == 0);
-  constexpr size_t count = sizeof(T) / (sizeof(U) << LOG_WARP_SIZE);
+  constexpr std::size_t count = sizeof(T) / (sizeof(U) << LOG_WARP_SIZE);
   constexpr unsigned threads_count = 1u << LOG_WARP_SIZE;
   const unsigned l = lane_id & (threads_count - 1);
   T value_copy = value;
@@ -266,7 +266,7 @@ template <class T> struct load_unit {
                                   std::conditional_t<sizeof(T) % 16 == 0, uint4, std::conditional_t<sizeof(T) % 8 == 0, uint2, unsigned>>>;
 };
 template <class T, unsigned LOG_WARP_SIZE> struct load_unit_warp {
-  static constexpr size_t WARP = 1u << LOG_WARP_SIZE;
+  static constexpr std::size_t WARP = 1u << LOG_WARP_SIZE;
   using type = std::conditional_t<sizeof(T) % (32 * WARP) == 0 && alignof(T) % 32 == 0, u32x8,
                                   std::conditional_t<sizeof(T) % (16 * WARP) == 0, uint4, std::conditional_t<sizeof(T) % (8 * WARP) == 0, uint2, unsigned>>>;
 };
@@ -394,9 +394,9 @@ struct vector_getter_setter : vector_accessor<T, vector_getter_setter<T, LD_MODI
 };
 
 template <typename T, typename U = T> struct matrix_accessor : vector_accessor<T, U> {
-  const size_t stride;
+  const std::size_t stride;
 
-  explicit matrix_accessor(const size_t stride) : stride(stride) {}
+  explicit matrix_accessor(const std::size_t stride) : stride(stride) {}
 
   DEVICE_FORCEINLINE U inc_row() { return this->operator++(); }
   DEVICE_FORCEINLINE U inc_col() { return this->operator+=(this->stride); }
@@ -409,7 +409,7 @@ template <typename T, typename U = T> struct matrix_accessor : vector_accessor<T
 };
 
 template <typename T, ld_modifier LD_MODIFIER = ld_modifier::none> struct matrix_getter : matrix_accessor<T, matrix_getter<T, LD_MODIFIER>> {
-  explicit matrix_getter(const size_t stride) : matrix_accessor<T, matrix_getter>(stride) {}
+  explicit matrix_getter(const std::size_t stride) : matrix_accessor<T, matrix_getter>(stride) {}
 
   DEVICE_FORCEINLINE T get() const { return load<T, LD_MODIFIER>(this->ptr); }
   DEVICE_FORCEINLINE T get_at_row(const unsigned row) const { return this->copy().add_row(row).get(); }
@@ -418,7 +418,7 @@ template <typename T, ld_modifier LD_MODIFIER = ld_modifier::none> struct matrix
 };
 
 template <typename T, st_modifier ST_MODIFIER = st_modifier::none> struct matrix_setter : matrix_accessor<T, matrix_setter<T, ST_MODIFIER>> {
-  explicit matrix_setter(const size_t stride) : matrix_accessor<T, matrix_setter>(stride) {}
+  explicit matrix_setter(const std::size_t stride) : matrix_accessor<T, matrix_setter>(stride) {}
 
   DEVICE_FORCEINLINE void set(const T &value) const { store<T, ST_MODIFIER>(this->ptr, value); }
   DEVICE_FORCEINLINE void set_at_row(const unsigned row, const T &value) const { this->copy().add_row(row).set(value); }
@@ -430,7 +430,7 @@ template <typename T, st_modifier ST_MODIFIER = st_modifier::none> struct matrix
 
 template <typename T, ld_modifier LD_MODIFIER = ld_modifier::none, st_modifier ST_MODIFIER = st_modifier::none>
 struct matrix_getter_setter : matrix_accessor<T, matrix_getter_setter<T, LD_MODIFIER, ST_MODIFIER>> {
-  explicit matrix_getter_setter(const size_t stride) : matrix_accessor<T, matrix_getter_setter>(stride) {}
+  explicit matrix_getter_setter(const std::size_t stride) : matrix_accessor<T, matrix_getter_setter>(stride) {}
 
   DEVICE_FORCEINLINE const matrix_getter<T, LD_MODIFIER> *as_getter() const { return reinterpret_cast<const matrix_getter<T, LD_MODIFIER> *>(this); }
 

--- a/gpu/core/native_headers/primitives/ptx.cuh
+++ b/gpu/core/native_headers/primitives/ptx.cuh
@@ -173,6 +173,8 @@ struct __align__(32) u32x8 {
   uint4 hi;
 };
 
+static_assert(sizeof(u32x8) == 32 && alignof(u32x8) == 32, "u32x8 ABI");
+
 #define AB_PTX_LD_V1(NAME, MOD)                                                                                                                                \
   DEVICE_FORCEINLINE u32 NAME(const u32 *p) {                                                                                                                  \
     u32 r;                                                                                                                                                     \

--- a/gpu/core/src/allocator/cpu_tests.rs
+++ b/gpu/core/src/allocator/cpu_tests.rs
@@ -160,6 +160,28 @@ fn disabled_small_allocator_identical_behavior() {
 }
 
 #[test]
+fn alloc_alignment_exceeding_chunk_rounds_to_alignment() {
+    // When the requested alignment exceeds the chunk granularity, the shared
+    // allocation tail rounds `alloc_len` up to the *alignment*, not the chunk
+    // size — this exercises the `.max(alignment)` term in `alloc_from_tracker`
+    // (BIG_CHUNK = 1024; a plain 8-byte alloc rounds to 1024, see the test above).
+    // Use a 2048-byte alignment (2^11 > BIG_CHUNK). The backend is sized well
+    // above alignment + alloc_len so a 2048-aligned block always fits regardless
+    // of the (arbitrary) backend base address.
+    const EXTRA_ALIGNMENT_LOG2: u32 = 11;
+    let extra_alignment = 1usize << EXTRA_ALIGNMENT_LOG2; // 2048 > BIG_CHUNK
+    let mut alloc = make_allocator_no_small(16);
+    let data = alloc
+        .alloc_with_extra_alignment::<u64, EXTRA_ALIGNMENT_LOG2>(1, AllocationPlacement::BestFit)
+        .unwrap();
+    // `.max(alignment)` took effect: rounded to the 2048 alignment, not the 1024
+    // chunk (which is what the same alloc without extra alignment would give).
+    assert_eq!(data.alloc_len, extra_alignment);
+    assert_eq!(data.ptr.as_ptr() as usize % extra_alignment, 0);
+    alloc.free(data);
+}
+
+#[test]
 fn zero_length_alloc_goes_to_big() {
     let mut alloc = make_allocator(4, 1);
     // Zero-length allocs bypass the small allocator (byte_len == 0)

--- a/gpu/core/src/allocator/cpu_tests.rs
+++ b/gpu/core/src/allocator/cpu_tests.rs
@@ -36,15 +36,49 @@ fn make_allocator_no_small(num_big_chunks: usize) -> InnerStaticAllocator<TestBa
     InnerStaticAllocator::new([backend], BIG_LCS)
 }
 
+/// Sweeps `byte_len` across the small/big routing threshold (256 B for
+/// `make_allocator(4, 1)`), asserting the exact `alloc_len` rounding on each
+/// side. Folds `small_alloc_basic_roundtrip` (below-threshold case),
+/// `threshold_boundary` (at-threshold + above-threshold cases), and
+/// `big_alloc_bypasses_small` (above-threshold case, same assertion as
+/// `threshold_boundary`'s upper half) — all three overlapped on this one
+/// byte_len-vs-threshold dimension.
 #[test]
-fn small_alloc_basic_roundtrip() {
+fn small_vs_big_alloc_routing_by_threshold() {
+    enum Expect {
+        /// below threshold (256 B): routed to small allocator, alloc_len
+        /// rounded exactly to SMALL_CHUNK (16). [small_alloc_basic_roundtrip]
+        SmallExact,
+        /// == threshold (256 B): still routed to small allocator, alloc_len
+        /// strictly less than BIG_CHUNK. [threshold_boundary, lower half]
+        SmallBound,
+        /// above threshold (264 B): routed to big allocator, alloc_len
+        /// rounded exactly to BIG_CHUNK (1024). [threshold_boundary upper
+        /// half + big_alloc_bypasses_small]
+        Big,
+    }
+
     let mut alloc = make_allocator(4, 1);
-    // Allocate 1 u64 = 8 bytes, below threshold (256), should go to small allocator
-    let data = alloc.alloc::<u64>(1, AllocationPlacement::BestFit).unwrap();
-    assert_eq!(data.len, 1);
-    // alloc_len should be rounded to small chunk size (16), not big (1024)
-    assert_eq!(data.alloc_len, SMALL_CHUNK);
-    alloc.free(data);
+    let cases = [
+        (1usize, Expect::SmallExact), // 1 u64 = 8 B
+        (32, Expect::SmallBound),     // 32 u64s = 256 B
+        (33, Expect::Big),            // 33 u64s = 264 B
+    ];
+
+    for (count, expect) in cases {
+        let data = alloc
+            .alloc::<u64>(count, AllocationPlacement::BestFit)
+            .unwrap();
+        match expect {
+            Expect::SmallExact => {
+                assert_eq!(data.len, count);
+                assert_eq!(data.alloc_len, SMALL_CHUNK);
+            }
+            Expect::SmallBound => assert!(data.alloc_len < BIG_CHUNK),
+            Expect::Big => assert_eq!(data.alloc_len, BIG_CHUNK),
+        }
+        alloc.free(data);
+    }
 }
 
 #[test]
@@ -58,18 +92,6 @@ fn small_alloc_reuse_after_free() {
     // Should reuse the same address after free
     assert_eq!(ptr1, ptr2);
     alloc.free(data2);
-}
-
-#[test]
-fn big_alloc_bypasses_small() {
-    let mut alloc = make_allocator(4, 1);
-    // Allocate above threshold: 33 u64s = 264 bytes > 256 threshold
-    let data = alloc
-        .alloc::<u64>(33, AllocationPlacement::BestFit)
-        .unwrap();
-    // alloc_len should be rounded to big chunk size (1024)
-    assert_eq!(data.alloc_len, BIG_CHUNK);
-    alloc.free(data);
 }
 
 #[test]
@@ -107,24 +129,6 @@ fn usage_counters_correct() {
     assert_eq!(big_used - BIG_CHUNK + small_used, SMALL_CHUNK);
 
     alloc.free(small);
-}
-
-#[test]
-fn threshold_boundary() {
-    let mut alloc = make_allocator(4, 1);
-    // Exactly at threshold: 32 u64s = 256 bytes = threshold → small
-    let at = alloc
-        .alloc::<u64>(32, AllocationPlacement::BestFit)
-        .unwrap();
-    assert!(at.alloc_len < BIG_CHUNK); // went to small allocator
-    alloc.free(at);
-
-    // One byte over: 33 u64s = 264 bytes > threshold → big
-    let over = alloc
-        .alloc::<u64>(33, AllocationPlacement::BestFit)
-        .unwrap();
-    assert_eq!(over.alloc_len, BIG_CHUNK); // went to big allocator
-    alloc.free(over);
 }
 
 #[test]

--- a/gpu/core/src/allocator/host.rs
+++ b/gpu/core/src/allocator/host.rs
@@ -13,10 +13,6 @@ use std::fmt::{Debug, Formatter};
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 use std::slice;
-use std::sync::OnceLock;
-
-#[allow(dead_code)]
-pub static STATIC_HOST_ALLOCATOR: OnceLock<ConcurrentStaticHostAllocator> = OnceLock::new();
 
 impl StaticAllocationBackend for HostAllocation<u8> {
     fn as_non_null(&mut self) -> NonNull<u8> {
@@ -50,12 +46,6 @@ type StaticHostAllocator<W> = StaticAllocator<HostAllocation<u8>, W>;
 
 pub type ConcurrentStaticHostAllocator =
     StaticHostAllocator<ConcurrentInnerStaticHostAllocatorWrapper>;
-
-impl ConcurrentStaticHostAllocator {
-    pub fn get_global() -> &'static ConcurrentStaticHostAllocator {
-        STATIC_HOST_ALLOCATOR.get().unwrap()
-    }
-}
 
 pub type NonConcurrentStaticHostAllocator =
     StaticHostAllocator<NonConcurrentInnerStaticHostAllocatorWrapper>;
@@ -111,7 +101,10 @@ unsafe impl<W: InnerStaticHostAllocatorWrapper> Allocator for StaticHostAllocato
 
 impl Default for ConcurrentStaticHostAllocator {
     fn default() -> Self {
-        ConcurrentStaticHostAllocator::get_global().clone()
+        panic!(
+            "ConcurrentStaticHostAllocator has no meaningful Default; \
+             construct it explicitly via ConcurrentStaticHostAllocator::new"
+        )
     }
 }
 

--- a/gpu/core/src/allocator/mod.rs
+++ b/gpu/core/src/allocator/mod.rs
@@ -96,6 +96,26 @@ impl<B: StaticAllocationBackend> InnerStaticAllocator<B> {
         alloc
     }
 
+    fn alloc_from_tracker<T>(
+        tracker: &mut AllocationsTracker,
+        log_chunk_size: u32,
+        len: usize,
+        byte_len: usize,
+        placement: AllocationPlacement,
+        alignment: usize,
+    ) -> CudaResult<StaticAllocationData<T>> {
+        let alloc_granularity = (1usize << log_chunk_size).max(alignment);
+        let alloc_len = byte_len.next_multiple_of(alloc_granularity);
+        match tracker.alloc_aligned(alloc_len, placement, alignment) {
+            Ok(ptr) => {
+                assert!(ptr.is_aligned_to(alignment));
+                let ptr = ptr.cast::<T>();
+                Ok(StaticAllocationData::new(ptr, len, alloc_len))
+            }
+            Err(_) => Err(CudaError::ErrorMemoryAllocation),
+        }
+    }
+
     fn alloc_impl<T>(
         &mut self,
         len: usize,
@@ -109,32 +129,25 @@ impl<B: StaticAllocationBackend> InnerStaticAllocator<B> {
 
         if let Some(ref mut small) = self.small {
             if byte_len > 0 && byte_len <= small.small_threshold {
-                let slcs = small.log_chunk_size;
-                let alloc_granularity = (1usize << slcs).max(alignment);
-                let alloc_len = byte_len.next_multiple_of(alloc_granularity);
-                match small.tracker.alloc_aligned(alloc_len, placement, alignment) {
-                    Ok(ptr) => {
-                        assert!(ptr.is_aligned_to(alignment));
-                        let ptr = ptr.cast::<T>();
-                        return Ok(StaticAllocationData::new(ptr, len, alloc_len));
-                    }
-                    Err(_) => return Err(CudaError::ErrorMemoryAllocation),
-                }
+                return Self::alloc_from_tracker(
+                    &mut small.tracker,
+                    small.log_chunk_size,
+                    len,
+                    byte_len,
+                    placement,
+                    alignment,
+                );
             }
         }
 
-        let lcs = self.log_chunk_size;
-        let alloc_granularity = (1 << lcs).max(alignment);
-        let alloc_len = byte_len.next_multiple_of(alloc_granularity);
-        match self.tracker.alloc_aligned(alloc_len, placement, alignment) {
-            Ok(ptr) => {
-                assert!(ptr.is_aligned_to(alignment));
-                let ptr = ptr.cast::<T>();
-                let data = StaticAllocationData::new(ptr, len, alloc_len);
-                Ok(data)
-            }
-            Err(_) => Err(CudaError::ErrorMemoryAllocation),
-        }
+        Self::alloc_from_tracker(
+            &mut self.tracker,
+            self.log_chunk_size,
+            len,
+            byte_len,
+            placement,
+            alignment,
+        )
     }
 
     pub fn alloc<T>(

--- a/gpu/core/src/allocator/mod.rs
+++ b/gpu/core/src/allocator/mod.rs
@@ -354,4 +354,4 @@ impl<B: StaticAllocationBackend, W: InnerStaticAllocatorWrapper<B>> Clone
 }
 
 #[cfg(test)]
-mod tests;
+mod cpu_tests;

--- a/gpu/core/src/allocator/tracker.rs
+++ b/gpu/core/src/allocator/tracker.rs
@@ -419,7 +419,7 @@ impl AllocationsTracker {
 unsafe impl Send for AllocationsTracker {}
 
 #[cfg(test)]
-mod tests {
+mod cpu_tests {
     use super::{AllocationPlacement, AllocationsTracker};
 
     const REGION_A: usize = 0x1000;

--- a/gpu/core/src/primitives/callbacks.rs
+++ b/gpu/core/src/primitives/callbacks.rs
@@ -17,6 +17,12 @@ use era_cudart::stream::CudaStream;
 
 pub struct Callbacks<'a>(Vec<HostFn<'a>>);
 
+impl Default for Callbacks<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> Callbacks<'a> {
     pub fn new() -> Self {
         Self(vec![])

--- a/gpu/core/src/primitives/context.rs
+++ b/gpu/core/src/primitives/context.rs
@@ -75,7 +75,7 @@ impl<T: ?Sized> UnsafeAccessor<T> {
 
 impl<T: ?Sized> Clone for UnsafeAccessor<T> {
     fn clone(&self) -> Self {
-        UnsafeAccessor(self.0)
+        *self
     }
 }
 
@@ -124,7 +124,7 @@ impl<T: ?Sized> UnsafeMutAccessor<T> {
 
 impl<T: ?Sized> Clone for UnsafeMutAccessor<T> {
     fn clone(&self) -> Self {
-        UnsafeMutAccessor(self.0)
+        *self
     }
 }
 
@@ -148,6 +148,9 @@ impl<T: ?Sized> HostAllocation<T> {
 }
 
 impl<T> HostAllocation<[T]> {
+    /// # Safety
+    /// The returned slice's `len` elements are uninitialized; the caller must
+    /// initialize each element before reading it.
     pub unsafe fn new_uninit_slice_in(len: usize, allocator: HostAllocator) -> Self {
         Self(Box::new_uninit_slice_in(len, allocator).assume_init())
     }

--- a/gpu/core/src/primitives/device_structures.rs
+++ b/gpu/core/src/primitives/device_structures.rs
@@ -78,6 +78,35 @@ impl<T> MutPtrAndStrideWrappingMatrix<T> {
     }
 }
 
+// ABI drift guards — these kernel-arg descriptors cross the Rust↔CUDA boundary
+// by value; keep them byte-compatible with the CUDA counterparts in
+// native_headers/primitives/memory.cuh (matrix_accessor / wrapping_matrix_accessor).
+// Layout is element-type independent (thin *const T = 8 B + usize = 8 B), so a
+// single representative instantiation (u32) pins the ABI.
+const _: () = {
+    use core::mem::{align_of, offset_of, size_of};
+    assert!(size_of::<PtrAndStride<u32>>() == 16 && align_of::<PtrAndStride<u32>>() == 8);
+    assert!(offset_of!(PtrAndStride<u32>, ptr) == 0 && offset_of!(PtrAndStride<u32>, stride) == 8);
+    assert!(size_of::<MutPtrAndStride<u32>>() == 16 && align_of::<MutPtrAndStride<u32>>() == 8);
+    assert!(
+        offset_of!(MutPtrAndStride<u32>, ptr) == 0 && offset_of!(MutPtrAndStride<u32>, stride) == 8
+    );
+    assert!(
+        size_of::<PtrAndStrideWrappingMatrix<u32>>() == 24
+            && align_of::<PtrAndStrideWrappingMatrix<u32>>() == 8
+    );
+    assert!(offset_of!(PtrAndStrideWrappingMatrix<u32>, ptr_and_stride) == 0);
+    assert!(offset_of!(PtrAndStrideWrappingMatrix<u32>, rows) == 16);
+    assert!(offset_of!(PtrAndStrideWrappingMatrix<u32>, cols) == 20);
+    assert!(
+        size_of::<MutPtrAndStrideWrappingMatrix<u32>>() == 24
+            && align_of::<MutPtrAndStrideWrappingMatrix<u32>>() == 8
+    );
+    assert!(offset_of!(MutPtrAndStrideWrappingMatrix<u32>, mut_ptr_and_stride) == 0);
+    assert!(offset_of!(MutPtrAndStrideWrappingMatrix<u32>, rows) == 16);
+    assert!(offset_of!(MutPtrAndStrideWrappingMatrix<u32>, cols) == 20);
+};
+
 pub trait DeviceVectorChunkImpl<T> {
     fn slice(&self) -> &DeviceSlice<T>;
 

--- a/gpu/core/src/primitives/device_structures.rs
+++ b/gpu/core/src/primitives/device_structures.rs
@@ -428,7 +428,7 @@ pub struct DeviceMatrixOwnsAllocation<T> {
 
 impl<T> DeviceMatrixOwnsAllocation<T> {
     pub fn new(allocation: crate::primitives::context::DeviceAllocation<T>, stride: usize) -> Self {
-        assert_eq!((&allocation).len() % stride, 0);
+        assert_eq!(allocation.len() % stride, 0);
         Self { allocation, stride }
     }
 }

--- a/gpu/core/src/primitives/nvtx.rs
+++ b/gpu/core/src/primitives/nvtx.rs
@@ -81,6 +81,13 @@ fn get_or_create_domain(name: &str) -> NvtxDomainHandle {
     handle
 }
 
+// `Box<Registration>` is deliberate, not redundant: `get_or_create_registration`
+// hands out `*const Registration` pointers into these entries that must stay valid
+// for the remainder of the process (see the SAFETY note in `start_range`). Boxing
+// gives each entry a stable heap address, so pushing new entries never reallocates
+// and invalidates outstanding pointers — a plain `Vec<Registration>` would dangle
+// them on growth.
+#[allow(clippy::vec_box)]
 fn range_registry() -> &'static Mutex<Vec<Box<Registration>>> {
     static REGISTRY: OnceLock<Mutex<Vec<Box<Registration>>>> = OnceLock::new();
     REGISTRY.get_or_init(|| Mutex::new(Vec::new()))

--- a/gpu/core/src/primitives/utils.rs
+++ b/gpu/core/src/primitives/utils.rs
@@ -68,6 +68,12 @@ pub fn smem_pool_bytes_per_sm() -> usize {
 
 /// Compute the smallest carveout percentage that accommodates a kernel's
 /// static shared memory at maximum occupancy.
+// `kernel` is an opaque CUDA `__global__` function handle handed to the runtime
+// (`cudaFuncGetAttributes` / `cudaOccupancyMaxActiveBlocksPerMultiprocessor`),
+// which validates it and returns an error for an invalid handle — it is never
+// dereferenced as data, so there is no UB precondition and marking this `unsafe`
+// would misrepresent the contract. Suppress the raw-pointer-arg lint.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn compute_minimal_carveout(kernel: *const c_void, block_size: i32, pool_bytes: usize) -> i32 {
     use era_cudart_sys::{
         cudaFuncGetAttributes, cudaOccupancyMaxActiveBlocksPerMultiprocessor, CudaFuncAttributes,
@@ -101,6 +107,10 @@ pub fn compute_minimal_carveout(kernel: *const c_void, block_size: i32, pool_byt
 }
 
 /// Set the preferred shared-memory carveout percentage for a kernel.
+// `kernel` is an opaque CUDA `__global__` handle (see `compute_minimal_carveout`):
+// runtime-validated via `cudaFuncSetAttribute`, never dereferenced as data — no UB
+// precondition, so `unsafe` would misrepresent the contract.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn set_shared_carveout(kernel: *const c_void, pct: i32) {
     use era_cudart_sys::CudaFuncAttribute;
     // SAFETY: `kernel` is a valid `__global__` function pointer; the attribute and value

--- a/gpu/core/src/primitives/utils.rs
+++ b/gpu/core/src/primitives/utils.rs
@@ -15,13 +15,13 @@ pub trait GetChunksCount {
 
 impl GetChunksCount for u32 {
     fn get_chunks_count(self, chunk_size: Self) -> Self {
-        self.next_multiple_of(chunk_size) / chunk_size
+        self.div_ceil(chunk_size)
     }
 }
 
 impl GetChunksCount for usize {
     fn get_chunks_count(self, chunk_size: Self) -> Self {
-        self.next_multiple_of(chunk_size) / chunk_size
+        self.div_ceil(chunk_size)
     }
 }
 
@@ -103,7 +103,7 @@ pub fn compute_minimal_carveout(kernel: *const c_void, block_size: i32, pool_byt
 
     let total_smem = smem_per_block * max_blocks as usize;
     // Round up to the next whole percent.
-    ((total_smem * 100 + pool_bytes - 1) / pool_bytes) as i32
+    (total_smem * 100).div_ceil(pool_bytes) as i32
 }
 
 /// Set the preferred shared-memory carveout percentage for a kernel.


### PR DESCRIPTION
## What ❔

Campaign crate 4 (`gpu_core`, the GPU-stack DAG root): a **library-hardening** deep-clean (net small-positive, not a deletion pass). Highlights (per-concern commits carry the detail):

- **repr(C)/ABI drift guards** (marquee): Rust `const _` + CUDA `static_assert` on size **and** align **and** field offsets for the kernel-arg descriptors (`PtrAndStride`/`MutPtrAndStride`/`*WrappingMatrix` ↔ `matrix_accessor`/`wrapping_matrix_accessor`) and the by-value field PODs (`bf`/`e2`/`e4`/`e6`/`u32x8`). The by-value Rust↔CUDA ABI was previously unguarded.
- Remove the one genuine broken vestige (`STATIC_HOST_ALLOCATOR`, a never-initialized global); `Default` stays and panics explicitly.
- `memory.cuh` self-contained: drop `using namespace std;`, add explicit `<type_traits>`/`<cstddef>`.
- Dedup the `alloc_impl` small/big tail; fold redundant allocator routing tests and reclassify the GPU-free allocator/tracker tests to `cpu_*`.
- Record the `native_headers` completeness policy in `gpu/AGENTS.md`.
- Clear gpu_core's latent clippy deny-errors + warnings (latent since the original GPU-stack squash, unseen because clippy ran crate-scoped) → **gpu_core is now fully clippy-clean**.

Stacked on #356 (base `rr/gpu_ops_deep_clean`); retarget to `av_gkr_compiler` once #354/#356 merge.

## Why ❔

`gpu_core` is a complete-surface primitives library, so the value here is guarding the by-value ABI against silent layout drift, header hygiene, and bringing the DAG-root crate to clippy-clean — not line count.

## Is this a breaking change?
- [ ] Yes
- [x] No

The ABI guards assert the *current* layout (no ABI/behavior change); e2e proof-parity is bit-exact. Only in-tree GPU crates consume `gpu_core`.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
