### PR TITLE
fix(gpu): adapt the GPU stack to prover's lazy-oracle split

### DIFF
--- a/gpu/circuit_prover/src/tests/asserts.rs
+++ b/gpu/circuit_prover/src/tests/asserts.rs
@@ -441,12 +441,11 @@ pub(super) fn assert_gkr_proof_structure_for_test(
     );
 }
 
-pub(super) fn stage1_caps_from_tree<T: ColumnMajorMerkleTreeConstructor<BF>>(
-    tree: &T,
+pub(super) fn stage1_subcaps_from_cap(
+    cap: MerkleTreeCapVarLength,
     subcap_size: usize,
 ) -> Vec<MerkleTreeCapVarLength> {
-    tree.get_cap()
-        .cap
+    cap.cap
         .chunks_exact(subcap_size)
         .map(|chunk| MerkleTreeCapVarLength {
             cap: chunk.to_vec(),

--- a/gpu/circuit_prover/src/tests/basic_unrolled_parity.rs
+++ b/gpu/circuit_prover/src/tests/basic_unrolled_parity.rs
@@ -201,7 +201,7 @@ fn run_basic_unrolled_workflow_input_parity_test() {
     .unwrap();
     context.get_h2d_stream().synchronize().unwrap();
 
-    let cpu_setup_caps = stage1_caps_from_tree(&setup_commitment.tree, subcap_size);
+    let cpu_setup_caps = stage1_subcaps_from_cap(setup_commitment.get_cap(), subcap_size);
     let gpu_setup_caps = gpu_setup_transfer
         .trace_holder
         .read_per_coset_caps_synchronously(&context)
@@ -263,7 +263,7 @@ fn run_basic_unrolled_workflow_input_parity_test() {
             trace_len.trailing_zeros() as usize,
             &worker,
         );
-    let cpu_memory_caps = stage1_caps_from_tree(&mem_oracle.tree, subcap_size);
+    let cpu_memory_caps = stage1_subcaps_from_cap(mem_oracle.tree.get_cap(), subcap_size);
     if gpu_memory_caps != cpu_memory_caps {
         let first_mismatch = describe_first_trace_holder_column_mismatch(
             &stage1_output.memory_trace_holder,
@@ -275,7 +275,7 @@ fn run_basic_unrolled_workflow_input_parity_test() {
         panic!("memory caps diverged; first flat mismatch: {first_mismatch}");
     }
 
-    let cpu_witness_caps = stage1_caps_from_tree(&wit_oracle.tree, subcap_size);
+    let cpu_witness_caps = stage1_subcaps_from_cap(wit_oracle.tree.get_cap(), subcap_size);
     let gpu_witness_caps = stage1_output
         .witness_trace_holder
         .read_per_coset_caps_synchronously(&context)
@@ -327,30 +327,15 @@ fn run_basic_unrolled_workflow_input_parity_test() {
     let mut cpu_transcript_input = Vec::new();
     external_challenges.flatten_into_buffer(&mut cpu_transcript_input);
     flatten_merkle_caps_iter_into(
-        Some(
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &setup_commitment.tree,
-            ),
-        )
-        .into_iter(),
+        Some(setup_commitment.get_cap()).into_iter(),
         &mut cpu_transcript_input,
     );
     flatten_merkle_caps_iter_into(
-        Some(
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &mem_oracle.tree,
-            ),
-        )
-        .into_iter(),
+        Some(mem_oracle.tree.get_cap()).into_iter(),
         &mut cpu_transcript_input,
     );
     flatten_merkle_caps_iter_into(
-        Some(
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &wit_oracle.tree,
-            ),
-        )
-        .into_iter(),
+        Some(wit_oracle.tree.get_cap()).into_iter(),
         &mut cpu_transcript_input,
     );
 

--- a/gpu/circuit_prover/src/tests/commit_memory.rs
+++ b/gpu/circuit_prover/src/tests/commit_memory.rs
@@ -331,8 +331,7 @@ fn assert_non_memory_commit_memory_matches_cpu_for_test<const FAMILY_IDX: u8>(
         &worker,
     );
     let mut cpu_transcript = vec![];
-    let cpu_cap: MerkleTreeCapVarLength =
-        ColumnMajorMerkleTreeConstructor::<BF>::get_cap(&cpu_mem_oracle.tree);
+    let cpu_cap: MerkleTreeCapVarLength = cpu_mem_oracle.tree.get_cap();
     flatten_merkle_caps_iter_into(Some(cpu_cap).into_iter(), &mut cpu_transcript);
     let device_block_size = 1usize << DEVICE_ALLOCATOR_BLOCK_LOG_SIZE;
     let max_device_allocation_blocks_count = DEVICE_ALLOCATOR_ARENA_BYTES / device_block_size;
@@ -525,8 +524,7 @@ fn assert_memory_commit_memory_matches_cpu_for_test<const FAMILY_IDX: u8>(
         &worker,
     );
     let mut cpu_transcript = vec![];
-    let cpu_cap: MerkleTreeCapVarLength =
-        ColumnMajorMerkleTreeConstructor::<BF>::get_cap(&cpu_mem_oracle.tree);
+    let cpu_cap: MerkleTreeCapVarLength = cpu_mem_oracle.tree.get_cap();
     flatten_merkle_caps_iter_into(Some(cpu_cap).into_iter(), &mut cpu_transcript);
     let device_block_size = 1usize << DEVICE_ALLOCATOR_BLOCK_LOG_SIZE;
     let max_device_allocation_blocks_count = DEVICE_ALLOCATOR_ARENA_BYTES / device_block_size;
@@ -625,8 +623,7 @@ fn assert_delegation_commit_memory_matches_cpu<W, O, F>(
         &worker,
     );
     let mut cpu_transcript = vec![];
-    let cpu_cap: MerkleTreeCapVarLength =
-        ColumnMajorMerkleTreeConstructor::<BF>::get_cap(&cpu_mem_oracle.tree);
+    let cpu_cap: MerkleTreeCapVarLength = cpu_mem_oracle.tree.get_cap();
     flatten_merkle_caps_iter_into(Some(cpu_cap).into_iter(), &mut cpu_transcript);
 
     let device_block_size = 1usize << DEVICE_ALLOCATOR_BLOCK_LOG_SIZE;

--- a/gpu/circuit_prover/src/tests/delegation_asserts.rs
+++ b/gpu/circuit_prover/src/tests/delegation_asserts.rs
@@ -74,7 +74,7 @@ pub(super) fn assert_delegation_workflow_matches_cpu<W, O, F>(
     .unwrap();
     context.get_h2d_stream().synchronize().unwrap();
 
-    let cpu_setup_caps = stage1_caps_from_tree(&setup_commitment.tree, subcap_size);
+    let cpu_setup_caps = stage1_subcaps_from_cap(setup_commitment.get_cap(), subcap_size);
     let gpu_setup_caps = gpu_setup_transfer
         .trace_holder
         .read_per_coset_caps_synchronously(&context)
@@ -121,7 +121,7 @@ pub(super) fn assert_delegation_workflow_matches_cpu<W, O, F>(
             trace_len.trailing_zeros() as usize,
             &worker,
         );
-    let cpu_memory_caps = stage1_caps_from_tree(&mem_oracle.tree, subcap_size);
+    let cpu_memory_caps = stage1_subcaps_from_cap(mem_oracle.tree.get_cap(), subcap_size);
     if gpu_memory_caps != cpu_memory_caps {
         let first_mismatch = describe_first_trace_holder_column_mismatch(
             &stage1_output.memory_trace_holder,
@@ -133,7 +133,7 @@ pub(super) fn assert_delegation_workflow_matches_cpu<W, O, F>(
         panic!("{label}: memory caps diverged; first flat mismatch: {first_mismatch}");
     }
 
-    let cpu_witness_caps = stage1_caps_from_tree(&wit_oracle.tree, subcap_size);
+    let cpu_witness_caps = stage1_subcaps_from_cap(wit_oracle.tree.get_cap(), subcap_size);
     let gpu_witness_caps = stage1_output
         .witness_trace_holder
         .read_per_coset_caps_synchronously(&context)
@@ -200,30 +200,15 @@ pub(super) fn assert_delegation_workflow_matches_cpu<W, O, F>(
     let mut cpu_transcript_input = Vec::new();
     external_challenges.flatten_into_buffer(&mut cpu_transcript_input);
     flatten_merkle_caps_iter_into(
-        Some(
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &setup_commitment.tree,
-            ),
-        )
-        .into_iter(),
+        Some(setup_commitment.get_cap()).into_iter(),
         &mut cpu_transcript_input,
     );
     flatten_merkle_caps_iter_into(
-        Some(
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &mem_oracle.tree,
-            ),
-        )
-        .into_iter(),
+        Some(mem_oracle.tree.get_cap()).into_iter(),
         &mut cpu_transcript_input,
     );
     flatten_merkle_caps_iter_into(
-        Some(
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &wit_oracle.tree,
-            ),
-        )
-        .into_iter(),
+        Some(wit_oracle.tree.get_cap()).into_iter(),
         &mut cpu_transcript_input,
     );
 

--- a/gpu/circuit_prover/src/tests/inits_and_teardowns.rs
+++ b/gpu/circuit_prover/src/tests/inits_and_teardowns.rs
@@ -329,8 +329,8 @@ pub(super) fn prepare_inits_and_teardowns_proof_fixture(
                 trace_len.trailing_zeros() as usize,
                 &worker,
             );
-        stage1_caps_from_tree(
-            &mem_oracle.tree,
+        stage1_subcaps_from_cap(
+            mem_oracle.tree.get_cap(),
             whir_schedule.cap_size / whir_schedule.base_lde_factor,
         )
     };
@@ -539,8 +539,8 @@ fn standalone_inits_and_teardowns_gpu_workflow_matches_cpu() {
             trace_len.trailing_zeros() as usize,
             &worker,
         );
-    let cpu_memory_caps = stage1_caps_from_tree(
-        &mem_oracle.tree,
+    let cpu_memory_caps = stage1_subcaps_from_cap(
+        mem_oracle.tree.get_cap(),
         whir_schedule.cap_size / whir_schedule.base_lde_factor,
     );
 
@@ -612,12 +612,7 @@ fn standalone_inits_and_teardowns_gpu_workflow_matches_cpu() {
         cpu_transcript_input.extend_from_slice(&canonical_top_bits);
         external_challenges.flatten_into_buffer(&mut cpu_transcript_input);
         flatten_merkle_caps_iter_into(
-            Some(
-                <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                    &mem_oracle.tree,
-                ),
-            )
-            .into_iter(),
+            Some(mem_oracle.tree.get_cap()).into_iter(),
             &mut cpu_transcript_input,
         );
         let mut cpu_seed =

--- a/gpu/circuit_prover/src/tests/memory_workflow.rs
+++ b/gpu/circuit_prover/src/tests/memory_workflow.rs
@@ -232,7 +232,7 @@ pub(super) fn run_memory_workflow_input_parity_test<const FAMILY_IDX: u8>(
     .unwrap();
     context.get_h2d_stream().synchronize().unwrap();
 
-    let cpu_setup_caps = stage1_caps_from_tree(&setup_commitment.tree, subcap_size);
+    let cpu_setup_caps = stage1_subcaps_from_cap(setup_commitment.get_cap(), subcap_size);
     let gpu_setup_caps = gpu_setup_transfer
         .trace_holder
         .read_per_coset_caps_synchronously(&context)
@@ -295,7 +295,7 @@ pub(super) fn run_memory_workflow_input_parity_test<const FAMILY_IDX: u8>(
             trace_len.trailing_zeros() as usize,
             &worker,
         );
-    let cpu_memory_caps = stage1_caps_from_tree(&mem_oracle.tree, subcap_size);
+    let cpu_memory_caps = stage1_subcaps_from_cap(mem_oracle.tree.get_cap(), subcap_size);
     if gpu_memory_caps != cpu_memory_caps {
         let first_mismatch = describe_first_trace_holder_column_mismatch(
             &stage1_output.memory_trace_holder,
@@ -332,7 +332,7 @@ pub(super) fn run_memory_workflow_input_parity_test<const FAMILY_IDX: u8>(
         );
     }
 
-    let cpu_witness_caps = stage1_caps_from_tree(&wit_oracle.tree, subcap_size);
+    let cpu_witness_caps = stage1_subcaps_from_cap(wit_oracle.tree.get_cap(), subcap_size);
     let gpu_witness_caps = stage1_output
         .witness_trace_holder
         .read_per_coset_caps_synchronously(&context)

--- a/gpu/circuit_prover/src/tests/stagewise.rs
+++ b/gpu/circuit_prover/src/tests/stagewise.rs
@@ -278,7 +278,7 @@ fn run_basic_unrolled_stagewise_parity_test() {
         .trace_holder
         .read_per_coset_caps_synchronously(&context)
         .unwrap();
-    let setup_caps = stage1_caps_from_tree(&setup_commitment.tree, subcap_size);
+    let setup_caps = stage1_subcaps_from_cap(setup_commitment.get_cap(), subcap_size);
     assert_eq!(trace_holder_caps, setup_caps);
     let h_decoder_table = witness_gen_data
         .iter()
@@ -322,7 +322,7 @@ fn run_basic_unrolled_stagewise_parity_test() {
         .unwrap();
     context.get_exec_stream().synchronize().unwrap();
 
-    let memory_caps = stage1_caps_from_tree(&mem_oracle.tree, subcap_size);
+    let memory_caps = stage1_subcaps_from_cap(mem_oracle.tree.get_cap(), subcap_size);
     assert_eq!(
         stage1_output
             .memory_trace_holder
@@ -331,7 +331,7 @@ fn run_basic_unrolled_stagewise_parity_test() {
         memory_caps
     );
 
-    let witness_caps = stage1_caps_from_tree(&wit_oracle.tree, subcap_size);
+    let witness_caps = stage1_subcaps_from_cap(wit_oracle.tree.get_cap(), subcap_size);
     assert_eq!(
         stage1_output
             .witness_trace_holder
@@ -343,30 +343,15 @@ fn run_basic_unrolled_stagewise_parity_test() {
     let mut transcript_input = vec![];
     external_challenges.flatten_into_buffer(&mut transcript_input);
     flatten_merkle_caps_iter_into(
-        Some(
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &setup_commitment.tree,
-            ),
-        )
-        .into_iter(),
+        Some(setup_commitment.get_cap()).into_iter(),
         &mut transcript_input,
     );
     flatten_merkle_caps_iter_into(
-        Some(
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &mem_oracle.tree,
-            ),
-        )
-        .into_iter(),
+        Some(mem_oracle.tree.get_cap()).into_iter(),
         &mut transcript_input,
     );
     flatten_merkle_caps_iter_into(
-        Some(
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &wit_oracle.tree,
-            ),
-        )
-        .into_iter(),
+        Some(wit_oracle.tree.get_cap()).into_iter(),
         &mut transcript_input,
     );
 
@@ -969,6 +954,9 @@ fn run_basic_unrolled_stagewise_parity_test() {
     // capture the full GPU WHIR proof from this call rather than running a
     // second gpu_whir_fold_supported_path (which would try to take the
     // already-consumed tree caps and panic).
+    let SetupCommitment::InMemory(setup_oracle) = &setup_commitment else {
+        panic!("WHIR oracle parity requires an in-memory setup commitment");
+    };
     let gpu_whir_proof = {
         let _range = scoped_range(None, "test.gpu.whir.recursive_oracle_parity");
         assert_recursive_whir_oracle_parity_for_supported_path(
@@ -978,7 +966,7 @@ fn run_basic_unrolled_stagewise_parity_test() {
             &wit_oracle,
             &cpu_wit_polys_claims,
             &mut stage1_output.witness_trace_holder,
-            &setup_commitment,
+            setup_oracle,
             &cpu_setup_polys_claims,
             &mut gpu_setup_transfer.trace_holder,
             base_layer_z,

--- a/gpu/circuit_prover/src/tests/whir_oracle_parity.rs
+++ b/gpu/circuit_prover/src/tests/whir_oracle_parity.rs
@@ -124,7 +124,7 @@ pub(super) fn assert_recursive_whir_oracle_parity_for_supported_path(
     // Main-domain (coset-0) columns per oracle set, read through the RSQueriable
     // value source (matches `whir_fold`'s batching after the lazy-oracle refactor).
     // These test oracles are materialized, so the source returns EVALUATIONS.
-    use prover::merkle_trees::{MainDomainColumn, RSQueriable};
+    use prover::merkle_trees::MainDomainColumn;
     let main_domain_cols: [Vec<MainDomainColumn<'_, BF>>; 3] = [
         (0..oracle_refs[0].num_columns())
             .map(|c| oracle_refs[0].cosets.main_domain_column(c))
@@ -320,15 +320,9 @@ pub(super) fn assert_recursive_whir_oracle_parity_for_supported_path(
     .unwrap();
     assert_eq!(
         gpu_rs_oracle.get_tree_cap(context).unwrap(),
-        <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-            &cpu_rs_oracle.tree,
-        )
+        cpu_rs_oracle.tree.get_cap()
     );
-    cpu_recursive_caps.push(
-        <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-            &cpu_rs_oracle.tree,
-        ),
-    );
+    cpu_recursive_caps.push(cpu_rs_oracle.tree.get_cap());
     let gpu_initial_round_checkpoint = debug_initial_round_checkpoint_for_test(
         gpu_mem_trace_holder,
         mem_polys_claims,
@@ -351,9 +345,7 @@ pub(super) fn assert_recursive_whir_oracle_parity_for_supported_path(
     add_whir_commitment_to_transcript::<BF, E4, Blake2sTranscript, DefaultTreeConstructor>(
         &mut transcript_seed,
         &WhirCommitment::<BF, DefaultTreeConstructor> {
-            cap: <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &cpu_rs_oracle.tree,
-            ),
+            cap: cpu_rs_oracle.tree.get_cap(),
             _marker: core::marker::PhantomData,
         },
     );
@@ -402,9 +394,7 @@ pub(super) fn assert_recursive_whir_oracle_parity_for_supported_path(
     }
     assert_eq!(
         gpu_initial_round_checkpoint.recursive_cap,
-        <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-            &cpu_rs_oracle.tree,
-        ),
+        cpu_rs_oracle.tree.get_cap(),
         "initial recursive WHIR commitment diverged before PoW",
     );
     assert_eq!(
@@ -537,13 +527,9 @@ pub(super) fn assert_recursive_whir_oracle_parity_for_supported_path(
         .unwrap();
         assert_eq!(
             next_gpu_oracle.get_tree_cap(context).unwrap(),
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &next_cpu_oracle.tree,
-            )
+            next_cpu_oracle.tree.get_cap()
         );
-        let next_cpu_oracle_cap = <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<
-            BF,
-        >>::get_cap(&next_cpu_oracle.tree);
+        let next_cpu_oracle_cap = next_cpu_oracle.tree.get_cap();
         cpu_recursive_caps.push(next_cpu_oracle_cap.clone());
         // Upstream folds the recursive oracle cap into the transcript before drawing
         // the next OOD point (see prover/src/gkr/whir/mod.rs).

--- a/gpu/circuit_prover/src/tests/workflow_parity.rs
+++ b/gpu/circuit_prover/src/tests/workflow_parity.rs
@@ -205,7 +205,7 @@ fn run_jump_branch_slt_workflow_input_parity_test() {
     .unwrap();
     context.get_h2d_stream().synchronize().unwrap();
 
-    let cpu_setup_caps = stage1_caps_from_tree(&setup_commitment.tree, subcap_size);
+    let cpu_setup_caps = stage1_subcaps_from_cap(setup_commitment.get_cap(), subcap_size);
     let gpu_setup_caps = gpu_setup_transfer
         .trace_holder
         .read_per_coset_caps_synchronously(&context)
@@ -267,7 +267,7 @@ fn run_jump_branch_slt_workflow_input_parity_test() {
             trace_len.trailing_zeros() as usize,
             &worker,
         );
-    let cpu_memory_caps = stage1_caps_from_tree(&mem_oracle.tree, subcap_size);
+    let cpu_memory_caps = stage1_subcaps_from_cap(mem_oracle.tree.get_cap(), subcap_size);
     if gpu_memory_caps != cpu_memory_caps {
         let first_mismatch = describe_first_trace_holder_column_mismatch(
             &stage1_output.memory_trace_holder,
@@ -279,7 +279,7 @@ fn run_jump_branch_slt_workflow_input_parity_test() {
         panic!("memory caps diverged; first flat mismatch: {first_mismatch}");
     }
 
-    let cpu_witness_caps = stage1_caps_from_tree(&wit_oracle.tree, subcap_size);
+    let cpu_witness_caps = stage1_subcaps_from_cap(wit_oracle.tree.get_cap(), subcap_size);
     let gpu_witness_caps = stage1_output
         .witness_trace_holder
         .read_per_coset_caps_synchronously(&context)
@@ -331,30 +331,15 @@ fn run_jump_branch_slt_workflow_input_parity_test() {
     let mut cpu_transcript_input = Vec::new();
     external_challenges.flatten_into_buffer(&mut cpu_transcript_input);
     flatten_merkle_caps_iter_into(
-        Some(
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &setup_commitment.tree,
-            ),
-        )
-        .into_iter(),
+        Some(setup_commitment.get_cap()).into_iter(),
         &mut cpu_transcript_input,
     );
     flatten_merkle_caps_iter_into(
-        Some(
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &mem_oracle.tree,
-            ),
-        )
-        .into_iter(),
+        Some(mem_oracle.tree.get_cap()).into_iter(),
         &mut cpu_transcript_input,
     );
     flatten_merkle_caps_iter_into(
-        Some(
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                &wit_oracle.tree,
-            ),
-        )
-        .into_iter(),
+        Some(wit_oracle.tree.get_cap()).into_iter(),
         &mut cpu_transcript_input,
     );
 

--- a/gpu/circuit_prover/src/upstream.rs
+++ b/gpu/circuit_prover/src/upstream.rs
@@ -110,6 +110,8 @@ pub(crate) use prover::gkr::prover::utils::flatten_merkle_caps_iter_into;
 #[cfg(test)]
 pub(crate) use prover::gkr::prover::CommitmentMode;
 #[cfg(test)]
+pub(crate) use prover::gkr::prover::SetupCommitment;
+#[cfg(test)]
 pub(crate) use prover::gkr::prover::{
     dimension_reduction, forward_loop, prove_configured_with_gkr, sumcheck_loop,
 };
@@ -153,7 +155,7 @@ pub(crate) use prover::gkr::witness_gen::oracles::{
     MemoryCircuitOracle, NonMemoryCircuitOracle, UnifiedRiscvCircuitOracle,
 };
 #[cfg(test)]
-pub(crate) use prover::merkle_trees::{ColumnMajorMerkleTreeConstructor, MerkleTreeCapVarLength};
+pub(crate) use prover::merkle_trees::{MerkleTreeCapVarLength, PathQueriable};
 #[cfg(test)]
 pub(crate) use prover::query_utils::{assemble_query_index, BitSource};
 #[cfg(test)]

--- a/gpu/gkr/src/setup/tests.rs
+++ b/gpu/gkr/src/setup/tests.rs
@@ -13,8 +13,7 @@ use worker::Worker;
 use super::*;
 use crate::test_utils::make_test_context;
 use crate::upstream::{
-    ColumnMajorMerkleTreeConstructor, DefaultTreeConstructor, FieldExtension,
-    MerkleTreeCapVarLength, PrimeField, VirtualSetupPoly,
+    DefaultTreeConstructor, FieldExtension, MerkleTreeCapVarLength, PrimeField, VirtualSetupPoly,
 };
 use gpu_core::primitives::field::E4;
 use gpu_ops::simple::set_by_ref;
@@ -281,7 +280,7 @@ fn setup_host_matches_flattened_cpu_setup_and_caps() {
 
     let worker = Worker::new();
     let twiddles: fft::Twiddles<BF, Global> = fft::Twiddles::new(trace_len, &worker);
-    let setup_commitment = setup.commit(
+    let setup_commitment = setup.commit::<DefaultTreeConstructor>(
         &twiddles,
         lde_factor,
         log_rows_per_leaf as usize,
@@ -290,15 +289,14 @@ fn setup_host_matches_flattened_cpu_setup_and_caps() {
         &worker,
     );
     let subcap_size = tree_cap_size / lde_factor;
-    let setup_caps = <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-        &setup_commitment.tree,
-    )
-    .cap
-    .chunks_exact(subcap_size)
-    .map(|chunk| MerkleTreeCapVarLength {
-        cap: chunk.to_vec(),
-    })
-    .collect_vec();
+    let setup_caps = setup_commitment
+        .get_cap()
+        .cap
+        .chunks_exact(subcap_size)
+        .map(|chunk| MerkleTreeCapVarLength {
+            cap: chunk.to_vec(),
+        })
+        .collect_vec();
     assert_eq!(
         stage1_caps_from_unified_host_cap(&host.unified_tree_cap[..], log_lde_factor),
         setup_caps

--- a/gpu/program_prover/src/proof_assembly.rs
+++ b/gpu/program_prover/src/proof_assembly.rs
@@ -18,9 +18,8 @@ use worker::Worker;
 
 use crate::upstream::{compute_end_params, Setups};
 use crate::upstream::{
-    config_for_security_level_under_pessimistic_conjecture, ColumnMajorMerkleTreeConstructor,
-    DefaultTreeConstructor, MerkleTreeCap, ProgramProof, SecurityLevel, Twiddles,
-    UnrolledCircuitSetupParams,
+    config_for_security_level_under_pessimistic_conjecture, DefaultTreeConstructor, MerkleTreeCap,
+    ProgramProof, SecurityLevel, Twiddles, UnrolledCircuitSetupParams,
 };
 
 /// Assemble a `ProgramProof` + its `Setups` map from a GPU prove result.
@@ -65,12 +64,7 @@ pub fn assemble_program_proof(
                 family_idx: *family_idx,
                 capacity: trace_len as u32,
                 setup_caps: MerkleTreeCap {
-                    cap: <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(
-                        &setup_commitment.tree,
-                    )
-                    .cap
-                    .try_into()
-                    .unwrap(),
+                    cap: setup_commitment.get_cap().cap.try_into().unwrap(),
                 },
             },
         );

--- a/gpu/trace/src/trace/holder/tests.rs
+++ b/gpu/trace/src/trace/holder/tests.rs
@@ -10,7 +10,7 @@ use worker::Worker;
 use super::*;
 use crate::upstream::{
     multivariate_coeffs_into_hypercube_evals, Blake2sU32MerkleTreeWithCap,
-    ColumnMajorMerkleTreeConstructor, Field, MerkleTreeCapVarLength, PrimeField,
+    ColumnMajorMerkleTreeConstructor, Field, MerkleTreeCapVarLength, PathQueriable, PrimeField,
 };
 use gpu_core::allocator::tracker::AllocationPlacement;
 use gpu_prover_context::ProverContextConfig;
@@ -124,7 +124,7 @@ fn stage1_caps_from_cpu_cosets(
         .collect_vec();
     let tree = <Blake2sU32MerkleTreeWithCap<Global> as ColumnMajorMerkleTreeConstructor<
             BF,
-        >>::construct_from_cosets::<BF, Global>(
+        >>::construct_from_cosets::<BF>(
             &source_refs,
             rows_per_leaf,
             total_cap_size,
@@ -134,7 +134,7 @@ fn stage1_caps_from_cpu_cosets(
             worker,
         );
     let subcap_size = total_cap_size >> log_lde_factor;
-    <Blake2sU32MerkleTreeWithCap<Global> as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(&tree)
+    PathQueriable::get_cap(&tree)
         .cap
         .chunks_exact(subcap_size)
         .map(|chunk| MerkleTreeCapVarLength {

--- a/gpu/trace/src/upstream.rs
+++ b/gpu/trace/src/upstream.rs
@@ -73,6 +73,8 @@ pub(crate) use prover::merkle_trees::blake2s_for_everything_tree::Blake2sU32Merk
 #[cfg(test)]
 pub(crate) use prover::merkle_trees::ColumnMajorMerkleTreeConstructor;
 pub(crate) use prover::merkle_trees::MerkleTreeCapVarLength;
+#[cfg(test)]
+pub(crate) use prover::merkle_trees::PathQueriable;
 
 // -----------------------------------------------------------------------
 // `setups` — compiled-circuit binary loading

--- a/gpu/whir/src/fold/tests/query_tests.rs
+++ b/gpu/whir/src/fold/tests/query_tests.rs
@@ -15,7 +15,9 @@ use super::make_lde_trace_holder;
 use crate::fold::debug::{
     copy_back, copy_small_to_device, query_base_trace_holder_for_folded_index,
 };
-use crate::upstream::{Blake2sU32MerkleTreeWithCap, ColumnMajorMerkleTreeConstructor, PrimeField};
+use crate::upstream::{
+    Blake2sU32MerkleTreeWithCap, ColumnMajorMerkleTreeConstructor, PathQueriable, PrimeField,
+};
 
 #[test]
 #[cfg(not(no_cuda))]
@@ -63,7 +65,7 @@ fn base_query_paths_match_cpu_tree() {
         .collect::<Vec<_>>();
     let cpu_tree = <Blake2sU32MerkleTreeWithCap<Global> as ColumnMajorMerkleTreeConstructor<
         BF,
-    >>::construct_from_cosets::<BF, Global>(
+    >>::construct_from_cosets::<BF>(
         &source_refs,
         1usize << log_rows_per_leaf,
         1usize << log_tree_cap_size,
@@ -78,11 +80,7 @@ fn base_query_paths_match_cpu_tree() {
         let (_, _, gpu_query) =
             query_base_trace_holder_for_folded_index(&mut trace_holder, query_index, &context)
                 .unwrap();
-        let (_, cpu_path) =
-            <Blake2sU32MerkleTreeWithCap<Global> as ColumnMajorMerkleTreeConstructor<BF>>::get_proof::<Global>(
-                &cpu_tree,
-                query_index,
-            );
+        let (_, cpu_path) = PathQueriable::get_proof(&cpu_tree, query_index);
         assert_eq!(gpu_query.path, cpu_path, "query_index={}", query_index);
     }
 }

--- a/gpu/whir/src/lib.rs
+++ b/gpu/whir/src/lib.rs
@@ -37,6 +37,8 @@ use gpu_trace::trace::holder::{TraceHolder, TreesCacheMode, PARTIAL_TREE_REDUCTI
 // below (the `#[cfg(any(test, feature = "test-utils"))]` items). The production
 // oracle path (`from_device_monomial_coeffs_impl`, `schedule_*_into_slab`,
 // `into_host_keepalive`, `lde_factor`) references none of these.
+#[cfg(test)]
+use crate::upstream::PathQueriable;
 #[cfg(any(test, feature = "test-utils"))]
 use crate::upstream::{extension_field_from_base_coeffs, Field, MerkleTreeCapVarLength};
 #[cfg(any(test, feature = "test-utils"))]
@@ -711,7 +713,7 @@ pub(crate) mod tests {
         commit_single_ext_poly_no_transform_for_test,
         commit_single_ext_poly_with_transform_for_test, ColumnMajorExtensionOracleForLDE,
     };
-    use prover::merkle_trees::{ColumnMajorMerkleTreeConstructor, DefaultTreeConstructor};
+    use prover::merkle_trees::DefaultTreeConstructor;
     use rand::Rng;
     use worker::Worker;
 
@@ -834,7 +836,7 @@ pub(crate) mod tests {
 
         assert_eq!(
             gpu.get_tree_cap(&context).unwrap(),
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(&cpu.tree)
+            PathQueriable::get_cap(&cpu.tree)
         );
 
         let query_indexes = [
@@ -1020,7 +1022,7 @@ pub(crate) mod tests {
 
         assert_eq!(
             gpu.get_tree_cap(&context).unwrap(),
-            <DefaultTreeConstructor as ColumnMajorMerkleTreeConstructor<BF>>::get_cap(&cpu.tree)
+            PathQueriable::get_cap(&cpu.tree)
         );
 
         for query_index in [0usize, 1, 7, 13] {

--- a/gpu/whir/src/upstream.rs
+++ b/gpu/whir/src/upstream.rs
@@ -44,6 +44,8 @@ pub(crate) use prover::gkr::whir::WhirCommitment;
 pub(crate) use prover::merkle_trees::blake2s_for_everything_tree::Blake2sU32MerkleTreeWithCap;
 #[cfg(test)]
 pub(crate) use prover::merkle_trees::ColumnMajorMerkleTreeConstructor;
+#[cfg(test)]
+pub(crate) use prover::merkle_trees::PathQueriable;
 #[cfg(any(test, feature = "test-utils"))]
 pub(crate) use prover::merkle_trees::{DefaultTreeConstructor, MerkleTreeCapVarLength};
 #[cfg(any(test, feature = "test-utils"))]


### PR DESCRIPTION
## What ❔

Unbreaks the GPU stack after #370's lazy-oracle split. That PR adapted one GPU test file and left the rest, so `av_gkr_compiler` did not compile: 56 errors across 6 targets in 5 crates, including `gpu_program_prover`'s **lib**. Only 2 of the 56 are reachable by `cargo check` — the rest appear at link time.

Three mechanical adaptations to the upstream changes:

- `get_cap`/`get_proof` moved to the new `PathQueriable` supertrait → requalified (~25 sites).
- `construct_from_cosets` lost its allocator generic → `::<BF, Global>` becomes `::<BF>`.
- `SetupCommitment` is now an `InMemory | OnDisk` enum with no `.tree` field → production reads the cap through its variant-agnostic `get_cap()`, so it also keeps working if setup ever moves on-disk.

The one non-mechanical bit: `stage1_caps_from_tree` is rekeyed on the cap (`stage1_subcaps_from_cap`), since a `SetupCommitment` hides its tree and the cap is all the helper consumed.

**No change to the GPU prover workflow** — the CPU setup commit runs exactly as before and the caps are byte-identical.

## Why ❔

`av_gkr_compiler` is currently broken for every GPU consumer, production included. #370 was merged with red CI; this restores the branch.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

Verified: normal mode and `no_cuda` (Toolkit hidden) both check clean across all 12 gpu crates with `--all-targets`, zero warnings in gpu files; `gpu_trace` + `gpu_gkr` GPU tests 23/23, including `trace_holder_materialization_matches_stage1_caps_for_grouped_leafs`, which compares GPU caps against the CPU reference. No tests added — this restores existing ones.
