### PR TITLE
refactor(gpu_cub): drop the unreachable mul reduce family + tidy common.cuh

### DIFF
--- a/gpu/cub/native/common.cuh
+++ b/gpu/cub/native/common.cuh
@@ -8,17 +8,11 @@ using namespace ::airbender::primitives::memory;
 
 namespace airbender::cub {
 
-#define BINARY_OP(op, init_fn)                                                                                                                                 \
-  template <typename T> struct op {                                                                                                                            \
-    DEVICE_FORCEINLINE T operator()(const T &a, const T &b) const { return T::op(a, b); }                                                                      \
-    static HOST_DEVICE_FORCEINLINE T init() { return T::init_fn(); }                                                                                           \
-  }
-
-BINARY_OP(add, ZERO);
-
-template <> struct add<u32> {
-  DEVICE_FORCEINLINE u32 operator()(const u32 &a, const u32 &b) const { return a + b; }
-  static HOST_DEVICE_FORCEINLINE u32 init() { return 0; }
+// Field-addition reduction operator for CUB DeviceReduce/DeviceSegmentedReduce,
+// instantiated over the field types (bf, e4) in device_reduce_*.cu.
+template <typename T> struct add {
+  DEVICE_FORCEINLINE T operator()(const T &a, const T &b) const { return T::add(a, b); }
+  static HOST_DEVICE_FORCEINLINE T init() { return T::ZERO(); }
 };
 
 } // namespace airbender::cub

--- a/gpu/cub/native/common.cuh
+++ b/gpu/cub/native/common.cuh
@@ -15,16 +15,10 @@ namespace airbender::cub {
   }
 
 BINARY_OP(add, ZERO);
-BINARY_OP(mul, ONE);
 
 template <> struct add<u32> {
   DEVICE_FORCEINLINE u32 operator()(const u32 &a, const u32 &b) const { return a + b; }
   static HOST_DEVICE_FORCEINLINE u32 init() { return 0; }
-};
-
-template <> struct mul<u32> {
-  DEVICE_FORCEINLINE u32 operator()(const u32 &a, const u32 &b) const { return a * b; }
-  static HOST_DEVICE_FORCEINLINE u32 init() { return 1; }
 };
 
 } // namespace airbender::cub

--- a/gpu/cub/native/device_reduce_basic.cu
+++ b/gpu/cub/native/device_reduce_basic.cu
@@ -13,7 +13,5 @@ namespace airbender::cub::device_reduce {
 
 REDUCE(add, bf);
 REDUCE(add, e4);
-REDUCE(mul, bf);
-REDUCE(mul, e4);
 
 } // namespace airbender::cub::device_reduce

--- a/gpu/cub/native/device_reduce_segmented.cu
+++ b/gpu/cub/native/device_reduce_segmented.cu
@@ -34,7 +34,5 @@ struct offset_iterator {
 
 SEGMENTED_REDUCE(add, bf);
 SEGMENTED_REDUCE(add, e4);
-SEGMENTED_REDUCE(mul, bf);
-SEGMENTED_REDUCE(mul, e4);
 
 } // namespace airbender::cub::device_reduce


### PR DESCRIPTION
## What ❔

Campaign crate 5 (`gpu_cub`, the CUB-library wrapper): a small native-only
dead-code pass. `gpu_cub` is a **consumer** crate (it wraps CUB for the prover),
so usage drives its surface.

- Drop the unreachable `mul` reduce family: the native archive compiled
  `ab_reduce_mul_{bf,e4}` + `ab_segmented_reduce_mul_{bf,e4}`, but `ReduceOperation`
  has only a `Sum` variant and `reduce_fns!` binds only `add` — nothing could
  ever call them. Since isolating the compile-heavy CCCL/CUB template
  instantiations is this crate's whole reason to exist, removing four
  unreachable `DeviceReduce`/`DeviceSegmentedReduce` instantiations is a direct
  build-speed win.
- Tidy `common.cuh` down to the single instantiated op: drop the dead `add<u32>`
  specialization (no `u32` reduce is instantiated) and inline the now-single-use
  `BINARY_OP` macro into a plain `add<T>` template (generated code unchanged).

No Rust and no downstream (`circuit_prover`) changes — the public API is
untouched. Stacked on #357 (base `rr/gpu_core_deep_clean`); retarget to
`av_gkr_compiler` once #354/#356/#357 merge.

## Why ❔

The `mul` reduce path was dead weight — four heavy CUB instantiations with no
Rust binding — directly counter to the crate's purpose of quarantining CUB
compile cost. Removing it (and the dead `add<u32>` specialization) trims the
archive and the header to exactly what is instantiated.

## Is this a breaking change?
- [ ] Yes
- [x] No

Only dead/unreachable native code is removed; the surviving `add` reduce, radix
sort, and run-length-encode kernels are byte-for-byte unchanged (verified by
symbol inspection). The in-crate suite passes and e2e proof-parity is bit-exact.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
