### PR TITLE
fix(circuit_prover): migrate tests to backend API

### DIFF
--- a/gpu/circuit_prover/src/tests/commit_memory.rs
+++ b/gpu/circuit_prover/src/tests/commit_memory.rs
@@ -352,7 +352,8 @@ fn assert_non_memory_commit_memory_matches_cpu_for_test<const FAMILY_IDX: u8>(
         .iter()
         .map(|col| &col[..])
         .collect();
-    let cpu_mem_oracle = commit_trace_part::<BF, DefaultTreeConstructor>(
+    let cpu_mem_oracle = commit_trace_part::<BF, BF, DefaultTreeConstructor>(
+        &NaiveBackend,
         &mem_inputs,
         &twiddles,
         whir_schedule.base_lde_factor,
@@ -362,7 +363,7 @@ fn assert_non_memory_commit_memory_matches_cpu_for_test<const FAMILY_IDX: u8>(
         &worker,
     );
     let mut cpu_transcript = vec![];
-    let cpu_cap: MerkleTreeCapVarLength = cpu_mem_oracle.tree.get_cap();
+    let cpu_cap: MerkleTreeCapVarLength = cpu_mem_oracle.get_cap();
     flatten_merkle_caps_iter_into(Some(cpu_cap).into_iter(), &mut cpu_transcript);
     let device_block_size = 1usize << DEVICE_ALLOCATOR_BLOCK_LOG_SIZE;
     let max_device_allocation_blocks_count = DEVICE_ALLOCATOR_ARENA_BYTES / device_block_size;
@@ -545,7 +546,8 @@ fn assert_memory_commit_memory_matches_cpu_for_test<const FAMILY_IDX: u8>(
         .iter()
         .map(|col| &col[..])
         .collect();
-    let cpu_mem_oracle = commit_trace_part::<BF, DefaultTreeConstructor>(
+    let cpu_mem_oracle = commit_trace_part::<BF, BF, DefaultTreeConstructor>(
+        &NaiveBackend,
         &mem_inputs,
         &twiddles,
         whir_schedule.base_lde_factor,
@@ -555,7 +557,7 @@ fn assert_memory_commit_memory_matches_cpu_for_test<const FAMILY_IDX: u8>(
         &worker,
     );
     let mut cpu_transcript = vec![];
-    let cpu_cap: MerkleTreeCapVarLength = cpu_mem_oracle.tree.get_cap();
+    let cpu_cap: MerkleTreeCapVarLength = cpu_mem_oracle.get_cap();
     flatten_merkle_caps_iter_into(Some(cpu_cap).into_iter(), &mut cpu_transcript);
     let device_block_size = 1usize << DEVICE_ALLOCATOR_BLOCK_LOG_SIZE;
     let max_device_allocation_blocks_count = DEVICE_ALLOCATOR_ARENA_BYTES / device_block_size;
@@ -644,7 +646,8 @@ fn assert_delegation_commit_memory_matches_cpu<W, O, F>(
         .iter()
         .map(|col| &col[..])
         .collect();
-    let cpu_mem_oracle = commit_trace_part::<BF, DefaultTreeConstructor>(
+    let cpu_mem_oracle = commit_trace_part::<BF, BF, DefaultTreeConstructor>(
+        &NaiveBackend,
         &mem_inputs,
         &twiddles,
         whir_schedule.base_lde_factor,
@@ -654,7 +657,7 @@ fn assert_delegation_commit_memory_matches_cpu<W, O, F>(
         &worker,
     );
     let mut cpu_transcript = vec![];
-    let cpu_cap: MerkleTreeCapVarLength = cpu_mem_oracle.tree.get_cap();
+    let cpu_cap: MerkleTreeCapVarLength = cpu_mem_oracle.get_cap();
     flatten_merkle_caps_iter_into(Some(cpu_cap).into_iter(), &mut cpu_transcript);
 
     let device_block_size = 1usize << DEVICE_ALLOCATOR_BLOCK_LOG_SIZE;

--- a/gpu/circuit_prover/src/tests/inits_and_teardowns.rs
+++ b/gpu/circuit_prover/src/tests/inits_and_teardowns.rs
@@ -317,7 +317,8 @@ pub(super) fn prepare_inits_and_teardowns_proof_fixture(
             .collect::<Vec<_>>()
     } else {
         let (mem_oracle, _wit_oracle) =
-            commit_separate_memory_and_witness_subtrees::<BF, DefaultTreeConstructor>(
+            commit_separate_memory_and_witness_subtrees::<BF, BF, DefaultTreeConstructor>(
+                &NaiveBackend,
                 &make_full_trace(),
                 &twiddles,
                 whir_schedule.base_lde_factor,
@@ -327,7 +328,7 @@ pub(super) fn prepare_inits_and_teardowns_proof_fixture(
                 &worker,
             );
         stage1_subcaps_from_cap(
-            &mem_oracle.tree.get_cap(),
+            &mem_oracle.get_cap(),
             whir_schedule.cap_size / whir_schedule.base_lde_factor,
         )
     };

--- a/gpu/circuit_prover/src/upstream.rs
+++ b/gpu/circuit_prover/src/upstream.rs
@@ -84,6 +84,8 @@ pub(crate) use field::{FieldExtension, PrimeField};
 #[cfg(test)]
 pub(crate) use prover::definitions::produce_initial_permutation_product_contribution;
 #[cfg(test)]
+pub(crate) use prover::gkr::prover::backend::NaiveBackend;
+#[cfg(test)]
 pub(crate) use prover::gkr::prover::prove_configured_with_gkr;
 #[cfg(test)]
 pub(crate) use prover::gkr::prover::setup::GKRSetup as CpuGKRSetup;


### PR DESCRIPTION
## What ❔

Migrate GPU circuit-prover reference tests to the backend-aware commitment API and base-oracle cap accessor.

## Why ❔

#379 changed the CPU commitment API, leaving the `gpu_circuit_prover` test target unable to compile.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated. (Not applicable.)
- [x] Code has been formatted.

## Testing

- Release `gpu_circuit_prover` test build
- All GPU-stack targets and security-100 feature path
- Memory commitment and inits-and-teardowns GPU parity tests
