### PR TITLE
fix(gpu_ntt): unbreak pre-Blackwell builds and declare shared-memory alignment

### DIFF
--- a/gpu/ntt/native/bench/dit_bench_kernels.cu
+++ b/gpu/ntt/native/bench/dit_bench_kernels.cu
@@ -19,7 +19,7 @@ DEVICE_FORCEINLINE void ntt_two_pass_fixed(const bf *__restrict__ monomials_bitr
   constexpr unsigned P1C = coupled_triangle_count<LOG_N, LOG_VPT, G::LOG_N1>();
   constexpr unsigned P2C = clean_triangle_count<G::LOG_N2, LOG_VPT>();
   constexpr unsigned P2C_PAD = (P2C + 3u) & ~3u; // keep d_smem/slab 16B-aligned
-  extern __shared__ bf smem[];
+  extern __shared__ __align__(16) bf smem[];
 
   bf *const couple = smem;            // P1C (mult of 4)
   bf *const tw_p2 = couple + P1C;     // P2C entries, P2C_PAD reserved

--- a/gpu/ntt/native/dit_kernels.cuh
+++ b/gpu/ntt/native/dit_kernels.cuh
@@ -34,7 +34,7 @@ DEVICE_FORCEINLINE void ntt_single(const bf *__restrict__ monomials_bitrev,
   constexpr unsigned BLOCK_THREADS = NUM_WARPS * 32u;
   constexpr unsigned TRI = clean_triangle_count<LOG_N, LOG_VPT>();
 
-  extern __shared__ bf smem[];
+  extern __shared__ __align__(16) bf smem[];
   bf *const tw = smem;
 
   const unsigned tid = threadIdx.x;
@@ -94,7 +94,7 @@ DEVICE_FORCEINLINE void ntt_single_stream(const bf *__restrict__ monomials_bitre
   constexpr unsigned BLOCK_THREADS = NUM_WARPS * 32u;
   constexpr unsigned TRI = clean_triangle_count<LOG_N, LOG_VPT>();
   constexpr unsigned SLOTS_PER_BLOCK = NUM_WARPS * NTTS_PER_WARP;
-  extern __shared__ bf smem[];
+  extern __shared__ __align__(16) bf smem[];
   bf *const tw = smem;
   const unsigned tid = threadIdx.x;
   const unsigned warp_id = tid >> 5;
@@ -154,7 +154,7 @@ DEVICE_FORCEINLINE void ntt_two_pass(const bf *__restrict__ monomials_bitrev,
   constexpr unsigned P1C = coupled_triangle_count<LOG_N, LOG_VPT, G::LOG_N1>();
   constexpr unsigned P2C = clean_triangle_count<G::LOG_N2, LOG_VPT>();
   constexpr unsigned P2C_PAD = (P2C + 3u) & ~3u; // keep d_smem/slab 16B-aligned
-  extern __shared__ bf smem[];
+  extern __shared__ __align__(16) bf smem[];
 
   bf *const couple = smem;            // P1C (mult of 4)
   bf *const tw_p2 = couple + P1C;     // P2C entries, P2C_PAD reserved

--- a/gpu/ntt/native/dit_memory.cuh
+++ b/gpu/ntt/native/dit_memory.cuh
@@ -1,216 +1,153 @@
-// Slim matrix accessors with cache-modifier loads/stores.
-// Pattern matches gpu_core/native_headers/primitives/memory.cuh for the cg modifier,
-// stripped to the bf row/col API used by NTT kernels.
+// bf-typed memory helpers. Every access routes through gpu_core's memory.cuh
+// load_*/store_* wrappers, which select the PTX vector width from the POD's
+// size and alignment and own the sm_100+ 256-bit arch guard, so no raw asm
+// lives here.
 
 #pragma once
 #include <primitives/field.cuh>
+#include <primitives/memory.cuh>
 #include <primitives/ptx.cuh>
 using namespace ::airbender::primitives::field;
 using namespace ::airbender::primitives;
 namespace airbender {
 namespace ntt {
 
-// `cg`: bypass L1, allocate L2-only. Matches gpu_core usage.
+namespace mem = ::airbender::primitives::memory;
+
+// Packed bf vectors. Size and alignment select the access width via
+// memory::load_unit<T>: 8 B -> uint2, 16 B -> uint4, 32 B -> u32x8. Not named
+// bf2/bf4/bf8 -- e2/e4 are the extension-field prefixes in field.cuh.
+struct __align__(8) bf2_wide {
+  bf v[2];
+};
+struct __align__(16) bf4_wide {
+  bf v[4];
+};
+struct __align__(32) bf8_wide {
+  bf v[8];
+};
+
+// The alignments are load-bearing: at align(16), bf8_wide still satisfies
+// ld/st's alignof check but load_unit selects uint4 and silently issues two
+// 128-bit accesses in place of one 256-bit access.
+static_assert(sizeof(bf2_wide) == 8 && alignof(bf2_wide) == 8, "bf2_wide ABI");
+static_assert(sizeof(bf4_wide) == 16 && alignof(bf4_wide) == 16, "bf4_wide ABI");
+static_assert(sizeof(bf8_wide) == 32 && alignof(bf8_wide) == 32, "bf8_wide ABI");
+
+// `cg`: bypass L1, allocate L2-only.
 DEVICE_FORCEINLINE bf ld_cg(const bf *p) { return bf::from_reduced_raw_repr(ptx::ld_cg(reinterpret_cast<const u32 *>(p))); }
 DEVICE_FORCEINLINE void st_cg(bf *p, bf v) { ptx::st_cg(reinterpret_cast<u32 *>(p), bf::into_raw_u32(v)); }
 
-// Vec2 (uint64_t = 2 bf) variants for V1.
 DEVICE_FORCEINLINE void ld_cg_v2(const bf *p, bf &a, bf &b) {
-  u32 a_v, b_v;
-  asm volatile("ld.global.cg.v2.u32 {%0, %1}, [%2];" : "=r"(a_v), "=r"(b_v) : "l"(p));
-  a = bf::from_reduced_raw_repr(a_v);
-  b = bf::from_reduced_raw_repr(b_v);
+  const bf2_wide r = mem::load_cg(reinterpret_cast<const bf2_wide *>(p));
+  a = r.v[0];
+  b = r.v[1];
 }
 DEVICE_FORCEINLINE void st_cg_v2(bf *p, bf a, bf b) {
-  asm volatile("st.global.cg.v2.u32 [%0], {%1, %2};" ::"l"(p), "r"(bf::into_raw_u32(a)), "r"(bf::into_raw_u32(b)));
+  const bf2_wide w{{a, b}};
+  mem::store_cg(reinterpret_cast<bf2_wide *>(p), w);
 }
 
-// Vec4 variants for V1 at wider configs.
 DEVICE_FORCEINLINE void ld_cg_v4(const bf *p, bf &a, bf &b, bf &c, bf &d) {
-  u32 a_v, b_v, c_v, d_v;
-  asm volatile("ld.global.cg.v4.u32 {%0, %1, %2, %3}, [%4];" : "=r"(a_v), "=r"(b_v), "=r"(c_v), "=r"(d_v) : "l"(p));
-  a = bf::from_reduced_raw_repr(a_v);
-  b = bf::from_reduced_raw_repr(b_v);
-  c = bf::from_reduced_raw_repr(c_v);
-  d = bf::from_reduced_raw_repr(d_v);
+  const bf4_wide r = mem::load_cg(reinterpret_cast<const bf4_wide *>(p));
+  a = r.v[0];
+  b = r.v[1];
+  c = r.v[2];
+  d = r.v[3];
 }
 DEVICE_FORCEINLINE void st_cg_v4(bf *p, bf a, bf b, bf c, bf d) {
-  asm volatile("st.global.cg.v4.u32 [%0], {%1, %2, %3, %4};" ::"l"(p), "r"(bf::into_raw_u32(a)), "r"(bf::into_raw_u32(b)), "r"(bf::into_raw_u32(c)),
-               "r"(bf::into_raw_u32(d)));
+  const bf4_wide w{{a, b, c, d}};
+  mem::store_cg(reinterpret_cast<bf4_wide *>(p), w);
 }
 
-// Vec8 cg load — single LDG.E.128 fused with another, or LDG.E.ENL2.256 on
-// sm_100+. Matches the st.global.cg.v8.b32 store side.
-// Pre-sm_100 has no 256-bit access: fall back to two 16 B-aligned v4 loads with
-// the same cache modifier (same bytes, same order — the SASS fuser may still
-// pair them). Guard mirrors gpu_core's AB_PTX_LD_V8 in primitives/ptx.cuh.
 DEVICE_FORCEINLINE void ld_cg_v8(const bf *p, bf &a0, bf &a1, bf &a2, bf &a3, bf &a4, bf &a5, bf &a6, bf &a7) {
-  u32 v0, v1, v2, v3, v4, v5, v6, v7;
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
-  asm volatile("ld.global.cg.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
-               : "=r"(v0), "=r"(v1), "=r"(v2), "=r"(v3), "=r"(v4), "=r"(v5), "=r"(v6), "=r"(v7)
-               : "l"(p));
-#else
-  asm volatile("ld.global.cg.v4.u32 {%0, %1, %2, %3}, [%4];" : "=r"(v0), "=r"(v1), "=r"(v2), "=r"(v3) : "l"(p));
-  asm volatile("ld.global.cg.v4.u32 {%0, %1, %2, %3}, [%4];" : "=r"(v4), "=r"(v5), "=r"(v6), "=r"(v7) : "l"(p + 4));
-#endif
-  a0 = bf::from_reduced_raw_repr(v0);
-  a1 = bf::from_reduced_raw_repr(v1);
-  a2 = bf::from_reduced_raw_repr(v2);
-  a3 = bf::from_reduced_raw_repr(v3);
-  a4 = bf::from_reduced_raw_repr(v4);
-  a5 = bf::from_reduced_raw_repr(v5);
-  a6 = bf::from_reduced_raw_repr(v6);
-  a7 = bf::from_reduced_raw_repr(v7);
+  const bf8_wide r = mem::load_cg(reinterpret_cast<const bf8_wide *>(p));
+  a0 = r.v[0];
+  a1 = r.v[1];
+  a2 = r.v[2];
+  a3 = r.v[3];
+  a4 = r.v[4];
+  a5 = r.v[5];
+  a6 = r.v[6];
+  a7 = r.v[7];
 }
 
-// Cached-all load (constant-uniform): used for twiddle table reads.
+// `ca`: cached-all, for the uniform twiddle-table reads.
 DEVICE_FORCEINLINE bf ld_ca(const bf *p) { return bf::from_reduced_raw_repr(ptx::ld_ca(reinterpret_cast<const u32 *>(p))); }
 
-// Vec4 cached-all load — 4 contiguous BFs in one LDG.E.CA.128 → fully
-// coalesced when the warp's threads access stride-VPT addresses. Caller must
-// 16 B-align p.
+// Caller must 16 B-align p.
 DEVICE_FORCEINLINE void ld_ca_v4(const bf *p, bf &a, bf &b, bf &c, bf &d) {
-  u32 a_v, b_v, c_v, d_v;
-  asm volatile("ld.global.ca.v4.u32 {%0, %1, %2, %3}, [%4];" : "=r"(a_v), "=r"(b_v), "=r"(c_v), "=r"(d_v) : "l"(p));
-  a = bf::from_reduced_raw_repr(a_v);
-  b = bf::from_reduced_raw_repr(b_v);
-  c = bf::from_reduced_raw_repr(c_v);
-  d = bf::from_reduced_raw_repr(d_v);
+  const bf4_wide r = mem::load_ca(reinterpret_cast<const bf4_wide *>(p));
+  a = r.v[0];
+  b = r.v[1];
+  c = r.v[2];
+  d = r.v[3];
 }
 
-// `cs`: cache streaming (likely evict-first hint). Used for write-once output
-// where L2 caching is wasted (output > L2 capacity).
+// `cs`: cache-streaming (evict-first). For write-once output exceeding L2.
 DEVICE_FORCEINLINE void st_cs_v4(bf *p, bf a, bf b, bf c, bf d) {
-  asm volatile("st.global.cs.v4.u32 [%0], {%1, %2, %3, %4};" ::"l"(p), "r"(bf::into_raw_u32(a)), "r"(bf::into_raw_u32(b)), "r"(bf::into_raw_u32(c)),
-               "r"(bf::into_raw_u32(d)));
+  const bf4_wide w{{a, b, c, d}};
+  mem::store_cs(reinterpret_cast<bf4_wide *>(p), w);
 }
 
-// `wb`: write-back, default global store behavior. Caches in L2 (and L1 if available).
+// `wb`: write-back, the default store behavior.
 DEVICE_FORCEINLINE void st_wb_v4(bf *p, bf a, bf b, bf c, bf d) {
-  asm volatile("st.global.wb.v4.u32 [%0], {%1, %2, %3, %4};" ::"l"(p), "r"(bf::into_raw_u32(a)), "r"(bf::into_raw_u32(b)), "r"(bf::into_raw_u32(c)),
-               "r"(bf::into_raw_u32(d)));
+  const bf4_wide w{{a, b, c, d}};
+  mem::store_wb(reinterpret_cast<bf4_wide *>(p), w);
 }
 
-// `wt`: write-through. Forces every store to commit to L2 AND DRAM. Used by
-// the benchmark harness to measure honest DRAM throughput — `cs` writes get
-// caught in L2 / write-combining buffers and the kernel finishes before the
-// data actually reaches DRAM, so cs-based timing reports L2 throughput. With
-// wt, per-launch time is bounded by DRAM bandwidth.
+// `wt`: write-through, commits to DRAM. For the bench harness only: `cs` writes
+// can still sit in L2, so cs-based timing reports L2 rather than DRAM throughput.
 DEVICE_FORCEINLINE void st_wt_v4(bf *p, bf a, bf b, bf c, bf d) {
-  asm volatile("st.global.wt.v4.u32 [%0], {%1, %2, %3, %4};" ::"l"(p), "r"(bf::into_raw_u32(a)), "r"(bf::into_raw_u32(b)), "r"(bf::into_raw_u32(c)),
-               "r"(bf::into_raw_u32(d)));
+  const bf4_wide w{{a, b, c, d}};
+  mem::store_wt(reinterpret_cast<bf4_wide *>(p), w);
 }
 DEVICE_FORCEINLINE void st_wt_v2(bf *p, bf a, bf b) {
-  asm volatile("st.global.wt.v2.u32 [%0], {%1, %2};" ::"l"(p), "r"(bf::into_raw_u32(a)), "r"(bf::into_raw_u32(b)));
+  const bf2_wide w{{a, b}};
+  mem::store_wt(reinterpret_cast<bf2_wide *>(p), w);
 }
-// 256-bit form on sm_100+; two v4 wt stores below that (see ld_cg_v8).
 DEVICE_FORCEINLINE void st_v8_aligned_wt(bf *p, bf a0, bf a1, bf a2, bf a3, bf a4, bf a5, bf a6, bf a7) {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
-  asm volatile("st.global.wt.v8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};" ::"l"(p), "r"(bf::into_raw_u32(a0)), "r"(bf::into_raw_u32(a1)),
-               "r"(bf::into_raw_u32(a2)), "r"(bf::into_raw_u32(a3)), "r"(bf::into_raw_u32(a4)), "r"(bf::into_raw_u32(a5)), "r"(bf::into_raw_u32(a6)),
-               "r"(bf::into_raw_u32(a7)));
-#else
-  st_wt_v4(p, a0, a1, a2, a3);
-  st_wt_v4(p + 4, a4, a5, a6, a7);
-#endif
+  const bf8_wide w{{a0, a1, a2, a3, a4, a5, a6, a7}};
+  mem::store_wt(reinterpret_cast<bf8_wide *>(p), w);
 }
 
-// 32-byte aligned packed-8 struct. When both source struct and destination
-// pointer are 32B-aligned, the SASS compiler fuses two v4 stores into a single
-// STG.E.ENL2.256 instruction (vec8 store). Target ≈97.5% DRAM SOL vs 96.7% for
-// vec4 stores on Blackwell.
-struct __align__(32) bf8_wide {
-  uint4 lo;
-  uint4 hi;
-};
-
+// Packed stores at the default `wb` cache op, and their `cs` counterparts.
 DEVICE_FORCEINLINE void st_v8_aligned(bf *p, bf a0, bf a1, bf a2, bf a3, bf a4, bf a5, bf a6, bf a7) {
-  bf8_wide packed;
-  packed.lo = make_uint4(bf::into_raw_u32(a0), bf::into_raw_u32(a1), bf::into_raw_u32(a2), bf::into_raw_u32(a3));
-  packed.hi = make_uint4(bf::into_raw_u32(a4), bf::into_raw_u32(a5), bf::into_raw_u32(a6), bf::into_raw_u32(a7));
-  *reinterpret_cast<bf8_wide *>(p) = packed;
+  const bf8_wide w{{a0, a1, a2, a3, a4, a5, a6, a7}};
+  mem::store_wb(reinterpret_cast<bf8_wide *>(p), w);
 }
 
-// Same packed-8 store but with the `cs` (cache-streaming, evict-first) hint —
-// matches production's `st.global.cs` modifier so writes drain past L2 quickly
-// and don't pollute the cache with output the kernel will not read back.
-// PTX 8.8 `st.global.cs.v8.b32` → SASS `STG.E.EF.ENL2.256` on sm_100+ (fused
-// 256-bit). Pre-sm_100 falls back to two v4 cs stores (see ld_cg_v8).
 DEVICE_FORCEINLINE void st_v8_aligned_cs(bf *p, bf a0, bf a1, bf a2, bf a3, bf a4, bf a5, bf a6, bf a7) {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
-  asm volatile("st.global.cs.v8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};" ::"l"(p), "r"(bf::into_raw_u32(a0)), "r"(bf::into_raw_u32(a1)),
-               "r"(bf::into_raw_u32(a2)), "r"(bf::into_raw_u32(a3)), "r"(bf::into_raw_u32(a4)), "r"(bf::into_raw_u32(a5)), "r"(bf::into_raw_u32(a6)),
-               "r"(bf::into_raw_u32(a7)));
-#else
-  st_cs_v4(p, a0, a1, a2, a3);
-  st_cs_v4(p + 4, a4, a5, a6, a7);
-#endif
+  const bf8_wide w{{a0, a1, a2, a3, a4, a5, a6, a7}};
+  mem::store_cs(reinterpret_cast<bf8_wide *>(p), w);
 }
-
-// 16-byte aligned packed-4 struct → single STG.E.128 on all archs. Used by the
-// VPT=4 kernel variant.
-struct __align__(16) bf4_wide {
-  uint4 v;
-};
 
 DEVICE_FORCEINLINE void st_v4_aligned(bf *p, bf a0, bf a1, bf a2, bf a3) {
-  bf4_wide packed;
-  packed.v = make_uint4(bf::into_raw_u32(a0), bf::into_raw_u32(a1), bf::into_raw_u32(a2), bf::into_raw_u32(a3));
-  *reinterpret_cast<bf4_wide *>(p) = packed;
+  const bf4_wide w{{a0, a1, a2, a3}};
+  mem::store_wb(reinterpret_cast<bf4_wide *>(p), w);
 }
 
 DEVICE_FORCEINLINE void st_v4_aligned_cs(bf *p, bf a0, bf a1, bf a2, bf a3) { st_cs_v4(p, a0, a1, a2, a3); }
 
-// Vec2 smem load — 8 bytes (2 bf) per thread in one LDS instruction.
+// Shared space: memory.cuh's ld_single/st_single are global-only, so these stay
+// local. Well defined because every `extern __shared__` site declares
+// __align__(16).
 DEVICE_FORCEINLINE void ld_shared_v2(const bf *p, bf &a, bf &b) {
-  u32 av, bv;
-  asm volatile("ld.shared.v2.u32 {%0, %1}, [%2];" : "=r"(av), "=r"(bv) : "l"(p));
-  a = bf::from_reduced_raw_repr(av);
-  b = bf::from_reduced_raw_repr(bv);
+  const bf2_wide r = *reinterpret_cast<const bf2_wide *>(p);
+  a = r.v[0];
+  b = r.v[1];
 }
 
-// Vec4 smem load/store (used for per-thread monomial state).
 DEVICE_FORCEINLINE void ld_shared_v4(const bf *p, bf &a, bf &b, bf &c, bf &d) {
-  u32 av, bv, cv, dv;
-  asm volatile("ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];" : "=r"(av), "=r"(bv), "=r"(cv), "=r"(dv) : "l"(p));
-  a = bf::from_reduced_raw_repr(av);
-  b = bf::from_reduced_raw_repr(bv);
-  c = bf::from_reduced_raw_repr(cv);
-  d = bf::from_reduced_raw_repr(dv);
+  const bf4_wide r = *reinterpret_cast<const bf4_wide *>(p);
+  a = r.v[0];
+  b = r.v[1];
+  c = r.v[2];
+  d = r.v[3];
 }
-DEVICE_FORCEINLINE void st_shared_v4(bf *p, bf a, bf b, bf c, bf d) {
-  asm volatile("st.shared.v4.u32 [%0], {%1, %2, %3, %4};" ::"l"(p), "r"(bf::into_raw_u32(a)), "r"(bf::into_raw_u32(b)), "r"(bf::into_raw_u32(c)),
-               "r"(bf::into_raw_u32(d)));
-}
-// Vec2 smem store — 8 bytes (2 bf) per thread in one STS instruction.
-DEVICE_FORCEINLINE void st_shared_v2(bf *p, bf a, bf b) {
-  asm volatile("st.shared.v2.u32 [%0], {%1, %2};" ::"l"(p), "r"(bf::into_raw_u32(a)), "r"(bf::into_raw_u32(b)));
-}
+DEVICE_FORCEINLINE void st_shared_v4(bf *p, bf a, bf b, bf c, bf d) { *reinterpret_cast<bf4_wide *>(p) = bf4_wide{{a, b, c, d}}; }
+DEVICE_FORCEINLINE void st_shared_v2(bf *p, bf a, bf b) { *reinterpret_cast<bf2_wide *>(p) = bf2_wide{{a, b}}; }
 
-// Column-major matrix getter / setter, mirroring gpu_core's matrix_accessor.
-// stride = bytes-per-column / sizeof(bf) = row count.
-struct bf_matrix_getter {
-  const bf *ptr;
-  size_t stride;
-  HOST_DEVICE_FORCEINLINE bf_matrix_getter(const bf *p, size_t s) : ptr(p), stride(s) {}
-  DEVICE_FORCEINLINE void add_col(unsigned c) { ptr += c * stride; }
-  DEVICE_FORCEINLINE void add_row(unsigned r) { ptr += r; }
-  DEVICE_FORCEINLINE bf get() const { return ld_cg(ptr); }
-  DEVICE_FORCEINLINE bf get_at_row(unsigned r) const { return ld_cg(ptr + r); }
-};
-
-struct bf_matrix_setter {
-  bf *ptr;
-  size_t stride;
-  HOST_DEVICE_FORCEINLINE bf_matrix_setter(bf *p, size_t s) : ptr(p), stride(s) {}
-  DEVICE_FORCEINLINE void add_col(unsigned c) { ptr += c * stride; }
-  DEVICE_FORCEINLINE void add_row(unsigned r) { ptr += r; }
-  DEVICE_FORCEINLINE void set(bf v) const { st_cg(ptr, v); }
-  DEVICE_FORCEINLINE void set_at_row(unsigned r, bf v) const { st_cg(ptr + r, v); }
-};
-
-// In-crate name kept to avoid call-site churn; delegates to gpu_core's guarded helper (common.cuh).
 DEVICE_FORCEINLINE unsigned bitrev_u32(unsigned x, unsigned log_n) { return ::bitreverse_low_bits(x, log_n); }
 
 // =========================================================================

--- a/gpu/ntt/native/dit_memory.cuh
+++ b/gpu/ntt/native/dit_memory.cuh
@@ -41,11 +41,19 @@ DEVICE_FORCEINLINE void st_cg_v4(bf *p, bf a, bf b, bf c, bf d) {
 
 // Vec8 cg load — single LDG.E.128 fused with another, or LDG.E.ENL2.256 on
 // sm_100+. Matches the st.global.cg.v8.b32 store side.
+// Pre-sm_100 has no 256-bit access: fall back to two 16 B-aligned v4 loads with
+// the same cache modifier (same bytes, same order — the SASS fuser may still
+// pair them). Guard mirrors gpu_core's AB_PTX_LD_V8 in primitives/ptx.cuh.
 DEVICE_FORCEINLINE void ld_cg_v8(const bf *p, bf &a0, bf &a1, bf &a2, bf &a3, bf &a4, bf &a5, bf &a6, bf &a7) {
   u32 v0, v1, v2, v3, v4, v5, v6, v7;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
   asm volatile("ld.global.cg.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
                : "=r"(v0), "=r"(v1), "=r"(v2), "=r"(v3), "=r"(v4), "=r"(v5), "=r"(v6), "=r"(v7)
                : "l"(p));
+#else
+  asm volatile("ld.global.cg.v4.u32 {%0, %1, %2, %3}, [%4];" : "=r"(v0), "=r"(v1), "=r"(v2), "=r"(v3) : "l"(p));
+  asm volatile("ld.global.cg.v4.u32 {%0, %1, %2, %3}, [%4];" : "=r"(v4), "=r"(v5), "=r"(v6), "=r"(v7) : "l"(p + 4));
+#endif
   a0 = bf::from_reduced_raw_repr(v0);
   a1 = bf::from_reduced_raw_repr(v1);
   a2 = bf::from_reduced_raw_repr(v2);
@@ -96,10 +104,16 @@ DEVICE_FORCEINLINE void st_wt_v4(bf *p, bf a, bf b, bf c, bf d) {
 DEVICE_FORCEINLINE void st_wt_v2(bf *p, bf a, bf b) {
   asm volatile("st.global.wt.v2.u32 [%0], {%1, %2};" ::"l"(p), "r"(bf::into_raw_u32(a)), "r"(bf::into_raw_u32(b)));
 }
+// 256-bit form on sm_100+; two v4 wt stores below that (see ld_cg_v8).
 DEVICE_FORCEINLINE void st_v8_aligned_wt(bf *p, bf a0, bf a1, bf a2, bf a3, bf a4, bf a5, bf a6, bf a7) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
   asm volatile("st.global.wt.v8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};" ::"l"(p), "r"(bf::into_raw_u32(a0)), "r"(bf::into_raw_u32(a1)),
                "r"(bf::into_raw_u32(a2)), "r"(bf::into_raw_u32(a3)), "r"(bf::into_raw_u32(a4)), "r"(bf::into_raw_u32(a5)), "r"(bf::into_raw_u32(a6)),
                "r"(bf::into_raw_u32(a7)));
+#else
+  st_wt_v4(p, a0, a1, a2, a3);
+  st_wt_v4(p + 4, a4, a5, a6, a7);
+#endif
 }
 
 // 32-byte aligned packed-8 struct. When both source struct and destination
@@ -122,11 +136,16 @@ DEVICE_FORCEINLINE void st_v8_aligned(bf *p, bf a0, bf a1, bf a2, bf a3, bf a4, 
 // matches production's `st.global.cs` modifier so writes drain past L2 quickly
 // and don't pollute the cache with output the kernel will not read back.
 // PTX 8.8 `st.global.cs.v8.b32` → SASS `STG.E.EF.ENL2.256` on sm_100+ (fused
-// 256-bit). Targets sm_100+ only.
+// 256-bit). Pre-sm_100 falls back to two v4 cs stores (see ld_cg_v8).
 DEVICE_FORCEINLINE void st_v8_aligned_cs(bf *p, bf a0, bf a1, bf a2, bf a3, bf a4, bf a5, bf a6, bf a7) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
   asm volatile("st.global.cs.v8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};" ::"l"(p), "r"(bf::into_raw_u32(a0)), "r"(bf::into_raw_u32(a1)),
                "r"(bf::into_raw_u32(a2)), "r"(bf::into_raw_u32(a3)), "r"(bf::into_raw_u32(a4)), "r"(bf::into_raw_u32(a5)), "r"(bf::into_raw_u32(a6)),
                "r"(bf::into_raw_u32(a7)));
+#else
+  st_cs_v4(p, a0, a1, a2, a3);
+  st_cs_v4(p + 4, a4, a5, a6, a7);
+#endif
 }
 
 // 16-byte aligned packed-4 struct → single STG.E.128 on all archs. Used by the

--- a/gpu/ntt/native/whir_leaves.cu
+++ b/gpu/ntt/native/whir_leaves.cu
@@ -35,7 +35,7 @@ EXTERN __launch_bounds__(512, 2) __global__
   src.add_row(base_lane_in_coset);
   dst.add_row(base_lane_in_coset);
 
-  extern __shared__ uint8_t smem[];
+  extern __shared__ __align__(16) uint8_t smem[];
 
   const unsigned leaves_per_coset = 1 << log_leaves_per_coset;
   const unsigned initial_slot_in_leaf = threadIdx.y;


### PR DESCRIPTION
## What ❔

Three commits in `gpu_ntt`'s native code:

1. Guard the 256-bit v8 PTX in `dit_memory.cuh` behind `__CUDA_ARCH__ >= 1000`, with a two-v4 fallback below it.
2. Declare `__align__(16)` on the four dynamic shared-memory bases in `dit_kernels.cuh`, `bench/dit_bench_kernels.cu` and `whir_leaves.cu`.
3. Route all DIT memory access through `gpu_core`'s `memory.cuh` `load_*`/`store_*` wrappers, deleting every inline-asm site and the unused local `bf_matrix_getter`/`bf_matrix_setter`.

`primitives/ptx.cuh` is now the only file under `gpu/` containing raw `asm volatile`.

## Why ❔

(1) unbreaks the build for every pre-Blackwell arch. `dit_memory.cuh` hand-rolled v8 PTX with no arch guard, so ptxas rejected 27 sites in the 11 production `LOG_VPT=3` DIT kernels at CI's `CUDAARCHS="80;89;90"` (A100/L4/H100). Latent since #335 — local builds default to `CMAKE_CUDA_ARCHITECTURES native`, so a Blackwell dev box never hits it.

(2) fixes alignment UB. Production compiles with `CUDA_SEPARABLE_COMPILATION ON`, and under `-rdc=true` nvcc emits the declared element alignment rather than a conservative 16, so `extern __shared__ bf smem[]` backed 8/16-byte vector accesses at `.align 4`. `whir_leaves.cu` was worse: `uint8_t smem[]` at `.align 1` reinterpreted as the `__align__(16)` `e4`. Both worked only because the real shared base happens to be aligned. A sweep of all 65 native TUs (237 shared-using functions, checked per symbol) found no other cases.

(3) removes the duplication that caused (1): the guard now exists in exactly one place instead of two, one of which was missing it. It also drops an address-space round trip — the old asm passed shared pointers through the 64-bit generic `"l"` constraint, so `cvta.shared.u64` across the 24 DIT kernels goes 54 → 0. No kernel regresses in SASS instruction count (sm_80 21 of 24 shorter, 3 equal; sm_120 18 shorter, 6 equal); static counts only, not timing.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.