### PR TITLE
feat(gpu_witness_eval_generator): drift-guard the committed witness CUDA

### DIFF
--- a/gpu/AGENTS.md
+++ b/gpu/AGENTS.md
@@ -17,9 +17,11 @@ gpu_core  <  { gpu_ntt, gpu_ops, gpu_hash, gpu_cub }  <  circuit_prover  <  exec
 Plus three off-DAG crates: **`gpu_witness_eval_generator`** (`witness_eval_generator/`:
 pure-CPU codegen producing the committed `circuit_defs/**/generated/witness_generation_fn.cuh`
 CUDA witness bodies that `circuit_prover`'s native templates `#include`; run manually via its
-`generate` bin (`generate_all` is a local `skip_if_ci` SMOKE test emitting gitignored
-scratch `.cuh`, NOT a committed-output drift guard — regenerate + diff the committed
-`.cuh` by hand when changing codegen); has its own `AGENTS.md`),
+`generate` bin; the committed artifacts are drift-guarded by the
+`committed_witness_cuh_is_current` test (regenerates each from its committed
+`cs/compiled_circuits/*_gkr.json` inputs and asserts byte-identity — GPU-free,
+runs in CI) and refreshed by the `regenerate_committed` bin after an intentional
+codegen change; has its own `AGENTS.md`),
 **`gpu_gkr_model`** (pure-CPU GKR layout model — address
 audit, storage layout, circuit transform; deps `cs` + `field`, no CUDA; consumed
 by `circuit_prover`'s `gkr` via `gkr::{gkr_address_audit, storage_layout,

--- a/gpu/witness_eval_generator/.gitignore
+++ b/gpu/witness_eval_generator/.gitignore
@@ -1,2 +1,3 @@
-# Scratch output of the `generate_all` test (real outputs live in circuit_defs/**/generated/).
+# Local scratch if the `generate` bin is pointed at this dir; the committed
+# artifacts live in circuit_defs/**/generated/.
 *.cuh

--- a/gpu/witness_eval_generator/Cargo.toml
+++ b/gpu/witness_eval_generator/Cargo.toml
@@ -16,6 +16,3 @@ serde = "1.0.219"
 serde_json = "1.0.140"
 
 [features]
-
-[dev-dependencies]
-test_utils = { workspace = true }

--- a/gpu/witness_eval_generator/src/bin/regenerate_committed.rs
+++ b/gpu/witness_eval_generator/src/bin/regenerate_committed.rs
@@ -1,0 +1,28 @@
+//! Regenerate every committed `witness_generation_fn.cuh` from its committed
+//! SSA/layout inputs, in place. Run this after an intentional change to the
+//! witness codegen, then commit the refreshed artifacts:
+//!
+//! ```text
+//! cargo run -p gpu_witness_eval_generator --bin regenerate_committed
+//! ```
+//!
+//! The `committed_witness_cuh_is_current` test fails until the artifacts match
+//! current codegen again. This binary and that test share the [`CIRCUITS`]
+//! table, so they cannot disagree about which files to touch.
+
+use gpu_witness_eval_generator::{CIRCUITS, repo_root};
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let root = repo_root();
+    for circuit in CIRCUITS {
+        let code = circuit.regenerate(&root)?;
+        let out = circuit.committed_path(&root);
+        if let Some(parent) = out.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&out, code)?;
+        println!("wrote {}", circuit.committed_cuh);
+    }
+    Ok(())
+}

--- a/gpu/witness_eval_generator/src/lib.rs
+++ b/gpu/witness_eval_generator/src/lib.rs
@@ -7,7 +7,7 @@ use cs::witness_placer::graph_description::{
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 mod boolean;
 mod field;
@@ -504,44 +504,212 @@ pub fn generate_from_files(
     ))
 }
 
-#[cfg(test)]
-mod tests {
-    use test_utils::skip_if_ci;
+/// A circuit whose witness-generation CUDA body is generated from committed
+/// SSA/layout inputs and checked in under `circuit_defs/`.
+///
+/// The generator is a pure function of `(layout, ssa)`, so each committed
+/// artifact must stay byte-identical to a fresh regeneration. The
+/// `committed_witness_cuh_is_current` test enforces that; the
+/// `regenerate_committed` binary refreshes the artifacts after an intentional
+/// codegen change.
+pub struct GeneratedCircuit {
+    /// Base name of the `cs/compiled_circuits/{id}_{layout,ssa}_gkr.json` inputs.
+    pub id: &'static str,
+    /// Repo-relative path of the checked-in `witness_generation_fn.cuh`.
+    pub committed_cuh: &'static str,
+}
 
-    use crate::generate_from_files;
-    use std::fs::File;
-    use std::io::Write;
-
-    fn generate(id: &str) {
-        let layout_path = format!("../../cs/compiled_circuits/{id}_layout_gkr.json");
-        let ssa_path = format!("../../cs/compiled_circuits/{id}_ssa_gkr.json");
-        let generated_cu_path = format!("{id}.cuh");
-        println!("{generated_cu_path}");
-        let code = generate_from_files(&layout_path, &ssa_path, false).unwrap();
-        File::create(&generated_cu_path)
-            .unwrap()
-            .write_all(code.as_bytes())
-            .unwrap();
+impl GeneratedCircuit {
+    /// Regenerate this circuit's witness-generation CUDA from its committed
+    /// inputs, exactly as the checked-in artifact was produced
+    /// (`perform_assignments_to_memory = false`).
+    pub fn regenerate(&self, repo_root: &Path) -> Result<String, Box<dyn std::error::Error>> {
+        let layout = repo_root.join(format!("cs/compiled_circuits/{}_layout_gkr.json", self.id));
+        let ssa = repo_root.join(format!("cs/compiled_circuits/{}_ssa_gkr.json", self.id));
+        generate_from_files(layout, ssa, false)
     }
 
-    #[test]
-    fn generate_all() {
-        skip_if_ci!();
-        const IDS: &[&str] = &[
-            "add_sub_lui_auipc_mop",
-            "bigint_with_extended_control",
-            "blake2_g_function",
-            "blake2_with_extended_control",
-            "jump_branch_slt",
-            "keccak_special5",
-            "mem_subword_only",
-            "mem_word_only",
-            "shift_binop",
-            "unified_reduced_machine",
-            "unsigned_mul_div",
-        ];
-        for id in IDS {
-            generate(id);
+    /// Absolute path of the checked-in artifact under `repo_root`.
+    pub fn committed_path(&self, repo_root: &Path) -> PathBuf {
+        repo_root.join(self.committed_cuh)
+    }
+}
+
+/// Every circuit with a committed `witness_generation_fn.cuh` artifact, paired
+/// with its generator input id. Single source of truth shared by the
+/// `regenerate_committed` binary and the drift-guard test, so the two halves
+/// cannot fall out of sync. Note the id and the committed directory name differ
+/// for several circuits (e.g. `blake2_with_extended_control` →
+/// `blake2_with_compression`), which is exactly why this mapping is explicit.
+pub const CIRCUITS: &[GeneratedCircuit] = &[
+    GeneratedCircuit {
+        id: "add_sub_lui_auipc_mop",
+        committed_cuh: "circuit_defs/unrolled_circuits/add_sub_lui_auipc_mop/generated/witness_generation_fn.cuh",
+    },
+    GeneratedCircuit {
+        id: "bigint_with_extended_control",
+        committed_cuh: "circuit_defs/bigint_with_control/generated/witness_generation_fn.cuh",
+    },
+    GeneratedCircuit {
+        id: "blake2_g_function",
+        committed_cuh: "circuit_defs/blake2_g_function/generated/witness_generation_fn.cuh",
+    },
+    GeneratedCircuit {
+        id: "blake2_with_extended_control",
+        committed_cuh: "circuit_defs/blake2_with_compression/generated/witness_generation_fn.cuh",
+    },
+    GeneratedCircuit {
+        id: "jump_branch_slt",
+        committed_cuh: "circuit_defs/unrolled_circuits/jump_branch_slt/generated/witness_generation_fn.cuh",
+    },
+    GeneratedCircuit {
+        id: "keccak_special5",
+        committed_cuh: "circuit_defs/keccak_special5/generated/witness_generation_fn.cuh",
+    },
+    GeneratedCircuit {
+        id: "mem_subword_only",
+        committed_cuh: "circuit_defs/unrolled_circuits/load_store_subword_only/generated/witness_generation_fn.cuh",
+    },
+    GeneratedCircuit {
+        id: "mem_word_only",
+        committed_cuh: "circuit_defs/unrolled_circuits/load_store_word_only/generated/witness_generation_fn.cuh",
+    },
+    GeneratedCircuit {
+        id: "shift_binop",
+        committed_cuh: "circuit_defs/unrolled_circuits/shift_binary_csr/generated/witness_generation_fn.cuh",
+    },
+    GeneratedCircuit {
+        id: "unified_reduced_machine",
+        committed_cuh: "circuit_defs/unrolled_circuits/unified_reduced_machine/generated/witness_generation_fn.cuh",
+    },
+    GeneratedCircuit {
+        id: "unsigned_mul_div",
+        committed_cuh: "circuit_defs/unrolled_circuits/mul_div_unsigned/generated/witness_generation_fn.cuh",
+    },
+];
+
+/// Absolute path to the repository root. This crate lives at
+/// `<root>/gpu/witness_eval_generator`, so the root is two levels up from
+/// `CARGO_MANIFEST_DIR` (stable regardless of the process working directory).
+pub fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("resolve repository root from CARGO_MANIFEST_DIR")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{CIRCUITS, repo_root};
+    use std::collections::HashSet;
+    use std::path::Path;
+
+    /// A readable description of the first byte where `generated` and
+    /// `committed` differ. Byte-level (matching the pass/fail comparison), so it
+    /// never misattributes a whitespace/line-ending/trailing difference — it
+    /// reports the exact offset, the containing line, and both sides' text.
+    fn first_diff(generated: &str, committed: &str) -> String {
+        let (gb, cb) = (generated.as_bytes(), committed.as_bytes());
+        match gb.iter().zip(cb).position(|(a, b)| a != b) {
+            Some(offset) => {
+                let line = gb[..offset].iter().filter(|&&b| b == b'\n').count() + 1;
+                let g = generated.lines().nth(line - 1).unwrap_or("");
+                let c = committed.lines().nth(line - 1).unwrap_or("");
+                format!(
+                    "first differs at byte {offset} (line {line}): generated {g:?} vs committed {c:?}"
+                )
+            }
+            None => format!(
+                "one is a prefix of the other: generated {} bytes vs committed {} bytes",
+                gb.len(),
+                cb.len()
+            ),
         }
+    }
+
+    /// Every committed `witness_generation_fn.cuh` under `circuit_defs/`,
+    /// repo-relative with `/` separators (matching `CIRCUITS.committed_cuh`).
+    fn collect_committed_cuh(dir: &Path, root: &Path, out: &mut Vec<String>) {
+        for entry in std::fs::read_dir(dir).expect("read circuit_defs") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                collect_committed_cuh(&path, root, out);
+            } else if path.file_name().and_then(|n| n.to_str()) == Some("witness_generation_fn.cuh")
+            {
+                let rel = path.strip_prefix(root).expect("under repo root");
+                out.push(rel.to_str().expect("utf-8 path").to_owned());
+            }
+        }
+    }
+
+    /// Drift guard: every committed `witness_generation_fn.cuh` must match a
+    /// fresh regeneration from its committed SSA/layout inputs. Runs in CI (no
+    /// `skip_if_ci`) — the generator is pure and its inputs are checked in, so
+    /// this is a cheap, deterministic, GPU-free check.
+    #[test]
+    fn committed_witness_cuh_is_current() {
+        let root = repo_root();
+        let mut stale = Vec::new();
+        for circuit in CIRCUITS {
+            let generated = circuit
+                .regenerate(&root)
+                .unwrap_or_else(|e| panic!("generator failed for {}: {e}", circuit.id));
+            let committed_path = circuit.committed_path(&root);
+            let committed = std::fs::read_to_string(&committed_path).unwrap_or_else(|e| {
+                panic!(
+                    "cannot read committed artifact {}: {e}",
+                    committed_path.display()
+                )
+            });
+            if generated != committed {
+                stale.push(format!(
+                    "  {} -> {}\n      {}",
+                    circuit.id,
+                    circuit.committed_cuh,
+                    first_diff(&generated, &committed)
+                ));
+            }
+        }
+        assert!(
+            stale.is_empty(),
+            "Committed witness-generation CUDA is stale vs current codegen:\n{}\n\n\
+             Regenerate and commit with:\n    \
+             cargo run -p gpu_witness_eval_generator --bin regenerate_committed",
+            stale.join("\n")
+        );
+    }
+
+    /// Completeness guard: every committed `witness_generation_fn.cuh` under
+    /// `circuit_defs/` must be listed in `CIRCUITS`. Without this, a future
+    /// artifact added without a table entry would be silently unguarded by
+    /// `committed_witness_cuh_is_current`.
+    #[test]
+    fn every_committed_cuh_is_listed() {
+        let root = repo_root();
+        let listed: HashSet<&str> = CIRCUITS.iter().map(|c| c.committed_cuh).collect();
+        let mut found = Vec::new();
+        collect_committed_cuh(&root.join("circuit_defs"), &root, &mut found);
+        let missing: Vec<&String> = found
+            .iter()
+            .filter(|p| !listed.contains(p.as_str()))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "committed witness CUDA not covered by CIRCUITS (add each to the table):\n{}",
+            missing
+                .iter()
+                .map(|p| format!("  {p}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        // Guard against a mis-resolved root vacuously passing: we must have
+        // found exactly as many artifacts as the table lists.
+        assert_eq!(
+            found.len(),
+            CIRCUITS.len(),
+            "found {} committed .cuh under circuit_defs but CIRCUITS lists {}",
+            found.len(),
+            CIRCUITS.len()
+        );
     }
 }


### PR DESCRIPTION
## What ❔

Add an automated drift guard for the committed witness-generation CUDA in
`gpu_witness_eval_generator`, closing the gap flagged (not fixed) in #363: the
old `generate_all` test wrote gitignored scratch and diffed nothing, and was
`skip_if_ci`-gated, so the checked-in `circuit_defs/**/generated/witness_generation_fn.cuh`
had **no automated correctness check**.

The generator is a pure function of committed `cs/compiled_circuits/*_gkr.json`
inputs, so two read-only, GPU-free, CI-runnable tests suffice:

- **`committed_witness_cuh_is_current`** — regenerate each circuit in memory and
  assert byte-identity against the committed artifact. On drift it names the
  file, the first differing byte/line, and the exact regenerate command.
- **`every_committed_cuh_is_listed`** — walk `circuit_defs/` and assert every
  committed `witness_generation_fn.cuh` is in the table, so a future artifact
  added without a table entry can't be silently unguarded.

Both consume a shared `CIRCUITS` table (single source of truth for the
id → committed-path map, whose names differ for 5 of 11 circuits), also driven by
a new **`regenerate_committed`** bin that refreshes the artifacts after an
intentional codegen change. The old scratch-writing smoke test and its
now-unused `test_utils` dev-dep are removed; `gpu/AGENTS.md` is corrected.

## Why ❔

Regeneration was a manual, undocumented step; nothing caught a stale `.cuh`.
These guards make drift a red test with a one-command fix, and cannot fall out of
sync with the regenerator (they share the table).

## Is this a breaking change?

- [ ] Yes
- [x] No

Behavior-preserving (no generator change). Verified: all 11 committed artifacts
are byte-identical to a fresh regenerate today; both guards fail on injected
drift (content drift / unlisted artifact) and restore clean; the bin round-trips
byte-identically. `check`/`clippy --no-deps` (0 own-crate)/`fmt`/tests green.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
