### PR TITLE
perf(gkr): fuse forward reduction prefix

### DIFF
--- a/gpu/gkr/native/gkr/forward/fwd_vm.cu
+++ b/gpu/gkr/native/gkr/forward/fwd_vm.cu
@@ -381,15 +381,6 @@ DEVICE_FORCEINLINE void fused_reduction_pair(const fwd_vm_reduction_pair &pair, 
   }
 }
 
-DEVICE_FORCEINLINE void fused_reduction_prefix(const fwd_vm_desc &desc, e4 *cell_file) {
-  const u32 warp = threadIdx.x >> FWD_VM_WARP_SHIFT;
-  e4 *smem = cell_file + warp * FWD_VM_BUCKETS * FWD_VM_WARP_LANES;
-  if (warp < desc.reduction_pair_count)
-    fused_reduction_pair(desc.reduction_pairs[warp], smem);
-  if (warp + 4 < desc.reduction_pair_count)
-    fused_reduction_pair(desc.reduction_pairs[warp + 4], smem);
-}
-
 // minBlocks = the occupancy the static smem permits: SM shared capacity
 // (~100 KB) / per-block footprint (BUCKETS * 16 B * 128 threads + ~1 KB driver
 // overhead), clamped to the 12-block warp limit (4 warps/block). ptxas then
@@ -399,7 +390,12 @@ EXTERN __launch_bounds__(128, 11) __global__ void ab_gkr_fwd_vm_kernel(const __g
   vm_body(desc, fwd_vm_cells);
   // Each reduction warp reloads rows written by the whole CTA.
   __syncthreads();
-  fused_reduction_prefix(desc, fwd_vm_cells);
+  const u32 warp = threadIdx.x >> FWD_VM_WARP_SHIFT;
+  e4 *smem = fwd_vm_cells + warp * FWD_VM_BUCKETS * FWD_VM_WARP_LANES;
+  if (warp < desc.reduction_pair_count)
+    fused_reduction_pair(desc.reduction_pairs[warp], smem);
+  if (warp + 4 < desc.reduction_pair_count)
+    fused_reduction_pair(desc.reduction_pairs[warp + 4], smem);
 }
 
 } // namespace airbender::gkr

--- a/gpu/gkr/native/gkr/forward/fwd_vm.cu
+++ b/gpu/gkr/native/gkr/forward/fwd_vm.cu
@@ -2,6 +2,7 @@
 // each thread keeps one E4 accumulator whose first limb is the base-field view.
 
 #include "../eval_vm_exec.cuh"
+#include "../support/lookup_helpers.cuh"
 #include "fwd_vm.cuh"
 
 // Runtime-produced derived E4 values and the optional decoder fill.
@@ -319,6 +320,76 @@ DEVICE_FORCEINLINE void vm_body(const fwd_vm_desc &desc, e4 *cell_file) {
   }
 }
 
+DEVICE_FORCEINLINE void fused_reduction_round0(const fwd_vm_reduction_pair &pair, e4 *smem) {
+  constexpr u32 round_len = 64;
+  const u32 lane = threadIdx.x & FWD_VM_LANE_MASK;
+  const u32 block_input = blockIdx.x * 128;
+  const u32 block_output = blockIdx.x * round_len;
+
+#pragma unroll
+  for (u32 local = lane; local < round_len; local += FWD_VM_WARP_LANES) {
+    const u32 even = block_input + 2 * local;
+    const u32 odd = even + 1;
+    e4 out0;
+    e4 out1;
+    if (pair.kind == FWD_VM_REDUCTION_PAIR_PAIRWISE2) {
+      gkr_eval_product(load<e4, ld_modifier::ca>(pair.input[0], even), load<e4, ld_modifier::ca>(pair.input[0], odd), out0);
+      gkr_eval_product(load<e4, ld_modifier::ca>(pair.input[1], even), load<e4, ld_modifier::ca>(pair.input[1], odd), out1);
+    } else {
+      const e4 a = load<e4, ld_modifier::ca>(pair.input[0], even);
+      const e4 b = load<e4, ld_modifier::ca>(pair.input[1], even);
+      const e4 c = load<e4, ld_modifier::ca>(pair.input[0], odd);
+      const e4 d = load<e4, ld_modifier::ca>(pair.input[1], odd);
+      gkr_eval_lookup_pair(a, b, c, d, out0, out1);
+    }
+    smem[local] = out0;
+    smem[round_len + local] = out1;
+    store<e4, st_modifier::cs>(pair.round_outputs[0][0], out0, block_output + local);
+    store<e4, st_modifier::cs>(pair.round_outputs[0][1], out1, block_output + local);
+  }
+  // Round 1 reads values written by other lanes.
+  __syncwarp();
+}
+
+DEVICE_FORCEINLINE void fused_reduction_pair(const fwd_vm_reduction_pair &pair, e4 *smem) {
+  fused_reduction_round0(pair, smem);
+  const u32 lane = threadIdx.x & FWD_VM_LANE_MASK;
+
+#pragma unroll
+  for (u32 round = 1; round < FWD_VM_FUSED_REDUCTION_ROUNDS; round++) {
+    const u32 round_len = 64 >> round;
+    e4 out0;
+    e4 out1;
+    if (lane < round_len) {
+      if (pair.kind == FWD_VM_REDUCTION_PAIR_PAIRWISE2) {
+        gkr_eval_product(smem[2 * lane], smem[2 * lane + 1], out0);
+        gkr_eval_product(smem[64 + 2 * lane], smem[64 + 2 * lane + 1], out1);
+      } else {
+        gkr_eval_lookup_pair(smem[2 * lane], smem[64 + 2 * lane], smem[2 * lane + 1], smem[64 + 2 * lane + 1], out0, out1);
+      }
+    }
+    // Finish all reads before overwriting inputs, then publish writes before the next round.
+    __syncwarp();
+    if (lane < round_len) {
+      smem[lane] = out0;
+      smem[64 + lane] = out1;
+      const u32 output = blockIdx.x * round_len + lane;
+      store<e4, st_modifier::cs>(pair.round_outputs[round][0], out0, output);
+      store<e4, st_modifier::cs>(pair.round_outputs[round][1], out1, output);
+    }
+    __syncwarp();
+  }
+}
+
+DEVICE_FORCEINLINE void fused_reduction_prefix(const fwd_vm_desc &desc, e4 *cell_file) {
+  const u32 warp = threadIdx.x >> FWD_VM_WARP_SHIFT;
+  e4 *smem = cell_file + warp * FWD_VM_BUCKETS * FWD_VM_WARP_LANES;
+  if (warp < desc.reduction_pair_count)
+    fused_reduction_pair(desc.reduction_pairs[warp], smem);
+  if (warp + 4 < desc.reduction_pair_count)
+    fused_reduction_pair(desc.reduction_pairs[warp + 4], smem);
+}
+
 // minBlocks = the occupancy the static smem permits: SM shared capacity
 // (~100 KB) / per-block footprint (BUCKETS * 16 B * 128 threads + ~1 KB driver
 // overhead), clamped to the 12-block warp limit (4 warps/block). ptxas then
@@ -326,6 +397,9 @@ DEVICE_FORCEINLINE void vm_body(const fwd_vm_desc &desc, e4 *cell_file) {
 EXTERN __launch_bounds__(128, 11) __global__ void ab_gkr_fwd_vm_kernel(const __grid_constant__ fwd_vm_desc desc) {
   __shared__ e4 fwd_vm_cells[FWD_VM_BUCKETS * 128];
   vm_body(desc, fwd_vm_cells);
+  // Each reduction warp reloads rows written by the whole CTA.
+  __syncthreads();
+  fused_reduction_prefix(desc, fwd_vm_cells);
 }
 
 } // namespace airbender::gkr

--- a/gpu/gkr/native/gkr/forward/fwd_vm.cuh
+++ b/gpu/gkr/native/gkr/forward/fwd_vm.cuh
@@ -19,6 +19,10 @@ constexpr u32 FWD_VM_SOURCE_COLUMN_MASK = (1u << FWD_VM_SOURCE_COLUMN_BITS) - 1;
 constexpr u32 FWD_VM_LAYER_CAP = 8;
 constexpr u32 FWD_VM_DST_SLOT_COUNT = 16;
 constexpr u32 FWD_VM_MAPPING_ARENA_COUNT = 3;
+constexpr u32 FWD_VM_FUSED_REDUCTION_ROUNDS = 7;
+constexpr u32 FWD_VM_REDUCTION_PAIR_CAP = 5;
+constexpr u32 FWD_VM_REDUCTION_PAIR_PAIRWISE2 = 0;
+constexpr u32 FWD_VM_REDUCTION_PAIR_LOOKUP = 1;
 
 static_assert(FWD_VM_SOURCE_WINDOW_COUNT == 1u << FWD_VM_SOURCE_WINDOW_BITS, "source-window field width drift");
 static_assert(FWD_VM_DST_SLOT_COUNT == 1u << FWD_VM_DST_SLOT_BITS, "destination-slot field width drift");
@@ -44,6 +48,13 @@ struct fwd_vm_layer {
   u16 instruction_count;
 };
 
+struct fwd_vm_reduction_pair {
+  const e4 *input[2];
+  e4 *round_outputs[FWD_VM_FUSED_REDUCTION_ROUNDS][2];
+  u32 kind;
+  u32 reserved;
+};
+
 struct fwd_vm_desc {
   e4 arg_derived_e4[FWD_VM_ARG_DERIVED_E4_CAP];
   char *source_base[FWD_VM_SOURCE_WINDOW_COUNT];
@@ -59,13 +70,21 @@ struct fwd_vm_desc {
   u32 count;
   u32 layer_count;
   fwd_vm_layer layers[FWD_VM_LAYER_CAP];
+  u32 reduction_pair_count;
+  fwd_vm_reduction_pair reduction_pairs[FWD_VM_REDUCTION_PAIR_CAP];
   u16 program[FWD_VM_PROGRAM_CAP];
 };
 
 static_assert(sizeof(fwd_vm_layer) == 4, "fwd_vm_layer ABI size drift");
-static_assert(sizeof(fwd_vm_desc) == 26976, "fwd_vm_desc ABI size drift");
+static_assert(sizeof(fwd_vm_reduction_pair) == 136, "fwd_vm_reduction_pair ABI size drift");
+static_assert(alignof(fwd_vm_reduction_pair) == 8, "fwd_vm_reduction_pair ABI alignment drift");
+static_assert(__builtin_offsetof(fwd_vm_reduction_pair, round_outputs) == 16, "fwd_vm_reduction_pair output offset drift");
+static_assert(__builtin_offsetof(fwd_vm_reduction_pair, kind) == 128, "fwd_vm_reduction_pair kind offset drift");
+static_assert(sizeof(fwd_vm_desc) == 27664, "fwd_vm_desc ABI size drift");
 static_assert(sizeof(fwd_vm_desc) <= 32764, "fwd_vm_desc exceeds the __grid_constant__ parameter limit");
 static_assert(alignof(fwd_vm_desc) == 16, "fwd_vm_desc alignment drift");
-static_assert(__builtin_offsetof(fwd_vm_desc, program) == 2396, "fwd_vm_desc program offset drift");
+static_assert(__builtin_offsetof(fwd_vm_desc, reduction_pair_count) == 2396, "fwd_vm_desc reduction count offset drift");
+static_assert(__builtin_offsetof(fwd_vm_desc, reduction_pairs) == 2400, "fwd_vm_desc reduction pairs offset drift");
+static_assert(__builtin_offsetof(fwd_vm_desc, program) == 3080, "fwd_vm_desc program offset drift");
 
 } // namespace airbender::gkr

--- a/gpu/gkr/src/backward/main_layer/extras.rs
+++ b/gpu/gkr/src/backward/main_layer/extras.rs
@@ -206,7 +206,7 @@ pub(crate) fn schedule_main_layer_extras_eval(
     })
 }
 
-/// Structural variant of [`schedule_dimension_reduction_forward`]'s
+/// Structural variant of `prepare_dimension_reduction_forward`'s
 /// `dimension_reduction_description` output: replicates the address-only
 /// portion of the per-round lowering in
 /// `gpu/gkr/src/forward/dimension_reducing.rs`'s

--- a/gpu/gkr/src/forward/dimension_reducing.rs
+++ b/gpu/gkr/src/forward/dimension_reducing.rs
@@ -32,59 +32,55 @@ pub(super) type DimensionReductionForwardResult = (
     BTreeMap<usize, BTreeMap<OutputType, DimensionReducingInputOutput>>,
 );
 
-pub(super) fn schedule_dimension_reduction_forward<E>(
+pub(super) struct PreparedDimensionReductionForward<E> {
+    pub(super) initial_trace_log_2: u32,
+    pub(super) total_rounds: u32,
+    pub(super) final_layer_idx: usize,
+    pub(super) dimension_reduction_description:
+        BTreeMap<usize, BTreeMap<OutputType, DimensionReducingInputOutput>>,
+    pub(super) slot_initial_inputs: Vec<LoweredSlotInitialInput<E>>,
+    pub(super) slot_output_types: Vec<OutputType>,
+    pub(super) per_round_slot_outputs: Vec<Vec<LoweredSlotOutput<E>>>,
+}
+
+impl<E> PreparedDimensionReductionForward<E> {
+    pub(super) fn into_result(self) -> DimensionReductionForwardResult {
+        (self.final_layer_idx, self.dimension_reduction_description)
+    }
+}
+
+pub(super) fn prepare_dimension_reduction_forward<E>(
     storage: &mut GpuGKRStorage<BF, E>,
     initial_layer_idx: usize,
     initial_output_map: &BTreeMap<OutputType, Vec<GKRAddress>>,
     initial_trace_log_2: u32,
     final_trace_log_2: u32,
     output_evaluations_slab: Option<&ForwardOutputSlabTarget<E>>,
-    tracing_ranges: &mut Vec<Range>,
     context: &ProverContext,
-) -> CudaResult<DimensionReductionForwardResult>
+) -> CudaResult<PreparedDimensionReductionForward<E>>
 where
-    E: FieldExtension<BF> + Field + SetByRef + SetByVal,
-    E: crate::ForwardKernels,
-    Add: BinaryOp<E, E, E>,
-    Add: BinaryOp<BF, E, E>,
-    Add: BinaryOp<E, BF, E>,
-    Mul: BinaryOp<E, E, E>,
-    Mul: BinaryOp<BF, E, E>,
-    Mul: BinaryOp<E, BF, E>,
-    Sub: BinaryOp<E, E, E>,
-    Sub: BinaryOp<E, BF, E>,
-    Sub: BinaryOp<BF, BF, BF>,
+    E: FieldExtension<BF> + Field + 'static,
 {
-    let mut dimension_reduction_description = BTreeMap::new();
-    let mut current_layer_idx = initial_layer_idx;
-    let stream = context.get_exec_stream();
     let total_rounds = initial_trace_log_2.saturating_sub(final_trace_log_2);
-    if total_rounds == 0 {
-        return Ok((current_layer_idx, dimension_reduction_description));
-    }
-
-    // Phase 1: lower + commit every round sequentially so subsequent rounds can resolve inputs
-    // from storage. Collect per-round per-slot output pointers for the later tower assembly.
-    let mut per_round_slot_outputs: Vec<Vec<LoweredSlotOutput<E>>> =
-        Vec::with_capacity(total_rounds as usize);
-    let mut slot_initial_inputs: Option<Vec<LoweredSlotInitialInput<E>>> = None;
-    let mut slot_output_types: Option<Vec<OutputType>> = None;
+    let mut dimension_reduction_description = BTreeMap::new();
+    let mut per_round_slot_outputs = Vec::with_capacity(total_rounds as usize);
+    let mut slot_initial_inputs = None;
+    let mut slot_output_types = None;
+    let mut current_layer_idx = initial_layer_idx;
 
     for round_idx in 0..total_rounds {
         let input_size_log_2 = initial_trace_log_2 - round_idx;
         let output_trace_len = 1usize << (input_size_log_2 - 1);
         let is_final_round = round_idx + 1 == total_rounds;
-
-        let layer_inputs = if current_layer_idx != initial_layer_idx {
+        let layer_inputs = if current_layer_idx == initial_layer_idx {
+            initial_output_map.clone()
+        } else {
             let previous: &BTreeMap<OutputType, DimensionReducingInputOutput> =
                 dimension_reduction_description
                     .get(&(current_layer_idx - 1))
                     .expect("dimension reduction input layer must exist");
-            BTreeMap::from_iter(previous.iter().map(|(k, v)| (*k, v.output.clone())))
-        } else {
-            initial_output_map.clone()
+            BTreeMap::from_iter(previous.iter().map(|(kind, io)| (*kind, io.output.clone())))
         };
-
         let lowered = lower_dimension_reducing_forward_round(
             &layer_inputs,
             current_layer_idx,
@@ -103,7 +99,6 @@ where
             slot_output_types = Some(lowered.slot_output_types.clone());
         }
         per_round_slot_outputs.push(lowered.slot_outputs.clone());
-
         for (address, poly) in lowered.computed_extension_outputs {
             storage.insert_extension_at_layer(current_layer_idx + 1, address, poly);
         }
@@ -111,78 +106,100 @@ where
         current_layer_idx += 1;
     }
 
-    // Phase 2: slot-major dispatch, all launches on exec_stream. Each slot's full reduction
-    // chain (every tower chunk) runs contiguously before the next slot starts. One NVTX range
-    // per OutputType wraps all slots belonging to that type — PermutationProduct covers both
-    // read_set and write_set chains; each lookup type covers its single (num, den) chain.
-    let slot_initial_inputs =
-        slot_initial_inputs.expect("non-zero rounds implies we captured initial inputs");
-    let slot_output_types =
-        slot_output_types.expect("non-zero rounds implies we captured slot output types");
-    let slot_count = slot_initial_inputs.len();
-    let log_block = GKR_DIM_REDUCING_FORWARD_TOWER_LOG_BLOCK;
+    Ok(PreparedDimensionReductionForward {
+        initial_trace_log_2,
+        total_rounds,
+        final_layer_idx: if total_rounds == 0 {
+            initial_layer_idx
+        } else {
+            current_layer_idx - 1
+        },
+        dimension_reduction_description,
+        slot_initial_inputs: slot_initial_inputs.unwrap_or_default(),
+        slot_output_types: slot_output_types.unwrap_or_default(),
+        per_round_slot_outputs,
+    })
+}
 
+pub(super) fn schedule_prepared_dimension_reduction_forward<E>(
+    prepared: &PreparedDimensionReductionForward<E>,
+    start_round: u32,
+    tracing_ranges: &mut Vec<Range>,
+    context: &ProverContext,
+) -> CudaResult<()>
+where
+    E: crate::ForwardKernels,
+{
+    assert!(start_round <= prepared.total_rounds);
+    if start_round == prepared.total_rounds {
+        return Ok(());
+    }
+
+    let stream = context.get_exec_stream();
+    let slot_count = prepared.slot_initial_inputs.len();
+    assert_eq!(prepared.slot_output_types.len(), slot_count);
     let mut slot_idx = 0usize;
     while slot_idx < slot_count {
-        let range_type = slot_output_types[slot_idx];
-        let range_end = slot_output_types[slot_idx..]
+        let range_type = prepared.slot_output_types[slot_idx];
+        let range_end = prepared.slot_output_types[slot_idx..]
             .iter()
-            .position(|t| *t != range_type)
+            .position(|kind| *kind != range_type)
             .map(|offset| slot_idx + offset)
             .unwrap_or(slot_count);
-
         let range = Range::new(format!(
-            "gkr.forward.dimension_reduction.tower.{:?}",
-            range_type
+            "gkr.forward.dimension_reduction.tower.{range_type:?}"
         ))?;
         range.start(stream)?;
 
-        for s in slot_idx..range_end {
-            let mut cur_input = slot_initial_inputs[s];
-            let mut cur_input_log_2 = initial_trace_log_2;
-            let mut r = 0u32;
-            while r < total_rounds {
-                let remaining = total_rounds - r;
-                let chunk_rounds = remaining.min(log_block);
-                let chunk_input_len = 1u32 << cur_input_log_2;
+        for slot in slot_idx..range_end {
+            let mut current_input = if start_round == 0 {
+                prepared.slot_initial_inputs[slot]
+            } else {
+                output_as_input(prepared.per_round_slot_outputs[start_round as usize - 1][slot])
+            };
+            let mut current_input_log_2 = prepared.initial_trace_log_2 - start_round;
+            let mut round = start_round;
+            while round < prepared.total_rounds {
+                let chunk_rounds =
+                    (prepared.total_rounds - round).min(GKR_DIM_REDUCING_FORWARD_TOWER_LOG_BLOCK);
                 dispatch_tower_slot_launch(
-                    cur_input,
-                    s,
-                    r,
+                    current_input,
+                    slot,
+                    round,
                     chunk_rounds,
-                    chunk_input_len,
-                    &per_round_slot_outputs,
+                    1u32 << current_input_log_2,
+                    &prepared.per_round_slot_outputs,
                     stream,
                 )?;
-                r += chunk_rounds;
-                cur_input_log_2 -= chunk_rounds;
-                if r < total_rounds {
-                    let last_round = (r - 1) as usize;
-                    cur_input = match per_round_slot_outputs[last_round][s] {
-                        LoweredSlotOutput::PairwiseProduct { output } => {
-                            LoweredSlotInitialInput::PairwiseProduct {
-                                input: output as *const E,
-                            }
-                        }
-                        LoweredSlotOutput::LookupPair {
-                            output_num,
-                            output_den,
-                        } => LoweredSlotInitialInput::LookupPair {
-                            num: output_num as *const E,
-                            den: output_den as *const E,
-                        },
-                    };
+                round += chunk_rounds;
+                current_input_log_2 -= chunk_rounds;
+                if round < prepared.total_rounds {
+                    current_input =
+                        output_as_input(prepared.per_round_slot_outputs[round as usize - 1][slot]);
                 }
             }
         }
 
         range.end(stream)?;
         tracing_ranges.push(range);
-
         slot_idx = range_end;
     }
+    Ok(())
+}
 
-    Ok((current_layer_idx - 1, dimension_reduction_description))
+fn output_as_input<E>(output: LoweredSlotOutput<E>) -> LoweredSlotInitialInput<E> {
+    match output {
+        LoweredSlotOutput::PairwiseProduct { output } => {
+            LoweredSlotInitialInput::PairwiseProduct { input: output }
+        }
+        LoweredSlotOutput::LookupPair {
+            output_num,
+            output_den,
+        } => LoweredSlotInitialInput::LookupPair {
+            num: output_num,
+            den: output_den,
+        },
+    }
 }
 
 fn dispatch_tower_slot_launch<E>(

--- a/gpu/gkr/src/forward/dimension_reducing.rs
+++ b/gpu/gkr/src/forward/dimension_reducing.rs
@@ -26,12 +26,6 @@ pub(super) struct LoweredDimReducingForwardRound<E> {
     pub(super) computed_extension_outputs: Vec<(GKRAddress, GpuExtensionFieldPoly<E>)>,
 }
 
-/// `(final_layer_idx, per-layer layer_description map)`.
-pub(super) type DimensionReductionForwardResult = (
-    usize,
-    BTreeMap<usize, BTreeMap<OutputType, DimensionReducingInputOutput>>,
-);
-
 pub(super) struct PreparedDimensionReductionForward<E> {
     pub(super) initial_trace_log_2: u32,
     pub(super) total_rounds: u32,
@@ -41,12 +35,6 @@ pub(super) struct PreparedDimensionReductionForward<E> {
     pub(super) slot_initial_inputs: Vec<LoweredSlotInitialInput<E>>,
     pub(super) slot_output_types: Vec<OutputType>,
     pub(super) per_round_slot_outputs: Vec<Vec<LoweredSlotOutput<E>>>,
-}
-
-impl<E> PreparedDimensionReductionForward<E> {
-    pub(super) fn into_result(self) -> DimensionReductionForwardResult {
-        (self.final_layer_idx, self.dimension_reduction_description)
-    }
 }
 
 pub(super) fn prepare_dimension_reduction_forward<E>(
@@ -61,7 +49,10 @@ pub(super) fn prepare_dimension_reduction_forward<E>(
 where
     E: FieldExtension<BF> + Field + 'static,
 {
-    let total_rounds = initial_trace_log_2.saturating_sub(final_trace_log_2);
+    let total_rounds = initial_trace_log_2
+        .checked_sub(final_trace_log_2)
+        .expect("final trace size must not exceed the initial trace size");
+    assert!(total_rounds >= vm::desc::FUSED_REDUCTION_ROUNDS as u32);
     let mut dimension_reduction_description = BTreeMap::new();
     let mut per_round_slot_outputs = Vec::with_capacity(total_rounds as usize);
     let mut slot_initial_inputs = None;
@@ -109,14 +100,10 @@ where
     Ok(PreparedDimensionReductionForward {
         initial_trace_log_2,
         total_rounds,
-        final_layer_idx: if total_rounds == 0 {
-            initial_layer_idx
-        } else {
-            current_layer_idx - 1
-        },
+        final_layer_idx: current_layer_idx - 1,
         dimension_reduction_description,
-        slot_initial_inputs: slot_initial_inputs.unwrap_or_default(),
-        slot_output_types: slot_output_types.unwrap_or_default(),
+        slot_initial_inputs: slot_initial_inputs.expect("dimension reduction inputs must exist"),
+        slot_output_types: slot_output_types.expect("dimension reduction output types must exist"),
         per_round_slot_outputs,
     })
 }

--- a/gpu/gkr/src/forward/mod.rs
+++ b/gpu/gkr/src/forward/mod.rs
@@ -219,7 +219,8 @@ pub fn schedule_forward_pass(
     )?;
     dimension_reduction_range.end(stream)?;
     tracing_ranges.push(dimension_reduction_range);
-    let (initial_layer_for_sumcheck, dimension_reducing_inputs) = prepared_reductions.into_result();
+    let initial_layer_for_sumcheck = prepared_reductions.final_layer_idx;
+    let dimension_reducing_inputs = prepared_reductions.dimension_reduction_description;
     forward_range.end(stream)?;
     tracing_ranges.push(forward_range);
 

--- a/gpu/gkr/src/forward/mod.rs
+++ b/gpu/gkr/src/forward/mod.rs
@@ -12,7 +12,6 @@ use super::{GpuBaseFieldPoly, GpuExtensionFieldPoly, GpuGKRLayerSource, GpuGKRSt
 use gpu_core::primitives::context::DeviceAllocation;
 use gpu_core::primitives::device_tracing::Range;
 use gpu_core::primitives::field::{BF, E4};
-use gpu_ops::simple::{Add, BinaryOp, Mul, SetByRef, SetByVal, Sub};
 use gpu_prover_context::ProverContext;
 
 use crate::GkrPrograms;
@@ -109,7 +108,9 @@ use crate::upstream::{
     DimensionReducingInputOutput, Field, FieldExtension, GKRAddress, GKRCircuitArtifact,
     GKRExternalChallenges, OutputType,
 };
-use dimension_reducing::schedule_dimension_reduction_forward;
+use dimension_reducing::{
+    prepare_dimension_reduction_forward, schedule_prepared_dimension_reduction_forward,
+};
 
 // The optional slab target transfers ownership into the scheduled forward pass.
 #[allow(clippy::needless_pass_by_value)]
@@ -159,9 +160,7 @@ pub fn schedule_forward_pass(
         "forward GKR program must cover every main layer",
     );
 
-    let vm_range = Range::new("gkr.forward.vm")?;
-    vm_range.start(stream)?;
-    vm::production_bind::schedule_vm(
+    let mut lowered_vm = vm::production_bind::prepare_vm(
         compiled_circuit,
         &programs.forward.layers,
         &mut storage,
@@ -170,6 +169,25 @@ pub fn schedule_forward_pass(
         external_challenges,
         trace_len,
         inits_and_teardowns_top_bits,
+        context,
+    )?;
+
+    let prepared_reductions = prepare_dimension_reduction_forward(
+        &mut storage,
+        compiled_circuit.layers.len(),
+        &compiled_circuit.global_output_map,
+        trace_len.trailing_zeros(),
+        final_trace_size_log_2,
+        output_evaluations_slab.as_ref(),
+        context,
+    )?;
+
+    let vm_range = Range::new("gkr.forward.vm")?;
+    vm_range.start(stream)?;
+    vm::production_bind::schedule_vm(
+        &mut lowered_vm,
+        &prepared_reductions,
+        forward_setup,
         context,
     )?;
     vm_range.end(stream)?;
@@ -193,19 +211,15 @@ pub fn schedule_forward_pass(
 
     let dimension_reduction_range = Range::new("gkr.forward.dimension_reduction")?;
     dimension_reduction_range.start(stream)?;
-    let (initial_layer_for_sumcheck, dimension_reducing_inputs) =
-        schedule_dimension_reduction_forward(
-            &mut storage,
-            compiled_circuit.layers.len(),
-            &compiled_circuit.global_output_map,
-            trace_len.trailing_zeros(),
-            final_trace_size_log_2,
-            output_evaluations_slab.as_ref(),
-            &mut tracing_ranges,
-            context,
-        )?;
+    schedule_prepared_dimension_reduction_forward(
+        &prepared_reductions,
+        vm::desc::FUSED_REDUCTION_ROUNDS as u32,
+        &mut tracing_ranges,
+        context,
+    )?;
     dimension_reduction_range.end(stream)?;
     tracing_ranges.push(dimension_reduction_range);
+    let (initial_layer_for_sumcheck, dimension_reducing_inputs) = prepared_reductions.into_result();
     forward_range.end(stream)?;
     tracing_ranges.push(forward_range);
 

--- a/gpu/gkr/src/forward/tests/mod.rs
+++ b/gpu/gkr/src/forward/tests/mod.rs
@@ -1,6 +1,10 @@
 use super::*;
 use helpers::*;
 
+use super::dimension_reducing::{
+    prepare_dimension_reduction_forward, schedule_prepared_dimension_reduction_forward,
+    LoweredSlotOutput,
+};
 use crate::test_utils::make_test_context;
 use gpu_core::primitives::field::E4;
 
@@ -106,19 +110,46 @@ fn dimension_reducing_forward_tower_matches_reference() {
         final_trace_log_2,
     );
 
-    let mut tracing_ranges = Vec::new();
-    let (final_layer_idx, dim_reducing_inputs) = schedule_dimension_reduction_forward::<E4>(
+    let prepared = prepare_dimension_reduction_forward::<E4>(
         &mut storage,
         current_layer_idx,
         &initial_output_map,
         initial_trace_log_2,
         final_trace_log_2,
         None,
-        &mut tracing_ranges,
         &context,
     )
     .unwrap();
+    let mut tracing_ranges = Vec::new();
+    schedule_prepared_dimension_reduction_forward(&prepared, 0, &mut tracing_ranges, &context)
+        .unwrap();
+
+    let stream = context.get_exec_stream();
+    for (round_idx, outputs) in prepared.per_round_slot_outputs.iter().enumerate().skip(7) {
+        let output_len = 1usize << (initial_trace_log_2 - round_idx as u32 - 1);
+        for output in outputs {
+            let pointers = match *output {
+                LoweredSlotOutput::PairwiseProduct { output } => [output, std::ptr::null_mut()],
+                LoweredSlotOutput::LookupPair {
+                    output_num,
+                    output_den,
+                } => [output_num, output_den],
+            };
+            for pointer in pointers.into_iter().filter(|pointer| !pointer.is_null()) {
+                let output = unsafe { DeviceSlice::from_raw_parts_mut(pointer, output_len) };
+                era_cudart::memory::memory_set_async(
+                    unsafe { output.transmute_mut::<u8>() },
+                    0,
+                    stream,
+                )
+                .unwrap();
+            }
+        }
+    }
+    schedule_prepared_dimension_reduction_forward(&prepared, 7, &mut tracing_ranges, &context)
+        .unwrap();
     context.get_exec_stream().synchronize().unwrap();
+    let (final_layer_idx, dim_reducing_inputs) = prepared.into_result();
 
     let total_rounds = initial_trace_log_2 - final_trace_log_2;
     assert_eq!(

--- a/gpu/gkr/src/forward/tests/mod.rs
+++ b/gpu/gkr/src/forward/tests/mod.rs
@@ -149,7 +149,8 @@ fn dimension_reducing_forward_tower_matches_reference() {
     schedule_prepared_dimension_reduction_forward(&prepared, 7, &mut tracing_ranges, &context)
         .unwrap();
     context.get_exec_stream().synchronize().unwrap();
-    let (final_layer_idx, dim_reducing_inputs) = prepared.into_result();
+    let final_layer_idx = prepared.final_layer_idx;
+    let dim_reducing_inputs = prepared.dimension_reduction_description;
 
     let total_rounds = initial_trace_log_2 - final_trace_log_2;
     assert_eq!(

--- a/gpu/gkr/src/forward/vm/desc.rs
+++ b/gpu/gkr/src/forward/vm/desc.rs
@@ -12,6 +12,10 @@ pub(crate) const SOURCE_WINDOW_COUNT: usize = 16;
 pub(crate) const LAYER_CAP: usize = 8;
 pub(crate) const DST_SLOT_COUNT: usize = 16;
 pub(crate) const MAPPING_ARENA_COUNT: usize = 3;
+pub(crate) const FUSED_REDUCTION_ROUNDS: usize = 7;
+pub(crate) const REDUCTION_PAIR_CAP: usize = 5;
+pub(crate) const REDUCTION_PAIR_PAIRWISE2: u32 = 0;
+pub(crate) const REDUCTION_PAIR_LOOKUP: u32 = 1;
 
 // --- special-descriptor strategy kinds (packed-desc `kind` field) ------------
 pub(crate) const SD_SINGLE_COLUMN: u32 = 0;
@@ -122,6 +126,15 @@ pub(crate) struct FwdVmLayer {
 
 #[repr(C)]
 #[derive(Clone, Copy)]
+pub(crate) struct FwdVmReductionPair {
+    pub input: [*const E4; 2],
+    pub round_outputs: [[*mut E4; 2]; FUSED_REDUCTION_ROUNDS],
+    pub kind: u32,
+    pub reserved: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
 pub(crate) struct FwdVmDesc {
     pub arg_derived_e4: [E4; ARG_DERIVED_E4_CAP],
     pub source_base: [*mut u8; SOURCE_WINDOW_COUNT],
@@ -137,13 +150,17 @@ pub(crate) struct FwdVmDesc {
     pub count: u32,
     pub layer_count: u32,
     pub layers: [FwdVmLayer; LAYER_CAP],
+    pub reduction_pair_count: u32,
+    pub reduction_pairs: [FwdVmReductionPair; REDUCTION_PAIR_CAP],
     pub program: [u16; PROGRAM_CAP],
 }
 
 /// ABI size guards, paired with the CUDA `static_assert`s in `fwd_vm.cuh`.
 const _: () = {
     assert!(core::mem::size_of::<FwdVmLayer>() == 4);
-    assert!(core::mem::size_of::<FwdVmDesc>() == 26_976);
+    assert!(core::mem::size_of::<FwdVmReductionPair>() == 136);
+    assert!(core::mem::align_of::<FwdVmReductionPair>() == 8);
+    assert!(core::mem::size_of::<FwdVmDesc>() == 27_664);
     assert!(core::mem::size_of::<FwdVmDesc>() <= 32_764);
     assert!(core::mem::align_of::<FwdVmDesc>() == 16);
 };
@@ -161,6 +178,13 @@ mod tests {
         assert_eq!(offset_of!(FwdVmLayer, program_offset), 0);
         assert_eq!(offset_of!(FwdVmLayer, instruction_count), 2);
 
+        assert_eq!(size_of::<FwdVmReductionPair>(), 136);
+        assert_eq!(align_of::<FwdVmReductionPair>(), 8);
+        assert_eq!(offset_of!(FwdVmReductionPair, input), 0);
+        assert_eq!(offset_of!(FwdVmReductionPair, round_outputs), 16);
+        assert_eq!(offset_of!(FwdVmReductionPair, kind), 128);
+        assert_eq!(offset_of!(FwdVmReductionPair, reserved), 132);
+
         assert_eq!(offset_of!(FwdVmDesc, arg_derived_e4), 0);
         assert_eq!(offset_of!(FwdVmDesc, source_base), 192);
         assert_eq!(offset_of!(FwdVmDesc, dst_base), 320);
@@ -175,8 +199,10 @@ mod tests {
         assert_eq!(offset_of!(FwdVmDesc, count), 2_356);
         assert_eq!(offset_of!(FwdVmDesc, layer_count), 2_360);
         assert_eq!(offset_of!(FwdVmDesc, layers), 2_364);
-        assert_eq!(offset_of!(FwdVmDesc, program), 2_396);
-        assert_eq!(size_of::<FwdVmDesc>(), 26_976);
+        assert_eq!(offset_of!(FwdVmDesc, reduction_pair_count), 2_396);
+        assert_eq!(offset_of!(FwdVmDesc, reduction_pairs), 2_400);
+        assert_eq!(offset_of!(FwdVmDesc, program), 3_080);
+        assert_eq!(size_of::<FwdVmDesc>(), 27_664);
         assert_eq!(align_of::<FwdVmDesc>(), 16);
     }
 

--- a/gpu/gkr/src/forward/vm/production_bind.rs
+++ b/gpu/gkr/src/forward/vm/production_bind.rs
@@ -233,7 +233,6 @@ fn bind_fused_reduction_prefix(
 ) {
     assert!(desc.count > 0 && desc.count % 128 == 0);
     assert_eq!(desc.count.trailing_zeros(), prepared.initial_trace_log_2);
-    assert!(prepared.total_rounds >= FUSED_REDUCTION_ROUNDS as u32);
     assert_eq!(
         prepared.per_round_slot_outputs.len(),
         prepared.total_rounds as usize
@@ -331,7 +330,6 @@ fn bind_fused_reduction_prefix(
         pair += 1;
         slot = range_end;
     }
-    assert!(pair > 0);
     desc.reduction_pair_count = pair as u32;
 }
 

--- a/gpu/gkr/src/forward/vm/production_bind.rs
+++ b/gpu/gkr/src/forward/vm/production_bind.rs
@@ -9,10 +9,16 @@ use era_cudart::slice::DeviceSlice;
 use era_cudart_sys::cudaGetSymbolAddress;
 use gpu_gkr_compiler::CompiledLayer;
 
-use super::desc::CONST_DERIVED_E4_CAP;
+use super::desc::{
+    FwdVmDesc, FwdVmReductionPair, CONST_DERIVED_E4_CAP, FUSED_REDUCTION_ROUNDS,
+    REDUCTION_PAIR_CAP, REDUCTION_PAIR_LOOKUP, REDUCTION_PAIR_PAIRWISE2,
+};
 use super::lower::{lower_desc, FwdVmInputs, LoweredFwdVm, ResolvedColumn};
 use super::output::{materialize_output_slot, register_layer_copy_aliases};
 use super::{ab_gkr_fwd_vm_const_derived_e4, launch_fwd_vm};
+use crate::forward::dimension_reducing::{
+    LoweredSlotInitialInput, LoweredSlotOutput, PreparedDimensionReductionForward,
+};
 use crate::gkr_address_audit::AddressClass;
 use crate::setup::GpuGKRForwardSetup;
 use crate::stage1::GpuGKRStage1Output;
@@ -221,8 +227,116 @@ pub(crate) fn prepare_layer_destinations(
     Ok(())
 }
 
+fn bind_fused_reduction_prefix(
+    desc: &mut FwdVmDesc,
+    prepared: &PreparedDimensionReductionForward<E4>,
+) {
+    assert!(desc.count > 0 && desc.count % 128 == 0);
+    assert_eq!(desc.count.trailing_zeros(), prepared.initial_trace_log_2);
+    assert!(prepared.total_rounds >= FUSED_REDUCTION_ROUNDS as u32);
+    assert_eq!(
+        prepared.per_round_slot_outputs.len(),
+        prepared.total_rounds as usize
+    );
+    assert_eq!(
+        prepared.slot_initial_inputs.len(),
+        prepared.slot_output_types.len()
+    );
+    assert!(!prepared.slot_initial_inputs.is_empty());
+    assert!(
+        prepared
+            .slot_output_types
+            .windows(2)
+            .all(|pair| pair[0] <= pair[1]),
+        "reduction slots must follow OutputType order"
+    );
+    for outputs in &prepared.per_round_slot_outputs {
+        assert_eq!(outputs.len(), prepared.slot_initial_inputs.len());
+    }
+
+    let mut slot = 0usize;
+    let mut pair = 0usize;
+    while slot < prepared.slot_output_types.len() {
+        assert!(pair < REDUCTION_PAIR_CAP);
+        let output_type = prepared.slot_output_types[slot];
+        let range_end = prepared.slot_output_types[slot..]
+            .iter()
+            .position(|kind| *kind != output_type)
+            .map(|offset| slot + offset)
+            .unwrap_or(prepared.slot_output_types.len());
+        let arity = range_end - slot;
+        let record = match output_type {
+            crate::upstream::OutputType::PermutationProduct
+            | crate::upstream::OutputType::InitsAndTeardownsProduct => {
+                assert_eq!(arity, 2);
+                let input = [slot, slot + 1].map(|slot| {
+                    let LoweredSlotInitialInput::PairwiseProduct { input } =
+                        prepared.slot_initial_inputs[slot]
+                    else {
+                        panic!("pairwise reduction input changed kind")
+                    };
+                    assert!(!input.is_null());
+                    input
+                });
+                let mut round_outputs = [[null_mut(); 2]; FUSED_REDUCTION_ROUNDS];
+                for (round, outputs) in round_outputs.iter_mut().enumerate() {
+                    for (output, slot) in outputs.iter_mut().zip([slot, slot + 1]) {
+                        let LoweredSlotOutput::PairwiseProduct { output: pointer } =
+                            prepared.per_round_slot_outputs[round][slot]
+                        else {
+                            panic!("pairwise reduction output changed kind")
+                        };
+                        assert!(!pointer.is_null());
+                        *output = pointer;
+                    }
+                }
+                FwdVmReductionPair {
+                    input,
+                    round_outputs,
+                    kind: REDUCTION_PAIR_PAIRWISE2,
+                    reserved: 0,
+                }
+            }
+            crate::upstream::OutputType::Lookup16Bits
+            | crate::upstream::OutputType::LookupTimestamps
+            | crate::upstream::OutputType::GenericLookup => {
+                assert_eq!(arity, 1);
+                let LoweredSlotInitialInput::LookupPair { num, den } =
+                    prepared.slot_initial_inputs[slot]
+                else {
+                    panic!("lookup reduction input changed kind")
+                };
+                assert!(!num.is_null() && !den.is_null());
+                let mut round_outputs = [[null_mut(); 2]; FUSED_REDUCTION_ROUNDS];
+                for (round, outputs) in round_outputs.iter_mut().enumerate() {
+                    let LoweredSlotOutput::LookupPair {
+                        output_num,
+                        output_den,
+                    } = prepared.per_round_slot_outputs[round][slot]
+                    else {
+                        panic!("lookup reduction output changed kind")
+                    };
+                    assert!(!output_num.is_null() && !output_den.is_null());
+                    *outputs = [output_num, output_den];
+                }
+                FwdVmReductionPair {
+                    input: [num, den],
+                    round_outputs,
+                    kind: REDUCTION_PAIR_LOOKUP,
+                    reserved: 0,
+                }
+            }
+        };
+        desc.reduction_pairs[pair] = record;
+        pair += 1;
+        slot = range_end;
+    }
+    assert!(pair > 0);
+    desc.reduction_pair_count = pair as u32;
+}
+
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn schedule_vm(
+pub(in crate::forward) fn prepare_vm(
     compiled_circuit: &GKRCircuitArtifact<BF>,
     compiled_layers: &[CompiledLayer],
     storage: &mut GpuGKRStorage<BF, E4>,
@@ -232,7 +346,7 @@ pub(crate) fn schedule_vm(
     trace_len: usize,
     inits_and_teardowns_top_bits: &[u32],
     context: &ProverContext,
-) -> CudaResult<()> {
+) -> CudaResult<LoweredFwdVm> {
     assert!(!compiled_circuit.layers.is_empty());
     assert_eq!(compiled_layers.len(), compiled_circuit.layers.len());
     for (layer_idx, layer) in compiled_circuit.layers.iter().enumerate() {
@@ -257,6 +371,16 @@ pub(crate) fn schedule_vm(
     let lowered = lower_desc(compiled_layers, &header, &resolve, &challenge)
         .unwrap_or_else(|error| panic!("forward VM lowering failed: {error:?}"));
     assert_eq!(lowered.desc.count, trace_len as u32);
+    Ok(lowered)
+}
+
+pub(in crate::forward) fn schedule_vm(
+    lowered: &mut LoweredFwdVm,
+    reductions: &PreparedDimensionReductionForward<E4>,
+    forward_setup: &GpuGKRForwardSetup,
+    context: &ProverContext,
+) -> CudaResult<()> {
+    bind_fused_reduction_prefix(&mut lowered.desc, reductions);
     stage_const_derived_e4_bank(&lowered, forward_setup, context)
         .unwrap_or_else(|error| panic!("forward VM constant staging failed: {error:?}"));
     launch_fwd_vm(&lowered.desc, context)
@@ -266,7 +390,159 @@ pub(crate) fn schedule_vm(
 mod tests {
     use super::*;
 
+    use std::collections::BTreeMap;
+
+    use crate::forward::dimension_reducing::{
+        LoweredSlotInitialInput, LoweredSlotOutput, PreparedDimensionReductionForward,
+    };
+    use crate::forward::vm::desc::{REDUCTION_PAIR_LOOKUP, REDUCTION_PAIR_PAIRWISE2};
     use crate::upstream::{ChallengeKey, ChallengePower, ChallengeRef, PermutationSlot};
+
+    fn pointer(value: usize) -> *mut E4 {
+        value as *mut E4
+    }
+
+    fn prepared_for_types(
+        types: Vec<crate::upstream::OutputType>,
+    ) -> PreparedDimensionReductionForward<E4> {
+        let slot_initial_inputs = types
+            .iter()
+            .enumerate()
+            .map(|(slot, kind)| {
+                let base = (slot + 1) * 0x1000;
+                match kind {
+                    crate::upstream::OutputType::PermutationProduct
+                    | crate::upstream::OutputType::InitsAndTeardownsProduct => {
+                        LoweredSlotInitialInput::PairwiseProduct {
+                            input: pointer(base),
+                        }
+                    }
+                    _ => LoweredSlotInitialInput::LookupPair {
+                        num: pointer(base),
+                        den: pointer(base + 0x80),
+                    },
+                }
+            })
+            .collect();
+        let per_round_slot_outputs = (0..7)
+            .map(|round| {
+                types
+                    .iter()
+                    .enumerate()
+                    .map(|(slot, kind)| {
+                        let base = (round + 1) * 0x10000 + (slot + 1) * 0x1000;
+                        match kind {
+                            crate::upstream::OutputType::PermutationProduct
+                            | crate::upstream::OutputType::InitsAndTeardownsProduct => {
+                                LoweredSlotOutput::PairwiseProduct {
+                                    output: pointer(base),
+                                }
+                            }
+                            _ => LoweredSlotOutput::LookupPair {
+                                output_num: pointer(base),
+                                output_den: pointer(base + 0x80),
+                            },
+                        }
+                    })
+                    .collect()
+            })
+            .collect();
+        PreparedDimensionReductionForward {
+            initial_trace_log_2: 10,
+            total_rounds: 7,
+            final_layer_idx: 0,
+            dimension_reduction_description: BTreeMap::new(),
+            slot_initial_inputs,
+            slot_output_types: types,
+            per_round_slot_outputs,
+        }
+    }
+
+    #[test]
+    fn add_sub_reduction_prefix_packs_four_pairs() {
+        use crate::upstream::OutputType::*;
+
+        let prepared = prepared_for_types(vec![
+            PermutationProduct,
+            PermutationProduct,
+            Lookup16Bits,
+            LookupTimestamps,
+            GenericLookup,
+        ]);
+        let mut desc: FwdVmDesc = unsafe { core::mem::zeroed() };
+        desc.count = 1024;
+
+        bind_fused_reduction_prefix(&mut desc, &prepared);
+
+        assert_eq!(desc.reduction_pair_count, 4);
+        assert_eq!(desc.reduction_pairs[0].kind, REDUCTION_PAIR_PAIRWISE2);
+        assert_eq!(
+            desc.reduction_pairs[0].input.map(|ptr| ptr as usize),
+            [0x1000, 0x2000]
+        );
+        assert_eq!(
+            desc.reduction_pairs[0].round_outputs[0].map(|ptr| ptr as usize),
+            [0x11000, 0x12000]
+        );
+        assert_eq!(desc.reduction_pairs[1].kind, REDUCTION_PAIR_LOOKUP);
+        assert_eq!(
+            desc.reduction_pairs[1].input.map(|ptr| ptr as usize),
+            [0x3000, 0x3080]
+        );
+        assert_eq!(
+            desc.reduction_pairs[3].round_outputs[6].map(|ptr| ptr as usize),
+            [0x75000, 0x75080]
+        );
+    }
+
+    #[test]
+    fn unified_reduction_prefix_packs_five_pairs() {
+        use crate::upstream::OutputType::*;
+
+        let prepared = prepared_for_types(vec![
+            PermutationProduct,
+            PermutationProduct,
+            Lookup16Bits,
+            LookupTimestamps,
+            GenericLookup,
+            InitsAndTeardownsProduct,
+            InitsAndTeardownsProduct,
+        ]);
+        let mut desc: FwdVmDesc = unsafe { core::mem::zeroed() };
+        desc.count = 1024;
+
+        bind_fused_reduction_prefix(&mut desc, &prepared);
+
+        assert_eq!(desc.reduction_pair_count, 5);
+        assert_eq!(desc.reduction_pairs[4].kind, REDUCTION_PAIR_PAIRWISE2);
+        assert_eq!(
+            desc.reduction_pairs[4].input.map(|ptr| ptr as usize),
+            [0x6000, 0x7000]
+        );
+        assert_eq!(
+            desc.reduction_pairs[4].round_outputs[6].map(|ptr| ptr as usize),
+            [0x76000, 0x77000]
+        );
+    }
+
+    #[test]
+    fn malformed_reduction_shapes_are_rejected() {
+        use crate::upstream::OutputType::*;
+
+        for types in [
+            vec![PermutationProduct],
+            vec![Lookup16Bits, Lookup16Bits],
+            vec![GenericLookup, Lookup16Bits],
+        ] {
+            let prepared = prepared_for_types(types);
+            let mut desc: FwdVmDesc = unsafe { core::mem::zeroed() };
+            desc.count = 1024;
+            assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                bind_fused_reduction_prefix(&mut desc, &prepared);
+            }))
+            .is_err());
+        }
+    }
 
     /// The permutation challenges ride the descriptor by value, so their
     /// mapping onto `GKRExternalChallenges` must match the upstream slot

--- a/gpu/gkr_model/src/storage_layout/tower.rs
+++ b/gpu/gkr_model/src/storage_layout/tower.rs
@@ -31,7 +31,7 @@ pub(super) fn append_tower_layers<F: PrimeField>(
         return;
     }
     // Tower starts one storage layer past the artifact's last input layer.
-    // `schedule_dimension_reduction_forward` is called with
+    // `prepare_dimension_reduction_forward` is called with
     // `initial_layer_idx = compiled_circuit.layers.len()` and writes round 0's
     // outputs at `output_layer = initial_layer_idx + 1`. The artifact-driven
     // layout already covers up to `compiled_circuit.layers.len()`, so the


### PR DESCRIPTION
## What ❔

- Fuse the first seven dimension-reduction rounds into the forward VM kernel.
- Reuse each warp's VM shared memory and resume the existing tower at round seven.
- Preserve every intermediate output required by the backward pass.

## Why ❔

Avoid reloading freshly produced forward outputs in separate kernels. Add/sub improves by 7.06% and unified by a median 4.89%; Blake2 compression remains neutral.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

Validation: all 12 release proof-parity and multi-schedule cases pass; Compute Sanitizer synchronization checks pass; NCU reports zero local or register-spill traffic.
