### PR TITLE
fix(gpu): make the no_cuda build compile without the CUDA Toolkit

### DIFF
--- a/gpu/core/build.rs
+++ b/gpu/core/build.rs
@@ -1,8 +1,9 @@
 /// Build script for gpu_core.
 ///
-/// Always compiles the NVTX C wrapper (`native/nvtx.c`) so that the
+/// Compiles the NVTX C wrapper (`native/nvtx.c`) so that the
 /// `#[link(name = "gpu_core_nvtx")]` directive in `primitives/nvtx.rs` resolves
-/// when gpu_core is tested or used standalone — plain C, no CUDA.
+/// when gpu_core is tested or used standalone. Plain C, but not CUDA-free: it
+/// includes `nvtx3/nvToolsExt.h` from the Toolkit, hence the `no_cuda` skip.
 ///
 /// Under the `bench` feature it additionally builds the field micro-benchmark
 /// CUDA archive (`native/bench/field.cu` → `gpu_core_bench_native`). gpu_core
@@ -11,15 +12,23 @@
 fn main() {
     use std::env;
 
-    // NVTX headers live in the CUDA include tree.
-    let cuda_include = env::var("CUDA_PATH")
-        .map(|p| format!("{p}/include"))
-        .unwrap_or_else(|_| "/usr/local/cuda/include".to_owned());
+    // Build-script cfgs do not propagate from dependencies, so `primitives/nvtx.rs`
+    // needs this crate to declare/set `no_cuda` itself.
+    gpu_native_build::emit_no_cuda_cfg();
 
-    cc::Build::new()
-        .file("native/nvtx.c")
-        .include(&cuda_include)
-        .compile("gpu_core_nvtx");
+    // Toolkit absent → the wrapper cannot compile; `primitives/nvtx.rs` swaps the
+    // `#[link]`ed externs for stubs, so nothing references the archive.
+    if !gpu_native_build::is_no_cuda() {
+        // NVTX headers live in the CUDA include tree.
+        let cuda_include = env::var("CUDA_PATH")
+            .map(|p| format!("{p}/include"))
+            .unwrap_or_else(|_| "/usr/local/cuda/include".to_owned());
+
+        cc::Build::new()
+            .file("native/nvtx.c")
+            .include(&cuda_include)
+            .compile("gpu_core_nvtx");
+    }
 
     println!("cargo:rerun-if-changed=native/nvtx.c");
 

--- a/gpu/core/src/primitives/nvtx.rs
+++ b/gpu/core/src/primitives/nvtx.rs
@@ -15,6 +15,7 @@ struct NvtxStringRegistration {
 type NvtxDomainHandle = *mut NvtxDomainRegistration;
 type NvtxStringHandle = *mut NvtxStringRegistration;
 
+#[cfg(not(no_cuda))]
 #[link(name = "gpu_core_nvtx")]
 unsafe extern "C" {
     fn gpu_core_nvtx_domain_create(name: *const c_char) -> NvtxDomainHandle;
@@ -33,6 +34,62 @@ unsafe extern "C" {
     fn gpu_core_nvtx_ascii_range_start(message: *const c_char) -> u64;
     fn gpu_core_nvtx_range_end(id: u64);
 }
+
+// Without the CUDA Toolkit there is no `nvtx3/nvToolsExt.h`, so `build.rs` skips
+// `native/nvtx.c` and there is no `gpu_core_nvtx` to link. No-ops rather than
+// era_cudart_sys's `unimplemented!()`: NVTX only annotates, and real NVTX is
+// inert with no profiler attached. Null handles and a zero id flow correctly
+// through the callers below.
+#[cfg(no_cuda)]
+mod stubs {
+    use super::{c_char, NvtxDomainHandle, NvtxStringHandle};
+    use std::ptr;
+
+    pub(super) unsafe extern "C" fn gpu_core_nvtx_domain_create(
+        _name: *const c_char,
+    ) -> NvtxDomainHandle {
+        ptr::null_mut()
+    }
+
+    #[allow(unused)]
+    pub(super) unsafe extern "C" fn gpu_core_nvtx_register_string(
+        _domain: NvtxDomainHandle,
+        _string: *const c_char,
+    ) -> NvtxStringHandle {
+        ptr::null_mut()
+    }
+
+    #[allow(unused)]
+    pub(super) unsafe extern "C" fn gpu_core_nvtx_domain_ascii_range_start(
+        _domain: NvtxDomainHandle,
+        _message: *const c_char,
+    ) -> u64 {
+        0
+    }
+
+    #[allow(unused)]
+    pub(super) unsafe extern "C" fn gpu_core_nvtx_registered_range_start(
+        _domain: NvtxDomainHandle,
+        _string: NvtxStringHandle,
+    ) -> u64 {
+        0
+    }
+
+    pub(super) unsafe extern "C" fn gpu_core_nvtx_ascii_range_start(
+        _message: *const c_char,
+    ) -> u64 {
+        0
+    }
+
+    pub(super) unsafe extern "C" fn gpu_core_nvtx_range_end(_id: u64) {}
+}
+
+#[cfg(no_cuda)]
+use stubs::{
+    gpu_core_nvtx_ascii_range_start, gpu_core_nvtx_domain_ascii_range_start,
+    gpu_core_nvtx_domain_create, gpu_core_nvtx_range_end, gpu_core_nvtx_register_string,
+    gpu_core_nvtx_registered_range_start,
+};
 
 #[derive(Clone, Copy)]
 pub struct RangeId(u64);

--- a/gpu/core/src/primitives/utils.rs
+++ b/gpu/core/src/primitives/utils.rs
@@ -41,6 +41,21 @@ pub fn get_grid_block_dims_for_warp_groups(
     get_grid_block_dims_for_threads_count(WARP_SIZE * warps_per_block, threads_count)
 }
 
+/// A pointer-typed `__device__ __constant__` symbol (`const T*` device-side), for
+/// use as the type in a [`era_cudart_sys::cuda_struct_and_stub`] declaration.
+///
+/// `repr(transparent)`, so the symbol layout stays exactly `*const T`. It exists to
+/// carry the `Sync` impl below: in `no_cuda` mode `cuda_struct_and_stub!` lowers a
+/// symbol to a real `static`, which must be `Sync`, and a bare `*const T` is neither
+/// `Sync` nor able to be given the impl locally (orphan rule).
+#[repr(transparent)]
+pub struct ConstPtrSymbol<T>(pub *const T);
+
+// SAFETY: the wrapped value is a device address. It is never dereferenced on the
+// host — the symbol is only ever addressed (`&symbol`) or memcpy'd to the device by
+// `memcpy_to_symbol` — so sharing one across threads carries no aliasing risk.
+unsafe impl<T> Sync for ConstPtrSymbol<T> {}
+
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn memcpy_to_symbol<T>(symbol: &T, src: &T) -> CudaResult<()> {
     cudaMemcpyToSymbol(

--- a/gpu/gkr/src/backward/compact/kernels.rs
+++ b/gpu/gkr/src/backward/compact/kernels.rs
@@ -9,7 +9,7 @@ use std::sync::OnceLock;
 use era_cudart::cuda_kernel_declaration;
 use era_cudart::execution::KernelFunction;
 use era_cudart::result::{CudaResult, CudaResultWrap};
-use era_cudart_sys::cudaGetSymbolAddress;
+use era_cudart_sys::{cudaGetSymbolAddress, cuda_struct_and_stub};
 
 use super::super::kernels::gkr_dim_reducing_launch_config;
 use super::super::kernels::GkrEqSizes;
@@ -117,8 +117,10 @@ pub(crate) fn launch_main_round0_constant<E: crate::BackwardKernels>(
 // Main-layer constants and __constant__ symbol addresses
 // ---------------------------------------------------------------------------
 
-extern "C" {
+cuda_struct_and_stub! {
     static ab_gkr_round2_challenges: [E4; 3];
+}
+cuda_struct_and_stub! {
     static ab_gkr_main_layer_claim_point: [E4; MAX_MAIN_LAYER_CLAIM_POINT_LEN];
 }
 

--- a/gpu/gkr/src/backward/flat/kernel_setup.rs
+++ b/gpu/gkr/src/backward/flat/kernel_setup.rs
@@ -5,7 +5,7 @@
 use std::ffi::c_void;
 
 use era_cudart::result::CudaResultWrap;
-use era_cudart_sys::cudaGetSymbolAddress;
+use era_cudart_sys::{cudaGetSymbolAddress, cuda_struct_and_stub};
 
 use super::types::FLAT_CONST_MAX;
 use gpu_core::primitives::field::E4;
@@ -61,7 +61,7 @@ pub(crate) fn configure_flat_kernel_cache_preference() {
 // __constant__ symbol address
 // ---------------------------------------------------------------------------
 
-extern "C" {
+cuda_struct_and_stub! {
     static ab_gkr_flat_coefficients: [E4; FLAT_CONST_MAX];
 }
 

--- a/gpu/gkr/src/backward/kernels/dim_reducing.rs
+++ b/gpu/gkr/src/backward/kernels/dim_reducing.rs
@@ -4,7 +4,7 @@ use std::ptr::null_mut;
 
 use era_cudart::result::{CudaResult, CudaResultWrap};
 use era_cudart::slice::{DeviceSlice, DeviceVariable};
-use era_cudart_sys::cudaGetSymbolAddress;
+use era_cudart_sys::{cudaGetSymbolAddress, cuda_struct_and_stub};
 
 use super::super::super::{
     GpuGKRStorage, GpuSumcheckRound1PreparedStorage, GpuSumcheckRound2PreparedStorage,
@@ -63,9 +63,11 @@ pub(crate) const GKR_DIM_REDUCING_BATCH_CHALLENGE_TABLE_LEN: usize = 10;
 pub(crate) const MAX_DIM_REDUCING_LAYER_CLAIM_POINT_LEN: usize =
     GKR_BACKWARD_MAX_TRACE_LEN_LOG2 + 2;
 
-extern "C" {
+cuda_struct_and_stub! {
     static ab_gkr_dim_reducing_batch_challenge_table:
         [E4; GKR_DIM_REDUCING_BATCH_CHALLENGE_TABLE_LEN];
+}
+cuda_struct_and_stub! {
     static ab_gkr_dim_reducing_layer_claim_point: [E4; MAX_DIM_REDUCING_LAYER_CLAIM_POINT_LEN];
 }
 

--- a/gpu/gkr/src/backward/kernels/launchers.rs
+++ b/gpu/gkr/src/backward/kernels/launchers.rs
@@ -5,7 +5,7 @@ use era_cudart::result::{CudaResult, CudaResultWrap};
 use era_cudart::slice::DeviceSlice;
 use era_cudart::stream::CudaStream;
 use era_cudart::{cuda_kernel_declaration, cuda_kernel_signature_arguments_and_function};
-use era_cudart_sys::cudaGetSymbolAddress;
+use era_cudart_sys::{cudaGetSymbolAddress, cuda_struct_and_stub};
 
 use super::super::super::{
     GpuExtensionFieldPolyContinuingLaunchDescriptor, GpuExtensionFieldPolyInitialSource,
@@ -80,7 +80,7 @@ pub fn make_eq_sizes(challenge_count: usize) -> GkrEqSizes {
     GkrEqSizes { high, low }
 }
 
-extern "C" {
+cuda_struct_and_stub! {
     static ab_gkr_eq_high: [[E4; GKR_EQ_GROUP_TABLE_LEN]; GKR_EQ_HIGH_SLOTS];
 }
 

--- a/gpu/gkr/src/forward/kernels/mod.rs
+++ b/gpu/gkr/src/forward/kernels/mod.rs
@@ -5,7 +5,7 @@ use era_cudart::execution::{CudaLaunchConfig, KernelFunction};
 use era_cudart::result::{CudaResult, CudaResultWrap};
 use era_cudart::stream::CudaStream;
 use era_cudart::{cuda_kernel_declaration, cuda_kernel_signature_arguments_and_function};
-use era_cudart_sys::cudaGetSymbolAddress;
+use era_cudart_sys::{cudaGetSymbolAddress, cuda_struct_and_stub};
 
 use super::super::{GpuBaseFieldPoly, GpuBaseFieldSourceKind, GpuExtensionFieldPoly};
 use crate::upstream::{Field, GKRAddress};
@@ -248,7 +248,7 @@ cuda_kernel_declaration!(pub(crate)
     )
 );
 
-extern "C" {
+cuda_struct_and_stub! {
     static ab_gkr_lookup_gamma_consts: [E4; 3];
 }
 

--- a/gpu/gkr/src/lib.rs
+++ b/gpu/gkr/src/lib.rs
@@ -12,6 +12,9 @@
 // gpu_hash's / gpu_ntt's / gpu_execution_prover's / gpu_trace's crate-level
 // allow).
 #![allow(clippy::too_many_arguments)]
+// `no_cuda` gates out every GPU test body, leaving their helpers and imports dead
+// by construction. That mode only ever compiles, so this is not a real finding.
+#![cfg_attr(no_cuda, allow(dead_code, unused_imports))]
 // `ForwardKernels`/`BackwardKernels`/`SetupKernels` (`{forward,backward,setup}::kernels`)
 // are deliberately sealed per-phase kernel-dispatch traits — `pub(crate)` on
 // purpose, implemented only for the concrete field types this crate wires up

--- a/gpu/gkr/src/setup/kernels.rs
+++ b/gpu/gkr/src/setup/kernels.rs
@@ -5,7 +5,7 @@ use era_cudart::execution::{CudaLaunchConfig, KernelFunction};
 use era_cudart::result::{CudaResult, CudaResultWrap};
 use era_cudart::slice::{CudaSlice, DeviceSlice, DeviceVariable};
 use era_cudart::{cuda_kernel_declaration, cuda_kernel_signature_arguments_and_function};
-use era_cudart_sys::cudaGetSymbolAddress;
+use era_cudart_sys::{cudaGetSymbolAddress, cuda_struct_and_stub};
 
 use super::super::{GpuBaseFieldPoly, GpuGKRStorage};
 use super::{flatten_setup_columns_into_pinned_buffer, precompute_partial_tree_cache};
@@ -22,7 +22,7 @@ use gpu_trace::trace::holder::TraceHolder;
 pub(super) const GKR_FORWARD_SETUP_GENERIC_LOOKUP_MAX_COLUMNS: usize = 10;
 pub(super) const GKR_FORWARD_SETUP_THREADS_PER_BLOCK: u32 = WARP_SIZE * 4;
 
-extern "C" {
+cuda_struct_and_stub! {
     static ab_gkr_lookup_alpha_powers: [E4; GKR_FORWARD_SETUP_GENERIC_LOOKUP_MAX_COLUMNS];
 }
 

--- a/gpu/native_build/src/lib.rs
+++ b/gpu/native_build/src/lib.rs
@@ -12,9 +12,12 @@
 //! `ab_cuda_configure_target` function that owns the common target
 //! configuration), whose directory is passed to CMake as `AB_CUDA_CMAKE_DIR`.
 
-use era_cudart_sys::{
-    get_cuda_include_path, get_cuda_lib_path, get_cuda_version, is_no_cuda, no_cuda_message,
-};
+use era_cudart_sys::{get_cuda_include_path, get_cuda_lib_path, get_cuda_version, no_cuda_message};
+
+/// Re-exported so a kernel `build.rs` can skip Toolkit-dependent steps — including a
+/// host `cc` compile, like `gpu_core`'s NVTX wrapper — without its own
+/// `era_cudart_sys` build-dependency.
+pub use era_cudart_sys::is_no_cuda;
 use std::env;
 use std::fs;
 use std::path::Path;

--- a/gpu/ntt/src/lib.rs
+++ b/gpu/ntt/src/lib.rs
@@ -12,6 +12,9 @@
 // as gpu_hash's crate-level allow): splitting them into config structs would
 // obscure the 1:1 Rust<->kernel correspondence.
 #![allow(clippy::too_many_arguments)]
+// `no_cuda` gates out every GPU test body, leaving their helpers and imports dead
+// by construction. That mode only ever compiles, so this is not a real finding.
+#![cfg_attr(no_cuda, allow(dead_code, unused_imports))]
 
 mod upstream;
 

--- a/gpu/ntt/src/ntt_twiddles.rs
+++ b/gpu/ntt/src/ntt_twiddles.rs
@@ -11,7 +11,7 @@ use crate::upstream::{
     TwoAdicField,
 };
 use gpu_core::primitives::field::BF;
-use gpu_core::primitives::utils::memcpy_to_symbol;
+use gpu_core::primitives::utils::{memcpy_to_symbol, ConstPtrSymbol};
 
 pub const OMEGA_LOG_ORDER: u32 = <BF as TwoAdicField>::TWO_ADICITY as u32;
 const _: () = assert!(OMEGA_LOG_ORDER == 27); // native/context.cuh literal
@@ -103,9 +103,9 @@ cuda_struct_and_stub! { static ab_fwd_cmem_twiddles_finest_10: [BF; 1 << 10]; }
 cuda_struct_and_stub! { static ab_inv_cmem_twiddles_finest_10: [BF; 1 << 10]; }
 cuda_struct_and_stub! { static ab_fwd_cmem_twiddles_finest_11: [BF; 1 << 11]; }
 cuda_struct_and_stub! { static ab_inv_cmem_twiddles_finest_11: [BF; 1 << 11]; }
-cuda_struct_and_stub! { static ab_fwd_gmem_twiddles_coarse: *const BF; }
-cuda_struct_and_stub! { static ab_inv_gmem_twiddles_coarse: *const BF; }
-cuda_struct_and_stub! { static ab_fully_precomputed_bitrev_twiddles: *const BF; }
+cuda_struct_and_stub! { static ab_fwd_gmem_twiddles_coarse: ConstPtrSymbol<BF>; }
+cuda_struct_and_stub! { static ab_inv_gmem_twiddles_coarse: ConstPtrSymbol<BF>; }
+cuda_struct_and_stub! { static ab_fully_precomputed_bitrev_twiddles: ConstPtrSymbol<BF>; }
 
 unsafe fn copy_to_symbols(
     powers_of_w_fine: *const BF,
@@ -146,11 +146,17 @@ unsafe fn copy_to_symbols(
         ),
     )?;
     memcpy_to_symbol(&ab_inv_sizes, &inv_sizes_host)?;
-    memcpy_to_symbol(&ab_fwd_gmem_twiddles_coarse, &fwd_gmem_twiddles_coarse)?;
-    memcpy_to_symbol(&ab_inv_gmem_twiddles_coarse, &inv_gmem_twiddles_coarse)?;
+    memcpy_to_symbol(
+        &ab_fwd_gmem_twiddles_coarse,
+        &ConstPtrSymbol(fwd_gmem_twiddles_coarse),
+    )?;
+    memcpy_to_symbol(
+        &ab_inv_gmem_twiddles_coarse,
+        &ConstPtrSymbol(inv_gmem_twiddles_coarse),
+    )?;
     memcpy_to_symbol(
         &ab_fully_precomputed_bitrev_twiddles,
-        &fully_precomputed_bitrev_twiddles,
+        &ConstPtrSymbol(fully_precomputed_bitrev_twiddles),
     )?;
     memcpy_to_symbol(&ab_fwd_cmem_twiddles_coarse, &fwd_cmem_twiddles_coarse)?;
     memcpy_to_symbol(&ab_inv_cmem_twiddles_coarse, &inv_cmem_twiddles_coarse)?;

--- a/gpu/trace/src/lib.rs
+++ b/gpu/trace/src/lib.rs
@@ -8,6 +8,9 @@
 // Rust<->kernel correspondence (same precedent as gpu_hash's / gpu_ntt's /
 // gpu_execution_prover's crate-level allow).
 #![allow(clippy::too_many_arguments)]
+// `no_cuda` gates out every GPU test body, leaving their helpers and imports dead
+// by construction. That mode only ever compiles, so this is not a real finding.
+#![cfg_attr(no_cuda, allow(dead_code, unused_imports))]
 
 pub mod trace;
 pub(crate) mod upstream;

--- a/gpu/whir/src/lib.rs
+++ b/gpu/whir/src/lib.rs
@@ -10,6 +10,9 @@
 // gpu_hash's / gpu_ntt's / gpu_execution_prover's / gpu_trace's / gpu_gkr's
 // crate-level allow).
 #![allow(clippy::too_many_arguments)]
+// `no_cuda` gates out every GPU test body, leaving their helpers and imports dead
+// by construction. That mode only ever compiles, so this is not a real finding.
+#![cfg_attr(no_cuda, allow(dead_code, unused_imports))]
 
 pub mod fold;
 pub(crate) mod kernels;


### PR DESCRIPTION
## What ❔

Fixes the `no_cuda` build (`ZKSYNC_USE_CUDA_STUBS=1`), which no longer compiled. Three independent defects:

1. **gpu_core** compiled `native/nvtx.c` unconditionally — host C, but it includes `nvtx3/nvToolsExt.h` from the Toolkit include tree, so the build script failed outright. Now gated, with no-op stubs for the `#[link]`ed externs. (gpu_core also never emitted the `no_cuda` cfg at all.)
2. **gpu_ntt** — three bare `*const BF` `__constant__` symbols; the mode's real `static` lowering requires `Sync`, which a raw pointer neither has nor can be given locally. Adds `gpu_core::primitives::utils::ConstPtrSymbol<T>` next to the `memcpy_to_symbol` that consumes it, since the wall applies to any pointer-typed symbol in any crate.
3. **gpu_gkr** — all 8 `__device__ __constant__` symbols used plain `extern "C" { static … }`, so they were undefined at link time. Converted to `cuda_struct_and_stub!`.

2 and 3 only surface when linking, so `cargo check` alone misses them.

A second commit gates `dead_code` / `unused_imports` under `no_cuda` in the four crates that carry GPU tests. Making the mode compile revealed 163 such warnings (gkr 69, ntt 45, whir 40, trace 9) — previously unreachable, and structural: `#[cfg(not(no_cuda))]` gates out every test body, so its helpers and imports are dead by construction. Normal builds stay strict.

## Why ❔

`no_cuda` exists so the GPU stack can be compiled (not run) without a CUDA Toolkit — useful for type-checking, linting and IDE work on non-GPU machines. It had bit-rotted: nothing exercises it, since the CUDA crates are omitted from `default-members` and no CI job sets the flag.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

Verified with the Toolkit hidden (`CUDA_PATH=/nonexistent-cuda`): `--all-targets` checks clean and the apex test binaries link, across the whole stack. Normal CUDA build/link unaffected; gpu_ntt 143/143 GPU tests pass. Clippy `--all-targets --no-deps` reports zero warnings for all 12 gpu crates in both modes. No test added — the mode is a build configuration, so a guard would mean a CI job, which is deliberately out of scope here.
