### PR TITLE
perf(whir): fuse coefficient leaf transformation and hashing

### DIFF
--- a/gpu/AGENTS.md
+++ b/gpu/AGENTS.md
@@ -59,8 +59,9 @@ root in `gkr_eval_ir`; `gpu_gkr_compiler` depends on it.
   `gpu_ntt_native`; `circuit_prover` drops `gpu_prover_ntt` and links gpu_ntt's
   archive via build-script propagation. Co-locating the `cuda_struct_and_stub!`
   twiddle stubs with their `native/ntt __constant__` defs fixes the NTT
-  cross-wall pitfall. Its tests are self-contained (raw era_cudart allocations +
-  `DeviceContext::create`, no `ProverContext`).
+  cross-wall pitfall. Its build exports `native/` so gpu_whir can include the
+  reusable `whir_leaf_transform.cuh` device helper. Its tests are self-contained
+  (raw era_cudart allocations + `DeviceContext::create`, no `ProverContext`).
 - **`gpu_ops`** = the generic math/transform kernels (`simple`, `powers`,
   `squaring`, `transpose`, `bit_reverse`) with its own
   `gpu_ops_native`. `bit_reverse` is **size-generic**: `bit_reverse_in_place<T>`
@@ -132,10 +133,12 @@ root in `gkr_eval_ir`; `gpu_gkr_compiler` depends on it.
   `gkr/support/{eq_inline,kernel_helpers}.cuh`; reads `gpu_hash`'s `hash.cuh`
   for its own blake2s-dependent protocol kernels. See [`gkr/AGENTS.md`](gkr/AGENTS.md).
 - **`gpu_whir`** = WHIR folds (`fold/`) + PoW/query scheduling (`pow.rs`) +
-  the recursive WHIR extension oracle, with its own `gpu_whir_native` (17
-  kernels, no `__constant__` symbols), namespace `airbender::whir`. Reads
+  the recursive WHIR extension oracle and its side-stream LDE/Merkle commit
+  scheduler, with its own `gpu_whir_native` (20 kernels, no `__constant__`
+  symbols), namespace `airbender::whir`. Reads
   `gpu_gkr`'s exported headers (`accumulate_eq.cu`) and `gpu_hash`'s
-  `hash.cuh` (`leaves.cu`). Features `deterministic_pow =
+  `hash.cuh` plus gpu_ntt's exported `whir_leaf_transform.cuh` (`leaves.cu`).
+  Features `deterministic_pow =
   ["prover/deterministic_pow","gpu_hash/deterministic_pow"]` (owns both
   determinism legs; `prover` is a normal, not dev-only, dependency here only
   for that forward), and `eval_leaves`. See [`whir/AGENTS.md`](whir/AGENTS.md).

--- a/gpu/docs/gpu_scheduling_contract.md
+++ b/gpu/docs/gpu_scheduling_contract.md
@@ -65,8 +65,8 @@ edge cases, and wiring behind each rule.
 
 - **Side stream** (`side_stream`, `get_side_stream()`): an auxiliary compute
   stream used to overlap independent kernel work with exec_stream. Its only
-  consumer is `gpu_trace`'s trace holder, for parallel trace commit — see
-  *Side stream* below.
+  consumer is `gpu_whir`'s recursive-oracle commit scheduler — see *Side
+  stream* below.
 
 **Rule for auxiliary streams**: any operation on an auxiliary stream
 (h2d_stream or side_stream) must be explicitly ordered with
@@ -229,11 +229,12 @@ and keep the host destination alive until that callback has been scheduled.
 
 `side_stream` (`ProverContext::get_side_stream()`) carries general compute
 kernels in parallel with the same kind of kernels on
-exec_stream. Its only current consumer is `gpu_trace`'s trace holder
-(`commit_trace_from_ntt_single_tree` in `gpu/trace/src/trace/holder/mod.rs`),
-for parallel trace commit — ping-ponging LDE, leaf-transform, and leaf-commit
-kernels across coset-index chunks between `exec_stream` and `side_stream` to
-overlap the two streams' compute.
+exec_stream. Its only current consumer is the recursive-WHIR commit scheduler
+(`commit_trace_from_ntt_single_tree` in
+`gpu/whir/src/oracle_commit.rs`), which ping-pongs LDE and leaf-commit work
+across coset-index chunks between `exec_stream` and `side_stream`. Coefficient
+commit uses the fused shared-memory transform-and-hash kernel; evaluation
+commit uses the ordinary leaf-hash kernel.
 
 The same fork/join/write-exclusivity/drop discipline as H2D applies, adapted to
 a compute workload:
@@ -241,8 +242,8 @@ a compute workload:
 ```text
 exec_stream:  record E_start                     ("first chunk's inputs are ready")
 side_stream:  wait_event(E_start)                 ("don't start before exec_stream is ready")
-exec_stream:  chunk 0, 2, 4, … : LDE / leaf-transform / leaf-commit kernels
-side_stream:  chunk 1, 3, 5, … : LDE / leaf-transform / leaf-commit kernels
+exec_stream:  chunk 0, 2, 4, … : LDE / leaf-commit kernels
+side_stream:  chunk 1, 3, 5, … : LDE / leaf-commit kernels
 side_stream:  record E_done                       ("side_stream's chunks are committed")
 exec_stream:  wait_event(E_done)                  ("don't build Merkle-tree nodes yet")
 exec_stream:  build_merkle_tree_nodes(...)         (exec_stream-only; reads every chunk)

--- a/gpu/hash/native/gather.cu
+++ b/gpu/hash/native/gather.cu
@@ -2,59 +2,6 @@
 
 namespace airbender::hash {
 
-// Warp-shuffle Merkle-path collection constants. Only the gather kernels below
-// need them, so they live here rather than in the shared hash.cuh surface.
-constexpr unsigned LOG_WARP_SIZE = 5;
-constexpr unsigned WARP_MASK = (1u << LOG_WARP_SIZE) - 1;
-constexpr u32 FULL_MASK = 0xffffffff;
-
-// Warp-cooperative Merkle-path collection for one query. Given this lane's
-// absorbed leaf `state`, hashes the bottom LOG_WARP_SIZE layers via warp-shuffle
-// (the output lane writes each layer's sibling digest), then walks the remaining
-// layers from the cached `tree_bottom`. `merkle_paths` points at layer 0's slot;
-// consecutive layers are `layer_stride_words` apart. `state` is consumed.
-DEVICE_FORCEINLINE void collect_merkle_path_warp(u32 state[STATE_SIZE], u32 *merkle_paths, const unsigned layer_stride_words, const unsigned lane_idx,
-                                                 const bool is_output_lane, const unsigned query_index, const unsigned log_total_leaves_count,
-                                                 const unsigned layers_count, const u32 *tree_bottom) {
-  u32 block[BLOCK_SIZE];
-#pragma unroll
-  for (unsigned layer = 0; layer < LOG_WARP_SIZE; layer++) {
-    digest other_state;
-    const bool take_other_first = (lane_idx >> layer) & 1;
-#pragma unroll
-    for (unsigned i = 0; i < STATE_SIZE; i++) {
-      other_state[i] = __shfl_xor_sync(FULL_MASK, state[i], 1 << layer);
-      if (take_other_first) {
-        block[i] = other_state[i];
-        block[i + STATE_SIZE] = state[i];
-      } else {
-        block[i] = state[i];
-        block[i + STATE_SIZE] = other_state[i];
-      }
-    }
-    if (is_output_lane)
-      store_cs(reinterpret_cast<digest *>(merkle_paths), other_state);
-    initialize(state);
-    u32 t = 0;
-    compress<true>(state, t, block, BLOCK_SIZE);
-    merkle_paths += layer_stride_words;
-  }
-  if (lane_idx >= STATE_SIZE)
-    return;
-  unsigned digest_index = query_index >> LOG_WARP_SIZE;
-  unsigned log_digests_count = log_total_leaves_count - LOG_WARP_SIZE;
-  const u32 *tree_layer = tree_bottom + lane_idx;
-  u32 *merkle_paths_dst = merkle_paths + lane_idx;
-  for (unsigned layer = LOG_WARP_SIZE; layer < layers_count; layer++) {
-    const unsigned other_index = digest_index ^ 1;
-    *merkle_paths_dst = *(tree_layer + other_index * STATE_SIZE);
-    digest_index >>= 1;
-    tree_layer += (1u << log_digests_count) * STATE_SIZE;
-    log_digests_count--;
-    merkle_paths_dst += layer_stride_words;
-  }
-}
-
 EXTERN __global__ void ab_gather_leaf_rows_kernel(const unsigned *indexes, const unsigned indexes_count, const bool bit_reverse_indexes,
                                                   const unsigned log_leaves_count, const unsigned log_rows_per_leaf,
                                                   const matrix_getter<bf, ld_modifier::cs> values, const matrix_setter<bf, st_modifier::cs> results) {

--- a/gpu/hash/native/hash.cuh
+++ b/gpu/hash/native/hash.cuh
@@ -26,6 +26,9 @@ using namespace ::airbender::primitives::field;
 constexpr unsigned ROUNDS = 7;
 constexpr unsigned STATE_SIZE = 8;
 constexpr unsigned BLOCK_SIZE = 16;
+constexpr unsigned LOG_WARP_SIZE = 5;
+constexpr unsigned WARP_MASK = (1u << LOG_WARP_SIZE) - 1;
+constexpr u32 FULL_MASK = 0xffffffff;
 
 // 32-byte aligned digest view. Used at every gmem digest boundary so the
 // `load`/`store` PTX dispatch picks the v8 (256-bit) path: one
@@ -111,6 +114,73 @@ template <typename Read> DEVICE_FORCEINLINE void absorb_stream(u32 state[STATE_S
       compress<true>(state, t, block, remaining);
     else
       compress<false>(state, t, block, BLOCK_SIZE);
+  }
+}
+
+// `values_count` counts E4 values, not base-field words.
+template <typename ReadE4> DEVICE_FORCEINLINE void absorb_e4_stream(u32 state[STATE_SIZE], u32 &t, const unsigned values_count, ReadE4 read_e4) {
+  constexpr unsigned E4S_PER_BLOCK = BLOCK_SIZE / 4;
+  u32 block[BLOCK_SIZE];
+  unsigned value_offset = 0;
+  while (value_offset < values_count) {
+    const unsigned remaining = values_count - value_offset;
+    const bool is_final_block = remaining <= E4S_PER_BLOCK;
+#pragma unroll
+    for (unsigned i = 0; i < E4S_PER_BLOCK; i++) {
+      const e4 value = i < remaining ? read_e4(value_offset + i) : e4::ZERO();
+#pragma unroll
+      for (unsigned coeff = 0; coeff < 4; coeff++)
+        block[4 * i + coeff] = bf::into_raw_u32(value.base_coefficient_from_flat_idx(coeff));
+    }
+    const unsigned consumed_values = remaining < E4S_PER_BLOCK ? remaining : E4S_PER_BLOCK;
+    value_offset += E4S_PER_BLOCK;
+    if (is_final_block)
+      compress<true>(state, t, block, consumed_values * 4);
+    else
+      compress<false>(state, t, block, BLOCK_SIZE);
+  }
+}
+
+// Rebuilds the bottom five layers with warp shuffles before walking the cached tree.
+DEVICE_FORCEINLINE void collect_merkle_path_warp(u32 state[STATE_SIZE], u32 *merkle_paths, const unsigned layer_stride_words, const unsigned lane_idx,
+                                                 const bool is_output_lane, const unsigned query_index, const unsigned log_total_leaves_count,
+                                                 const unsigned layers_count, const u32 *tree_bottom) {
+  u32 block[BLOCK_SIZE];
+#pragma unroll
+  for (unsigned layer = 0; layer < LOG_WARP_SIZE; layer++) {
+    digest other_state;
+    const bool take_other_first = (lane_idx >> layer) & 1;
+#pragma unroll
+    for (unsigned i = 0; i < STATE_SIZE; i++) {
+      other_state[i] = __shfl_xor_sync(FULL_MASK, state[i], 1 << layer);
+      if (take_other_first) {
+        block[i] = other_state[i];
+        block[i + STATE_SIZE] = state[i];
+      } else {
+        block[i] = state[i];
+        block[i + STATE_SIZE] = other_state[i];
+      }
+    }
+    if (is_output_lane)
+      ::airbender::primitives::memory::store_cs(reinterpret_cast<digest *>(merkle_paths), other_state);
+    initialize(state);
+    u32 t = 0;
+    compress<true>(state, t, block, BLOCK_SIZE);
+    merkle_paths += layer_stride_words;
+  }
+  if (lane_idx >= STATE_SIZE)
+    return;
+  unsigned digest_index = query_index >> LOG_WARP_SIZE;
+  unsigned log_digests_count = log_total_leaves_count - LOG_WARP_SIZE;
+  const u32 *tree_layer = tree_bottom + lane_idx;
+  u32 *merkle_paths_dst = merkle_paths + lane_idx;
+  for (unsigned layer = LOG_WARP_SIZE; layer < layers_count; layer++) {
+    const unsigned other_index = digest_index ^ 1;
+    *merkle_paths_dst = *(tree_layer + other_index * STATE_SIZE);
+    digest_index >>= 1;
+    tree_layer += (1u << log_digests_count) * STATE_SIZE;
+    log_digests_count--;
+    merkle_paths_dst += layer_stride_words;
   }
 }
 

--- a/gpu/ntt/build.rs
+++ b/gpu/ntt/build.rs
@@ -1,7 +1,8 @@
 use std::env;
 
 fn main() {
-    let mut archive = gpu_native_build::CudaArchive::new("gpu_ntt_native", "GPU_NTT");
+    let mut archive =
+        gpu_native_build::CudaArchive::new("gpu_ntt_native", "GPU_NTT").export_include(true);
     if env::var_os("CARGO_FEATURE_BENCH").is_some() {
         archive = archive.define("GPU_NTT_BUILD_BENCH", "ON");
     }

--- a/gpu/ntt/native/CMakeLists.txt
+++ b/gpu/ntt/native/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(gpu_ntt_native STATIC
         monomials_to_evals_two_pass.cu
         ntt.cu
         ntt.cuh
+        whir_leaf_transform.cuh
         whir_leaves.cu
 )
 option(GPU_NTT_BUILD_BENCH "Compile bench-only DIT kernel variants into the archive" OFF)

--- a/gpu/ntt/native/whir_leaf_transform.cuh
+++ b/gpu/ntt/native/whir_leaf_transform.cuh
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <common.cuh>
+#include <cstddef>
+#include <primitives/field.cuh>
+#include <primitives/memory.cuh>
+
+using namespace ::airbender::primitives::field;
+using namespace ::airbender::primitives::memory;
+
+namespace airbender::ntt {
+
+struct whir_leaf_transform_params {
+  const bf *inverse_fine_values;
+  unsigned inverse_fine_mask;
+  unsigned inverse_fine_log_count;
+  const bf *inverse_coarse_values;
+  unsigned inverse_coarse_mask;
+  bf two_inv_power;
+  unsigned omega_log_order;
+};
+
+// Twin of `WhirLeafTransformParams` in `src/ntt_twiddles.rs`.
+static_assert(sizeof(whir_leaf_transform_params) == 40);
+static_assert(alignof(whir_leaf_transform_params) == 8);
+static_assert(offsetof(whir_leaf_transform_params, inverse_fine_values) == 0);
+static_assert(offsetof(whir_leaf_transform_params, inverse_fine_mask) == 8);
+static_assert(offsetof(whir_leaf_transform_params, inverse_fine_log_count) == 12);
+static_assert(offsetof(whir_leaf_transform_params, inverse_coarse_values) == 16);
+static_assert(offsetof(whir_leaf_transform_params, inverse_coarse_mask) == 24);
+static_assert(offsetof(whir_leaf_transform_params, two_inv_power) == 28);
+static_assert(offsetof(whir_leaf_transform_params, omega_log_order) == 32);
+
+struct params_inverse_power_source {
+  whir_leaf_transform_params params;
+
+  DEVICE_FORCEINLINE bf get(const unsigned idx) const {
+    const unsigned coarse_idx = (idx >> params.inverse_fine_log_count) & params.inverse_coarse_mask;
+    const unsigned fine_idx = idx & params.inverse_fine_mask;
+    bf value = load_ca(params.inverse_coarse_values + coarse_idx);
+    if (fine_idx != 0) {
+      value = bf::mul(value, load_ca(params.inverse_fine_values + fine_idx));
+    }
+    return value;
+  }
+};
+
+// "Improving running time via alternate domain evaluation," page 15:
+// https://eprint.iacr.org/2024/1586.pdf
+template <class Source, class Destination, class InversePowerSource>
+DEVICE_FORCEINLINE void transform_whir_leaf_from_ntt(const Source &src, Destination &dst, const unsigned log_trace_len, const unsigned log_lde_factor,
+                                                     const unsigned log_values_per_leaf, const unsigned coset, const unsigned base_lane_in_coset,
+                                                     e4 *values_smem, bf *x_invs_smem, const bf two_inv_power, const InversePowerSource &inverse_power_source) {
+  const unsigned leaves_per_coset = 1 << (log_trace_len - log_values_per_leaf);
+  const unsigned initial_slot_in_leaf = threadIdx.y;
+  const unsigned initial_exchg_stride = leaves_per_coset << (log_values_per_leaf - 1);
+  // Bit-reversed jumps make the NTT-like transform's butterfly pairing direct.
+  const unsigned src_row_a = leaves_per_coset * initial_slot_in_leaf;
+  const unsigned src_row_b = src_row_a + initial_exchg_stride;
+
+  const e4 a = src.get_at_row(src_row_a);
+  const e4 b = src.get_at_row(src_row_b);
+
+  const unsigned coset_offset = coset << (inverse_power_source.params.omega_log_order - log_trace_len - log_lde_factor);
+  bf x_inv = inverse_power_source.get(((base_lane_in_coset + src_row_a) << (inverse_power_source.params.omega_log_order - log_trace_len)) + coset_offset);
+
+  if (log_values_per_leaf == 1) {
+    const e4 c = e4::mul(two_inv_power, e4::add(a, b));
+    const e4 d = e4::mul(bf::mul(x_inv, two_inv_power), e4::sub(a, b));
+    dst.set_at_slot(0, c);
+    dst.set_at_slot(1, d);
+    return;
+  }
+
+  e4 *smem_thread = values_smem + threadIdx.x;
+  bf *x_invs = x_invs_smem + threadIdx.x;
+
+  smem_thread[blockDim.x * initial_slot_in_leaf] = e4::mul(two_inv_power, e4::add(a, b));
+  smem_thread[blockDim.x * (initial_slot_in_leaf + blockDim.y)] = e4::mul(bf::mul(x_inv, two_inv_power), e4::sub(a, b));
+
+  for (unsigned stage = 1; stage < log_values_per_leaf - 1; stage++) {
+    const unsigned log_exchg_stride = log_values_per_leaf - 1 - stage;
+    const unsigned exchg_stride = 1 << log_exchg_stride;
+    const unsigned exchg_region = threadIdx.y >> log_exchg_stride;
+    const unsigned exchg_lane = threadIdx.y & (exchg_stride - 1);
+    const unsigned mid_stage_slot_in_leaf = 2 * exchg_stride * exchg_region + exchg_lane;
+
+    if (exchg_region == 0) {
+      x_inv = bf::sqr(x_inv);
+      x_invs[blockDim.x * exchg_lane] = x_inv;
+    }
+    __syncthreads();
+    const e4 stage_a = smem_thread[blockDim.x * mid_stage_slot_in_leaf];
+    const e4 stage_b = smem_thread[blockDim.x * (mid_stage_slot_in_leaf + exchg_stride)];
+    if (exchg_region != 0)
+      x_inv = x_invs[blockDim.x * exchg_lane];
+
+    const e4 c = e4::add(stage_a, stage_b);
+    const e4 d = e4::mul(x_inv, e4::sub(stage_a, stage_b));
+    smem_thread[blockDim.x * mid_stage_slot_in_leaf] = c;
+    smem_thread[blockDim.x * (mid_stage_slot_in_leaf + exchg_stride)] = d;
+
+    x_invs += blockDim.x * (blockDim.y >> stage);
+  }
+
+  const unsigned final_slot_in_leaf = 2 * threadIdx.y;
+  if (threadIdx.y == 0) {
+    x_inv = bf::sqr(x_inv);
+    x_invs[0] = x_inv;
+  }
+  __syncthreads();
+  if (threadIdx.y != 0)
+    x_inv = x_invs[0];
+  const e4 final_a = smem_thread[blockDim.x * final_slot_in_leaf];
+  const e4 final_b = smem_thread[blockDim.x * (final_slot_in_leaf + 1)];
+
+  if constexpr (Destination::ALIASES_VALUES_SMEM) {
+    // All final reads must finish before aliased stores reuse values_smem.
+    __syncthreads();
+  }
+  dst.set_at_slot(final_slot_in_leaf, e4::add(final_a, final_b));
+  dst.set_at_slot(final_slot_in_leaf + 1, e4::mul(x_inv, e4::sub(final_a, final_b)));
+}
+
+} // namespace airbender::ntt

--- a/gpu/ntt/native/whir_leaves.cu
+++ b/gpu/ntt/native/whir_leaves.cu
@@ -4,12 +4,30 @@
 #include <primitives/vectorized.cuh>
 
 #include "context.cuh"
+#include "whir_leaf_transform.cuh"
 
 using namespace ::airbender::primitives::field;
 using namespace ::airbender::primitives::memory;
 using namespace ::airbender::primitives::vectorized;
 
 namespace airbender::ntt {
+
+struct constant_inverse_power_source {
+  struct {
+    unsigned omega_log_order;
+  } params;
+
+  DEVICE_FORCEINLINE bf get(const unsigned idx) const { return get_inverse_twiddle_power(idx); }
+};
+
+struct matrix_leaf_destination {
+  static constexpr bool ALIASES_VALUES_SMEM = false;
+
+  vectorized_e4_matrix_setter<st_modifier::cs> dst;
+  unsigned leaves_per_coset;
+
+  DEVICE_FORCEINLINE void set_at_slot(const unsigned slot, const e4 value) { dst.set_at_row(leaves_per_coset * slot, value); }
+};
 
 // Implements "Improving running time via alternate domain evaluation" from page 15 of
 // https://eprint.iacr.org/2024/1586.pdf.
@@ -38,87 +56,12 @@ EXTERN __launch_bounds__(512, 2) __global__
   extern __shared__ __align__(16) uint8_t smem[];
 
   const unsigned leaves_per_coset = 1 << log_leaves_per_coset;
-  const unsigned initial_slot_in_leaf = threadIdx.y;
-  const unsigned initial_exchg_stride = leaves_per_coset << (log_values_per_leaf - 1);
-  // Grabbing inputs by jumping around in bitreversed order is convenient for the NTT-like transform.
-  const unsigned src_row_a = leaves_per_coset * initial_slot_in_leaf;
-  const unsigned src_row_b = src_row_a + initial_exchg_stride;
-
-  const e4 a = src.get_at_row(src_row_a);
-  const e4 b = src.get_at_row(src_row_b);
-
-  const unsigned coset_offset = coset << (OMEGA_LOG_ORDER - log_trace_len - log_lde_factor);
-  bf x_inv = get_inverse_twiddle_power(((base_lane_in_coset + src_row_a) << (OMEGA_LOG_ORDER - log_trace_len)) + coset_offset);
-
-  const bf two_inv_power = ab_inv_sizes[log_values_per_leaf];
-
-  if (log_values_per_leaf == 1) {
-    // We need to multiply by two_inv_power at some point. Might as well be here.
-    const e4 c = e4::mul(two_inv_power, e4::add(a, b));
-    const e4 d = e4::mul(bf::mul(x_inv, two_inv_power), e4::sub(a, b));
-
-    dst.set(c);
-    dst.set_at_row(initial_exchg_stride, d);
-  } else {
-    e4 *smem_thread = reinterpret_cast<e4 *>(smem) + threadIdx.x;
-    bf *x_invs = reinterpret_cast<bf *>(smem + 2 * blockDim.x * blockDim.y * sizeof(e4)) + threadIdx.x;
-
-    // We need to multiply by two_inv_power at some point. Might as well be here.
-    smem_thread[blockDim.x * initial_slot_in_leaf] = e4::mul(two_inv_power, e4::add(a, b));
-    smem_thread[blockDim.x * (initial_slot_in_leaf + blockDim.y)] = e4::mul(bf::mul(x_inv, two_inv_power), e4::sub(a, b));
-
-    // Middle stages (stage enumeration runs from 0 to log_values_per_leaf - 1)
-    for (unsigned stage = 1; stage < log_values_per_leaf - 1; stage++) {
-      const unsigned log_exchg_stride = log_values_per_leaf - 1 - stage;
-      const unsigned exchg_stride = 1 << log_exchg_stride;
-      const unsigned exchg_region = threadIdx.y >> log_exchg_stride;
-      const unsigned exchg_lane = threadIdx.y & (exchg_stride - 1);
-      const unsigned mid_stage_slot_in_leaf = 2 * exchg_stride * exchg_region + exchg_lane;
-
-      // Publish squared x_invs reusable across exchange regions
-      if (exchg_region == 0) {
-        x_inv = bf::sqr(x_inv);
-        x_invs[blockDim.x * exchg_lane] = x_inv;
-      }
-      // TODO: Evaluate performance impact of full syncthreads().
-      // If it's bad, remap threads so exchanges happen within warps, with a swizzled access pattern to avoid bank conflicts.
-      __syncthreads();
-      const e4 a = smem_thread[blockDim.x * mid_stage_slot_in_leaf];
-      const e4 b = smem_thread[blockDim.x * (mid_stage_slot_in_leaf + exchg_stride)];
-      if (exchg_region != 0)
-        x_inv = x_invs[blockDim.x * exchg_lane];
-      // not needed because
-      //  - in each stage, each thread acts on its touched smem in place,
-      //  - we use fresh smem to share x_invs each iteration
-      // __syncthreads();
-
-      const e4 c = e4::add(a, b);
-      const e4 d = e4::mul(x_inv, e4::sub(a, b));
-      smem_thread[blockDim.x * mid_stage_slot_in_leaf] = c;
-      smem_thread[blockDim.x * (mid_stage_slot_in_leaf + exchg_stride)] = d;
-
-      x_invs += blockDim.x * (blockDim.y >> stage);
-    }
-
-    // Last stage (special cased to elide a bit of work)
-    const unsigned final_slot_in_leaf = 2 * threadIdx.y;
-
-    // Leader publishes final squared x_inv
-    if (threadIdx.y == 0) {
-      x_inv = bf::sqr(x_inv);
-      x_invs[0] = x_inv;
-    }
-    __syncthreads();
-    if (threadIdx.y != 0)
-      x_inv = x_invs[0];
-    const e4 a = smem_thread[blockDim.x * final_slot_in_leaf];
-    const e4 b = smem_thread[blockDim.x * (final_slot_in_leaf + 1)];
-
-    const e4 c = e4::add(a, b);
-    const e4 d = e4::mul(x_inv, e4::sub(a, b));
-    dst.set_at_row(leaves_per_coset * final_slot_in_leaf, c);
-    dst.set_at_row(leaves_per_coset * (final_slot_in_leaf + 1), d);
-  }
+  e4 *values_smem = reinterpret_cast<e4 *>(smem);
+  bf *x_invs_smem = reinterpret_cast<bf *>(smem + 2 * blockDim.x * blockDim.y * sizeof(e4));
+  matrix_leaf_destination destination{dst, leaves_per_coset};
+  constant_inverse_power_source inverse_power_source{{OMEGA_LOG_ORDER}};
+  transform_whir_leaf_from_ntt(src, destination, log_trace_len, log_lde_factor, log_values_per_leaf, coset, base_lane_in_coset, values_smem, x_invs_smem,
+                               ab_inv_sizes[log_values_per_leaf], inverse_power_source);
 }
 
 } // namespace airbender::ntt

--- a/gpu/ntt/src/ntt_twiddles.rs
+++ b/gpu/ntt/src/ntt_twiddles.rs
@@ -211,11 +211,40 @@ fn generate_powers_dev<F: Field>(
     memory_copy(powers_dev, &powers_host)
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct WhirLeafTransformParams {
+    pub inverse_fine_values: *const BF,
+    pub inverse_fine_mask: u32,
+    pub inverse_fine_log_count: u32,
+    pub inverse_coarse_values: *const BF,
+    pub inverse_coarse_mask: u32,
+    pub two_inv_power: BF,
+    pub omega_log_order: u32,
+}
+
+// Cross-language layout drift guard. Keep these literal offsets synchronized
+// with `native/whir_leaf_transform.cuh`.
+const _: () = {
+    assert!(core::mem::size_of::<WhirLeafTransformParams>() == 40);
+    assert!(core::mem::align_of::<WhirLeafTransformParams>() == 8);
+    assert!(core::mem::offset_of!(WhirLeafTransformParams, inverse_fine_values) == 0);
+    assert!(core::mem::offset_of!(WhirLeafTransformParams, inverse_fine_mask) == 8);
+    assert!(core::mem::offset_of!(WhirLeafTransformParams, inverse_fine_log_count) == 12);
+    assert!(core::mem::offset_of!(WhirLeafTransformParams, inverse_coarse_values) == 16);
+    assert!(core::mem::offset_of!(WhirLeafTransformParams, inverse_coarse_mask) == 24);
+    assert!(core::mem::offset_of!(WhirLeafTransformParams, two_inv_power) == 28);
+    assert!(core::mem::offset_of!(WhirLeafTransformParams, omega_log_order) == 32);
+};
+
 pub struct DeviceContext {
     _powers_of_w_fine_for_ntt: DeviceAllocation<BF>,
     _powers_of_w_coarse_for_ntt: DeviceAllocation<BF>,
-    _powers_of_w_inv_fine_for_ntt: DeviceAllocation<BF>,
-    _powers_of_w_inv_coarse_for_ntt: DeviceAllocation<BF>,
+    powers_of_w_inv_fine_for_ntt: DeviceAllocation<BF>,
+    powers_of_w_inv_coarse_for_ntt: DeviceAllocation<BF>,
+    powers_of_w_fine_log_count: u32,
+    powers_of_w_coarse_log_count: u32,
+    inv_sizes_host: [BF; OMEGA_LOG_ORDER as usize + 1],
     _fwd_gmem_twiddles_coarse: DeviceAllocation<BF>,
     _inv_gmem_twiddles_coarse: DeviceAllocation<BF>,
     _fully_precomputed_bitrev_twiddles: DeviceAllocation<BF>,
@@ -376,8 +405,11 @@ impl DeviceContext {
         Ok(Self {
             _powers_of_w_fine_for_ntt: powers_of_w_fine_for_ntt,
             _powers_of_w_coarse_for_ntt: powers_of_w_coarse_for_ntt,
-            _powers_of_w_inv_fine_for_ntt: powers_of_w_inv_fine_for_ntt,
-            _powers_of_w_inv_coarse_for_ntt: powers_of_w_inv_coarse_for_ntt,
+            powers_of_w_inv_fine_for_ntt,
+            powers_of_w_inv_coarse_for_ntt,
+            powers_of_w_fine_log_count,
+            powers_of_w_coarse_log_count,
+            inv_sizes_host,
             _fwd_gmem_twiddles_coarse: fwd_gmem_twiddles_coarse,
             _inv_gmem_twiddles_coarse: inv_gmem_twiddles_coarse,
             _fully_precomputed_bitrev_twiddles: fully_precomputed_bitrev_twiddles,
@@ -395,5 +427,44 @@ impl DeviceContext {
     /// Panics if the config is not in the fixed set built at `create`.
     pub fn coupled_triangle(&self, log_n: u32, log_vpt: u32) -> &DeviceSlice<BF> {
         self.dit_triangles.coupled(log_n, log_vpt)
+    }
+
+    pub fn whir_leaf_transform_params(&self, log_values_per_leaf: u32) -> WhirLeafTransformParams {
+        assert!((1..=5).contains(&log_values_per_leaf));
+        WhirLeafTransformParams {
+            inverse_fine_values: self.powers_of_w_inv_fine_for_ntt.as_ptr(),
+            inverse_fine_mask: (1 << self.powers_of_w_fine_log_count) - 1,
+            inverse_fine_log_count: self.powers_of_w_fine_log_count,
+            inverse_coarse_values: self.powers_of_w_inv_coarse_for_ntt.as_ptr(),
+            inverse_coarse_mask: (1 << self.powers_of_w_coarse_log_count) - 1,
+            two_inv_power: self.inv_sizes_host[log_values_per_leaf as usize],
+            omega_log_order: OMEGA_LOG_ORDER,
+        }
+    }
+}
+
+#[cfg(all(test, not(no_cuda)))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn whir_leaf_transform_params_cover_all_leaf_widths() {
+        let context = DeviceContext::create(13).unwrap();
+        let two_inv = BF::new(2).inverse().unwrap();
+        let mut expected_two_inv_power = BF::ONE;
+
+        for log_values_per_leaf in 1..=5 {
+            expected_two_inv_power.mul_assign(&two_inv);
+            let params = context.whir_leaf_transform_params(log_values_per_leaf);
+
+            assert_eq!(params.inverse_fine_log_count, OMEGA_LOG_ORDER - 13);
+            assert_eq!(
+                params.inverse_fine_mask,
+                (1 << params.inverse_fine_log_count) - 1
+            );
+            assert_eq!(params.inverse_coarse_mask, (1 << 13) - 1);
+            assert_eq!(params.omega_log_order, OMEGA_LOG_ORDER);
+            assert_eq!(params.two_inv_power, expected_two_inv_power);
+        }
     }
 }

--- a/gpu/trace/AGENTS.md
+++ b/gpu/trace/AGENTS.md
@@ -3,8 +3,10 @@
 `gpu_trace` owns witness generation (`witness/**`) and trace commit/holder
 (`trace/**`): the machinery that turns a compiled circuit + captured
 non-determinism into a device-resident trace and commits it (LDE, leaf
-transform, Merkle-tree build). It carries the `gpu_trace_native` CUDA archive
-(the tree that used to live under `circuit_prover/native/witness/`).
+transform, Merkle-tree build). Recursive-WHIR oracle commitment is owned by
+`gpu_whir/src/oracle_commit.rs`. This crate carries the `gpu_trace_native`
+CUDA archive (the tree that used to live under
+`circuit_prover/native/witness/`).
 
 ## Layer position
 
@@ -18,14 +20,13 @@ it, never the reverse.
 
 ## GPU Scheduling Contract
 
-`trace::holder` schedules GPU work directly (LDE, leaf-transform, and
-leaf-commit kernels; the Merkle-tree build; the trace holder's parallel-commit
-use of `side_stream`). Before editing anything under `src/trace/` or
+`trace::holder` schedules GPU work directly (LDE, leaf-transform and
+leaf-commit kernels, and Merkle-tree builds). Before editing anything under `src/trace/` or
 `src/witness/` that launches kernels, schedules host callbacks, or manages
 streams, read [`../docs/gpu_scheduling_contract.md`](../docs/gpu_scheduling_contract.md)
-in full — in particular the *Side stream* section, which documents this
-crate's `commit_trace_from_ntt_single_tree` (`src/trace/holder/mod.rs`) as the
-only current consumer of `ProverContext::get_side_stream()`.
+in full. The contract's *Side stream* section now belongs to `gpu_whir`'s
+recursive-oracle scheduler; `gpu_trace` does not call
+`ProverContext::get_side_stream()`.
 
 ## Upstream imports
 

--- a/gpu/trace/src/trace/holder/mod.rs
+++ b/gpu/trace/src/trace/holder/mod.rs
@@ -1,9 +1,8 @@
 use blake2s_u32::BLAKE2S_DIGEST_SIZE_U32_WORDS;
-use era_cudart::event::{CudaEvent, CudaEventCreateFlags};
 use era_cudart::memory::memory_copy_async;
 use era_cudart::result::CudaResult;
 use era_cudart::slice::DeviceSlice;
-use era_cudart::stream::{CudaStream, CudaStreamWaitEventFlags};
+use era_cudart::stream::CudaStream;
 
 use crate::upstream::MerkleTreeCapVarLength;
 use gpu_core::allocator::tracker::AllocationPlacement;
@@ -24,8 +23,7 @@ use gpu_hash::blake2s::{
 };
 use gpu_ntt::ntt::{
     bitreversed_monomials_to_natural_evals_multi_coset, hypercube_x1_msb_evals_to_x1_msb_monomials,
-    lde_with_coset_range, log_size_supports_transposed_monomials,
-    transform_whir_leaves_from_ntt_in_place_multi_coset, MAX_LOG_N_FOR_SINGLE_KERNEL_LDE,
+    log_size_supports_transposed_monomials,
 };
 use gpu_prover_context::ProverContext;
 
@@ -86,11 +84,7 @@ pub struct TraceHolder<T> {
     pub unified_device_cap: Option<DeviceAllocation<Digest>>,
 }
 
-// `pub` methods below (`new`, `commit_all_into`, `get_uninit_*`, `get_consolidated_*`,
-// `whir_lde_and_commit_all*`, `schedule_query_*`, …) form `TraceHolder`'s cross-crate
-// API surface: apex production (`prover::{gkr,whir,proof}`) drives the holder across the
-// Task-8 split (bridge removed in Task 12). Methods tagged `#[doc(hidden)]` are the
-// test-only readers the apex test suites reach.
+// Public methods are cross-crate production APIs; `#[doc(hidden)]` methods are test seams.
 impl<T> TraceHolder<T> {
     pub fn new(
         log_domain_size: u32,
@@ -198,6 +192,17 @@ impl<T> TraceHolder<T> {
             .expect("unified device cap must be materialized before access")
     }
 
+    /// Installs a private unified cap after an external scheduler has filled it.
+    #[doc(hidden)]
+    pub fn install_unified_device_cap(&mut self, cap: DeviceAllocation<Digest>) {
+        assert_eq!(cap.len(), 1usize << self.log_tree_cap_size);
+        assert!(
+            self.unified_device_cap.is_none(),
+            "unified device cap was already installed",
+        );
+        self.unified_device_cap = Some(cap);
+    }
+
     // test-reference readers: gpu_circuit_prover's test suites reach this across the crate boundary.
     #[doc(hidden)]
     pub fn get_hypercube_evals(&self) -> &DeviceSlice<T> {
@@ -293,6 +298,20 @@ impl<T> TraceHolder<T> {
             }
             TreesHolder::None => None,
         }
+    }
+
+    /// Returns disjoint mutable views of the unmaterialized consolidated
+    /// coset storage and tree storage for an external commit scheduler.
+    pub fn get_uninit_cosets_and_tree_mut(&mut self) -> (&mut DeviceSlice<T>, &mut TreesHolder) {
+        assert!(
+            !self.cosets_materialized,
+            "cosets are already marked materialized",
+        );
+        let cosets = match &mut self.cosets {
+            CosetsHolder::Full(backing) => &mut backing[..],
+            CosetsHolder::None(_) => panic!("cosets storage is not allocated"),
+        };
+        (cosets, &mut self.trees)
     }
 
     /// Shared-borrow per-coset tree slice. Returns the subrange of the
@@ -630,221 +649,6 @@ impl TraceHolder<BF> {
         self.commit_all_into(dst_u32, context)
     }
 
-    /// Natural-NTT variant of `commit_all_into`: the caller has populated the
-    /// cosets backing with `lde_factor * trace_len * src_cols_per_coset` BFs in
-    /// the natural multi-coset NTT layout (coset-major outer, column-major
-    /// inner). Builds a single flat merkle tree using
-    /// `commit_trace_from_ntt_single_tree`, then gathers the cap via the same
-    /// `gather_tree_caps_inline` path `commit_all_into` uses.
-    ///
-    /// Asserted shape: `self.log_lde_factor == 0`, `self.log_rows_per_leaf == 0`
-    /// (the WHIR oracle's TraceHolder shape). The natural lde factor and
-    /// per-leaf size are passed as arguments — they live outside the TraceHolder
-    /// abstraction.
-    pub fn whir_lde_and_commit_all_into(
-        &mut self,
-        inputs_matrix: &DeviceMatrixChunk<BF>,
-        dst_u32: &mut DeviceSlice<u32>,
-        log_trace_len: u32,
-        natural_log_lde_factor: u32,
-        log_values_per_leaf: u32,
-        src_cols_per_coset: usize,
-        transform_leaves_to_multilinear_coeffs: bool,
-        context: &ProverContext,
-    ) -> CudaResult<()> {
-        assert_eq!(
-            self.log_lde_factor, 0,
-            "whir_lde_and_commit_all_into: TraceHolder must be the WHIR-oracle shape (log_lde_factor = 0)"
-        );
-        assert_eq!(
-            self.log_rows_per_leaf, 0,
-            "whir_lde_and_commit_all_into: TraceHolder must be the WHIR-oracle shape (log_rows_per_leaf = 0)"
-        );
-        assert!(
-            !self.cosets_materialized,
-            "whir_lde_and_commit_all_into: cosets already materialized"
-        );
-        let stream = context.get_exec_stream();
-        let cap_size = 1usize << self.log_tree_cap_size;
-        assert_eq!(
-            dst_u32.len(),
-            cap_size * BLAKE2S_DIGEST_SIZE_U32_WORDS,
-            "whir_lde_and_commit_all_into dst_u32 length must match cap_size * DIGEST_U32_WORDS",
-        );
-
-        // Snapshot the cosets backing as a raw const slice so we can borrow
-        // `self.cosets` shared and `self.trees` mutable in the same scope.
-        let evals_ptr = match &mut self.cosets {
-            CosetsHolder::Full(backing) => backing.as_mut_ptr(),
-            CosetsHolder::None(_) => {
-                panic!("cosets not allocated — call ensure_cosets_materialized first")
-            }
-        };
-        let lde_factor = 1usize << natural_log_lde_factor;
-        let trace_len = 1usize << log_trace_len;
-        let evals_total_len = lde_factor * trace_len * src_cols_per_coset;
-        // SAFETY: cosets backing remains alive for `&self`; evals range is
-        // disjoint from the trees backing.
-        let ntt_output: &mut DeviceSlice<BF> =
-            unsafe { DeviceSlice::from_raw_parts_mut(evals_ptr, evals_total_len) };
-
-        let total_leaf_count_log2 = (log_trace_len - log_values_per_leaf) + natural_log_lde_factor;
-        let total_leaf_count = 1usize << total_leaf_count_log2;
-        let per_coset_tree_full_len = total_leaf_count << 1;
-        let log_subtree_cap_size = self.log_tree_cap_size; // log_lde_factor == 0
-        let cap_words_per_coset =
-            ((1usize << log_subtree_cap_size) * BLAKE2S_DIGEST_SIZE_U32_WORDS) as u32;
-
-        match &mut self.trees {
-            TreesHolder::Full(backing) => {
-                commit_trace_from_ntt_single_tree(
-                    inputs_matrix,
-                    ntt_output,
-                    backing,
-                    log_trace_len,
-                    natural_log_lde_factor,
-                    log_values_per_leaf,
-                    self.log_tree_cap_size,
-                    src_cols_per_coset,
-                    transform_leaves_to_multilinear_coeffs,
-                    context,
-                )?;
-            }
-            TreesHolder::Partial(backing) => {
-                // Partial mode: the single flat tree's top
-                // (leaves + PARTIAL_TREE_REDUCTION_LAYERS-1 layers) lives in a
-                // transient slab; the bottom (the rest of the layers) lives in
-                // `backing`.
-                let tree_top_len = per_coset_tree_full_len;
-                let mut tree_top =
-                    context.alloc::<Digest>(tree_top_len, AllocationPlacement::BestFit)?;
-                // Build top: leaves + (PARTIAL_TREE_REDUCTION_LAYERS - 1) layers.
-                // commit_trace_from_ntt_single_tree builds leaves + (layers_count
-                // - 1) node layers; pass log_tree_cap_size such that layers_count
-                // = PARTIAL_TREE_REDUCTION_LAYERS.
-                let top_log_cap = total_leaf_count_log2 + 1 - PARTIAL_TREE_REDUCTION_LAYERS;
-                commit_trace_from_ntt_single_tree(
-                    inputs_matrix,
-                    ntt_output,
-                    &mut tree_top[..],
-                    log_trace_len,
-                    natural_log_lde_factor,
-                    log_values_per_leaf,
-                    top_log_cap,
-                    src_cols_per_coset,
-                    transform_leaves_to_multilinear_coeffs,
-                    context,
-                )?;
-                // Bottom: read the "top layer" digests out of `tree_top` and
-                // continue the merkle tree into `backing` for the remaining
-                // layers.
-                let bottom_layers_count = total_leaf_count_log2 + 1
-                    - PARTIAL_TREE_REDUCTION_LAYERS
-                    - self.log_tree_cap_size;
-                let tree_bottom_len = tree_top_len >> PARTIAL_TREE_REDUCTION_LAYERS;
-                assert_eq!(backing.len(), tree_bottom_len);
-                let values = &tree_top[tree_top_len - 2 * tree_bottom_len..][..tree_bottom_len];
-                gpu_hash::blake2s::build_merkle_tree_nodes(
-                    values,
-                    backing,
-                    bottom_layers_count,
-                    stream,
-                )?;
-                let _ = tree_top;
-            }
-            TreesHolder::None => {
-                panic!("whir_lde_and_commit_all_into: TreesCacheMode::CacheNone is not supported; use CachePartial or CacheFull");
-            }
-        }
-
-        // Cap gather: the WHIR oracle has log_lde_factor == 0, so the cap lives
-        // at the tail of the single tree (no per-coset slabs to merge). Cap
-        // region offset is `tree_len - 2 * cap_size`.
-        match &self.trees {
-            TreesHolder::Full(backing) => {
-                let cap_offset_in_digests =
-                    per_coset_tree_full_len - (1usize << (log_subtree_cap_size + 1));
-                let cap_offset_in_u32_words = cap_offset_in_digests * BLAKE2S_DIGEST_SIZE_U32_WORDS;
-                let stride_in_u32_words =
-                    (per_coset_tree_full_len * BLAKE2S_DIGEST_SIZE_U32_WORDS) as u32;
-                let base_u32 = backing.as_ptr() as *const u32;
-                // SAFETY: cap_offset_in_u32_words is within per_coset_tree_full_len.
-                let cap_base = unsafe { base_u32.add(cap_offset_in_u32_words) };
-                gather_tree_caps_inline(
-                    cap_base,
-                    cap_words_per_coset,
-                    stride_in_u32_words,
-                    /*log_lde_factor=*/ 0,
-                    dst_u32,
-                    stream,
-                )?;
-            }
-            TreesHolder::Partial(backing) => {
-                // Partial: cap lives in the bottom slab now. The bottom slab is
-                // `tree_bottom_len = per_coset_tree_full_len >>
-                // PARTIAL_TREE_REDUCTION_LAYERS` digests; the cap is the tail
-                // `2 * cap_size`.
-                let tree_bottom_len = per_coset_tree_full_len >> PARTIAL_TREE_REDUCTION_LAYERS;
-                let cap_offset_in_digests =
-                    tree_bottom_len - (1usize << (log_subtree_cap_size + 1));
-                let cap_offset_in_u32_words = cap_offset_in_digests * BLAKE2S_DIGEST_SIZE_U32_WORDS;
-                let stride_in_u32_words = (tree_bottom_len * BLAKE2S_DIGEST_SIZE_U32_WORDS) as u32;
-                let base_u32 = backing.as_ptr() as *const u32;
-                let cap_base = unsafe { base_u32.add(cap_offset_in_u32_words) };
-                gather_tree_caps_inline(
-                    cap_base,
-                    cap_words_per_coset,
-                    stride_in_u32_words,
-                    /*log_lde_factor=*/ 0,
-                    dst_u32,
-                    stream,
-                )?;
-            }
-            TreesHolder::None => unreachable!(),
-        }
-
-        Ok(())
-    }
-
-    /// Wrapper around `whir_lde_and_commit_all_into` that allocates a private
-    /// `unified_device_cap` (mirrors `commit_all`'s relationship to
-    /// `commit_all_into`). Used by `#[cfg(test)]` callers that don't have a slab
-    /// destination handy.
-    pub fn whir_lde_and_commit_all(
-        &mut self,
-        inputs_matrix: &DeviceMatrixChunk<BF>,
-        log_trace_len: u32,
-        natural_log_lde_factor: u32,
-        log_values_per_leaf: u32,
-        src_cols_per_coset: usize,
-        transform_leaves_to_multilinear_coeffs: bool,
-        context: &ProverContext,
-    ) -> CudaResult<()> {
-        let cap_size = 1usize << self.log_tree_cap_size;
-        let unified_cap: DeviceAllocation<Digest> =
-            context.alloc(cap_size, AllocationPlacement::BestFit)?;
-        assert!(self.unified_device_cap.replace(unified_cap).is_none());
-        let unified_cap_mut = self
-            .unified_device_cap
-            .as_mut()
-            .expect("unified_device_cap was just placed above");
-        // SAFETY: identical reborrow to `commit_all`; see that function's SAFETY
-        // comment.
-        let dst_ptr = unified_cap_mut.as_mut_ptr() as *mut u32;
-        let dst_len = cap_size * BLAKE2S_DIGEST_SIZE_U32_WORDS;
-        let dst_u32 = unsafe { DeviceSlice::from_raw_parts_mut(dst_ptr, dst_len) };
-        self.whir_lde_and_commit_all_into(
-            inputs_matrix,
-            dst_u32,
-            log_trace_len,
-            natural_log_lde_factor,
-            log_values_per_leaf,
-            src_cols_per_coset,
-            transform_leaves_to_multilinear_coeffs,
-            context,
-        )
-    }
-
     /// Builds and caches partial trees from already-materialized coset evaluations.
     /// The caller must set `self.trees` to `TreesHolder::Partial(...)` with allocated
     /// storage before calling this method.
@@ -1146,50 +950,6 @@ impl TraceHolder<BF> {
         Ok(merkle_paths)
     }
 
-    /// Test-only sibling of `get_query_merkle_paths` for the WHIR oracle's
-    /// natural-NTT cosets backing. Allocates a device path slab + invokes
-    /// `schedule_query_merkle_paths_into_from_ntt`, then copies asynchronously
-    /// to host. Caller is responsible for stream synchronization.
-    // test-reference readers: gpu_circuit_prover's test suites reach this across the crate boundary.
-    #[doc(hidden)]
-    pub fn get_query_merkle_paths_from_ntt(
-        &mut self,
-        indexes: &DeviceSlice<u32>,
-        log_trace_len: u32,
-        natural_log_lde_factor: u32,
-        log_values_per_leaf: u32,
-        log_src_cols_per_coset: u32,
-        context: &ProverContext,
-    ) -> CudaResult<HostAllocation<[Digest]>> {
-        let queries_count = indexes.len();
-        let (_, digests_len) = self.query_merkle_path_layout(queries_count);
-        let mut d_merkle_paths: DeviceAllocation<Digest> =
-            context.alloc(digests_len, AllocationPlacement::BestFit)?;
-        // Reinterpret the Digest slab as u32 for the kernel's signature. SAFETY:
-        // `Digest = [u32; STATE_SIZE]` has the same byte layout; both views
-        // alias the same exclusive allocation for the duration of the call.
-        let words_len = digests_len * gpu_hash::blake2s::STATE_SIZE;
-        let d_merkle_paths_u32 = unsafe {
-            DeviceSlice::from_raw_parts_mut(d_merkle_paths.as_mut_ptr() as *mut u32, words_len)
-        };
-        self.schedule_query_merkle_paths_into_from_ntt(
-            indexes,
-            d_merkle_paths_u32,
-            log_trace_len,
-            natural_log_lde_factor,
-            log_values_per_leaf,
-            log_src_cols_per_coset,
-            context,
-        )?;
-        let mut merkle_paths = unsafe { context.alloc_host_uninit_slice(digests_len) };
-        memory_copy_async(
-            &mut merkle_paths,
-            &d_merkle_paths,
-            context.get_exec_stream(),
-        )?;
-        Ok(merkle_paths)
-    }
-
     // test-reference readers: gpu_circuit_prover's test suites reach this across the crate boundary.
     #[doc(hidden)]
     pub fn get_leafs_and_merkle_paths(
@@ -1279,241 +1039,6 @@ pub(crate) fn commit_trace_multi_coset(
         columns_count,
         stream,
     )
-}
-
-/// Mirror of `commit_trace_multi_coset` for the WHIR oracle path: builds a
-/// single flat merkle tree across all `cosets_in_tile = 1 <<
-/// natural_log_lde_factor` cosets, reading the natural-NTT cosets layout via
-/// `hash_leaves_from_ntt_multi_coset` and constructing node layers
-/// with the single-tree `build_merkle_tree_nodes` (NOT the multi-coset
-/// variant, because the WHIR oracle's `TraceHolder` has `log_lde_factor = 0`
-/// and thus owns ONE flat tree across all natural cosets).
-///
-/// `natural_log_lde_factor` is the actual coset count of the NTT output
-/// (typically `whir_steps_lde_factors[i].trailing_zeros()`), NOT the
-/// `TraceHolder`'s `log_lde_factor`.
-pub(crate) fn commit_trace_from_ntt_single_tree(
-    inputs_matrix: &DeviceMatrixChunk<BF>,
-    ntt_output: &mut DeviceSlice<BF>,
-    trees_backing: &mut DeviceSlice<Digest>,
-    log_trace_len: u32,
-    natural_log_lde_factor: u32,
-    log_values_per_leaf: u32,
-    log_tree_cap_size: u32,
-    src_cols_per_coset: usize,
-    transform_leaves_to_multilinear_coeffs: bool,
-    context: &ProverContext,
-) -> CudaResult<()> {
-    assert!(natural_log_lde_factor >= 1);
-    assert!(log_trace_len >= log_values_per_leaf);
-    let trace_len = 1 << log_trace_len;
-    let packed_leaf_count = 1usize << (log_trace_len - log_values_per_leaf);
-    let total_leaf_count = packed_leaf_count
-        .checked_mul(1 << natural_log_lde_factor)
-        .expect("total_leaf_count overflow");
-    assert_eq!(trees_backing.len(), total_leaf_count << 1);
-    let total_leaf_count_log2 = (log_trace_len - log_values_per_leaf) + natural_log_lde_factor;
-    assert!(log_tree_cap_size <= total_leaf_count_log2);
-    let layers_count = total_leaf_count_log2 + 1 - log_tree_cap_size;
-    let (leaves, nodes) = trees_backing.split_at_mut(total_leaf_count);
-
-    let device_properties = context.get_device_properties();
-    let ntt_ctx = context.ntt_device_context();
-    // Recursive WHIR folds to a small trace (trace_len_log2 <= 13), the DIT
-    // forward-NTT range, which needs a pooled d-table scratch (len >= N).
-    // Allocate from the stream-ordered pool so this stays enqueue-only per
-    // the GPU scheduling contract; the handle outlives the launches below.
-    // Outside the DIT range the compact path ignores the scratch, so the
-    // allocation is skipped entirely.
-    let mut d_scratch = if log_trace_len <= 13 {
-        Some(context.alloc::<BF>(trace_len, AllocationPlacement::BestFit)?)
-    } else {
-        None
-    };
-
-    // L2 chunking doesn't help for whir stages where we use oneshot LDE kernels
-    // (log_n <= MAX_LOG_N_FOR_SINGLE_KERNEL_LDE).
-    // So the strategy is:
-    // If log_n > MAX_LOG_N_FOR_SINGLE_KERNEL_LDE, include NTTs in the chunked sequence.
-    // If log_n <= MAX_LOG_N_FOR_SINGLE_KERNEL_LDE, launch oneshot LDE kernel for all cosets,
-    // then do chunking for leaf transform and leaf commits.
-    let include_lde_in_l2_persistence_chain =
-        log_trace_len as usize > MAX_LOG_N_FOR_SINGLE_KERNEL_LDE;
-    let total_cosets = 1 << natural_log_lde_factor;
-    // Trial-and-error-based heuristic that appears to give reasonable performance:
-    let l2_bytes_with_safety_margin = if include_lde_in_l2_persistence_chain {
-        // If we're chunking LDE, leaf transform, and leaf commitment, use 1/2 of L2.
-        device_properties.l2_cache_size_bytes >> 1
-    } else {
-        // If we're only chunking leaf transform and leaf commitment, use 1/4 of L2.
-        device_properties.l2_cache_size_bytes >> 2
-    };
-    let single_bf_col_bytes = std::mem::size_of::<BF>() << log_trace_len;
-    let single_coset_bytes = src_cols_per_coset * single_bf_col_bytes;
-
-    let half_l2_bytes_with_safety_margin = l2_bytes_with_safety_margin >> 1;
-    let (mut cosets_in_tile_chunk, mut num_streams) =
-        if single_coset_bytes > half_l2_bytes_with_safety_margin {
-            (1, 1)
-        } else {
-            let nearest = half_l2_bytes_with_safety_margin / single_coset_bytes;
-            if nearest.is_power_of_two() {
-                (nearest, 2)
-            } else {
-                (nearest.next_power_of_two() >> 1, 2)
-            }
-        };
-
-    if total_cosets > cosets_in_tile_chunk {
-        assert_eq!(total_cosets % cosets_in_tile_chunk, 0);
-    }
-
-    // There are two scenarios where chunking isn't beneficial.
-    //   - include_lde_in_l2_persistence_chain = false, transform_leaves_to_multilinear_coeffs = false
-    //       Here the only op eligible for chunking is leaf commitment.
-    //       A single-op "chain" makes no sense.
-    //   - The final production whir stage, where the total amount of data is much smaller.
-    // In these cases, we disable chunking by overriding the "chunk" to contain all cosets.
-    let is_last_production_whir_stage = (log_trace_len - log_values_per_leaf) == 1;
-    if (!include_lde_in_l2_persistence_chain && !transform_leaves_to_multilinear_coeffs)
-        || is_last_production_whir_stage
-    {
-        num_streams = 1;
-        cosets_in_tile_chunk = total_cosets;
-    }
-
-    let mut ntt_output_matrix = DeviceMatrixMut::new(ntt_output, trace_len);
-
-    let (start_event, end_event) = if num_streams > 1 {
-        (
-            Some(CudaEvent::create_with_flags(
-                CudaEventCreateFlags::DISABLE_TIMING,
-            )?),
-            Some(CudaEvent::create_with_flags(
-                CudaEventCreateFlags::DISABLE_TIMING,
-            )?),
-        )
-    } else {
-        (None, None)
-    };
-
-    let mut occupancy_hint_numerator = 1;
-    let mut occupancy_hint_denominator = 1;
-    let exec_stream = context.get_exec_stream();
-    let side_stream = context.get_side_stream();
-    let streams = [exec_stream, side_stream];
-
-    if !include_lde_in_l2_persistence_chain {
-        let scratch_opt = d_scratch.as_mut().map(|s| &mut s[..]);
-        lde_with_coset_range(
-            inputs_matrix,
-            ntt_output_matrix.slice_mut(),
-            log_trace_len as usize,
-            natural_log_lde_factor as usize,
-            total_cosets, // cosets_in_tile,
-            0,            // coset_index_base,
-            src_cols_per_coset,
-            occupancy_hint_numerator,
-            occupancy_hint_denominator,
-            ntt_ctx,
-            scratch_opt,
-            streams[0],
-            device_properties,
-        )?;
-    }
-
-    if num_streams > 1 {
-        occupancy_hint_numerator = 5;
-        occupancy_hint_denominator = 8;
-        start_event.as_ref().unwrap().record(streams[0])?;
-        streams[1].wait_event(
-            start_event.as_ref().unwrap(),
-            CudaStreamWaitEventFlags::DEFAULT,
-        )?;
-    }
-
-    for coset_index_base in (0..total_cosets).step_by(num_streams * cosets_in_tile_chunk) {
-        let mut helpers_per_stream = Vec::with_capacity(2);
-        for i in 0..num_streams {
-            let coset_index_base_this_stream = coset_index_base + i * cosets_in_tile_chunk;
-            if coset_index_base_this_stream < total_cosets {
-                let cosets_in_tile = std::cmp::min(
-                    cosets_in_tile_chunk,
-                    total_cosets - coset_index_base_this_stream,
-                );
-                let offset = src_cols_per_coset * trace_len * coset_index_base_this_stream;
-                helpers_per_stream.push((coset_index_base_this_stream, cosets_in_tile, offset));
-            }
-        }
-        // If we're using two streams, dispatch with breadth-first ping pong pattern
-        for (i, &(coset_index_base_this_stream, cosets_in_tile, offset)) in
-            helpers_per_stream.iter().enumerate()
-        {
-            if include_lde_in_l2_persistence_chain {
-                let scratch_opt = d_scratch.as_mut().map(|s| &mut s[..]);
-                lde_with_coset_range(
-                    inputs_matrix,
-                    &mut (ntt_output_matrix.slice_mut())[offset..],
-                    log_trace_len as usize,
-                    natural_log_lde_factor as usize,
-                    cosets_in_tile,
-                    coset_index_base_this_stream,
-                    src_cols_per_coset,
-                    occupancy_hint_numerator,
-                    occupancy_hint_denominator,
-                    ntt_ctx,
-                    scratch_opt,
-                    streams[i],
-                    device_properties,
-                )?;
-            }
-        }
-        if transform_leaves_to_multilinear_coeffs {
-            for (i, &(coset_index_base_this_stream, cosets_in_tile, _offset)) in
-                helpers_per_stream.iter().enumerate()
-            {
-                transform_whir_leaves_from_ntt_in_place_multi_coset(
-                    &mut ntt_output_matrix,
-                    log_trace_len,
-                    natural_log_lde_factor,
-                    log_values_per_leaf,
-                    coset_index_base_this_stream as u32,
-                    cosets_in_tile as u32,
-                    streams[i],
-                )?;
-            }
-        }
-        for (i, &(coset_index_base_this_stream, cosets_in_tile, offset)) in
-            helpers_per_stream.iter().enumerate()
-        {
-            gpu_hash::blake2s::hash_leaves_from_ntt_multi_coset(
-                &(ntt_output_matrix.slice())[offset..],
-                leaves,
-                log_values_per_leaf,
-                src_cols_per_coset as u32,
-                natural_log_lde_factor,
-                coset_index_base_this_stream as u32,
-                cosets_in_tile,
-                packed_leaf_count,
-                trace_len as u32,
-                streams[i],
-            )?;
-        }
-    }
-
-    if num_streams > 1 {
-        end_event.as_ref().unwrap().record(side_stream)?;
-        exec_stream.wait_event(
-            end_event.as_ref().unwrap(),
-            CudaStreamWaitEventFlags::DEFAULT,
-        )?;
-    }
-
-    // Single-tree node layers: build_merkle_tree_nodes operates on a flat
-    // `[leaves | nodes]` slab. `layers_count - 1` because the leaf layer is
-    // already written; the function builds the remaining `layers_count - 1`
-    // node layers.
-    gpu_hash::blake2s::build_merkle_tree_nodes(leaves, nodes, layers_count - 1, exec_stream)
 }
 
 /// Takes one big

--- a/gpu/whir/AGENTS.md
+++ b/gpu/whir/AGENTS.md
@@ -2,7 +2,8 @@
 
 `gpu_whir` owns the WHIR polynomial-commitment folding rounds (`fold/`) and
 the PoW-verify/query-index scheduling (`pow.rs`), plus the recursive WHIR
-extension oracle (`lib.rs`). It carries the `gpu_whir_native` CUDA archive
+extension oracle (`lib.rs`) and its LDE/Merkle commitment scheduler
+(`oracle_commit.rs`). It carries the `gpu_whir_native` CUDA archive
 (the WHIR/PoW protocol kernels that used to live under
 `circuit_prover/native/whir/`).
 
@@ -18,9 +19,10 @@ it, never the reverse.
 
 ## GPU Scheduling Contract
 
-`fold` and `pow` schedule GPU work directly (kernel launches, host callbacks,
-pool allocations, D2H readback for query answers). Before editing either, or
-anything else that launches kernels or manages streams, read
+`fold`, `pow`, and `oracle_commit` schedule GPU work directly (kernel launches,
+host callbacks, pool allocations, D2H readback for query answers, and the
+recursive-commit `side_stream` fork/join). Before editing them, or anything
+else that launches kernels or manages streams, read
 [`../docs/gpu_scheduling_contract.md`](../docs/gpu_scheduling_contract.md) in
 full.
 
@@ -56,7 +58,7 @@ rather than letting the duplicate drift by convention.
 - **Archive / `links` key**: `gpu_whir_native` (`build.rs`:
   `gpu_native_build::CudaArchive::new("gpu_whir_native", "GPU_WHIR").build()`
   — no `export_include`; nothing above this crate includes its headers).
-- **Kernel count**: 17 `__global__` kernels (verified by grep, across
+- **Kernel count**: 20 `__global__` kernels (verified by grep, across
   `whir/{accumulate_eq,columns,fold,leaves}.cu`). No `__constant__` symbols
   (all 8 cluster-wide ones live in `gpu_gkr`).
 - **Namespace**: `airbender::whir`.
@@ -64,9 +66,11 @@ rather than letting the duplicate drift by convention.
   `gkr/support/{eq_inline,kernel_helpers}.cuh` via
   `DEP_GPU_GKR_NATIVE_INCLUDE` (forwarded because `gpu_gkr`'s build.rs sets
   `export_include(true)`); `leaves.cu` includes `gpu_hash`'s `hash.cuh` via
-  `DEP_GPU_HASH_NATIVE_INCLUDE`. Both directories resolve automatically as
-  CMake `-D` defines that `gpu_native_build` forwards. This crate also reads
-  `gpu_core`'s base headers. `deterministic_pow` is not a native `#define`
+  `DEP_GPU_HASH_NATIVE_INCLUDE`, and gpu_ntt's reusable
+  `whir_leaf_transform.cuh` via `DEP_GPU_NTT_NATIVE_INCLUDE`. All three
+  directories resolve automatically as CMake `-D` defines that
+  `gpu_native_build` forwards. This crate also reads gpu_core's base headers.
+  `deterministic_pow` is not a native `#define`
   here: the PoW search kernel itself lives in `gpu_hash`, so
   `gpu_whir/deterministic_pow` forwards to `gpu_hash/deterministic_pow`
   (and to `prover/deterministic_pow`, above) instead of defining

--- a/gpu/whir/build.rs
+++ b/gpu/whir/build.rs
@@ -3,7 +3,8 @@ fn main() {
     // `gkr/support/{eq_inline,kernel_helpers}.cuh` via DEP_GPU_GKR_NATIVE_INCLUDE
     // (gpu_gkr's build.rs `export_include(true)` emits it, auto-forwarded as a
     // CMake -D by gpu_native_build). `leaves.cu` includes gpu_hash's `hash.cuh`
-    // via DEP_GPU_HASH_NATIVE_INCLUDE. `deterministic_pow` is not defined here:
+    // and gpu_ntt's reusable WHIR leaf transform via their exported include
+    // directories. `deterministic_pow` is not defined here:
     // the PoW search kernel lives in gpu_hash, so gpu_whir/deterministic_pow
     // forwards to gpu_hash/deterministic_pow instead of an AB_DETERMINISTIC_POW
     // define on this archive.

--- a/gpu/whir/native/CMakeLists.txt
+++ b/gpu/whir/native/CMakeLists.txt
@@ -12,10 +12,11 @@ endif ()
 include(${AB_CUDA_CMAKE_DIR}/ab_cuda_target.cmake)
 # WHIR protocol + PoW kernels. `accumulate_eq.cu` resolves gpu_gkr's eq/kernel
 # headers via ${GPU_GKR_NATIVE_INCLUDE}; `leaves.cu` resolves gpu_hash's
-# `hash.cuh` via ${GPU_HASH_NATIVE_INCLUDE}. Both dirs arrive as DEP_* env vars
-# that gpu_native_build forwards as CMake -D defines.
+# `hash.cuh` and gpu_ntt's reusable WHIR transform through their exported
+# include directories. These dirs arrive as DEP_* env vars that
+# gpu_native_build forwards as CMake -D defines.
 add_library(gpu_whir_native STATIC)
 add_subdirectory(whir)
 ab_cuda_configure_target(gpu_whir_native
         PREFIX GPU_WHIR
-        INCLUDE_DIRS ${GPU_CORE_NATIVE_INCLUDE} ${GPU_HASH_NATIVE_INCLUDE} ${GPU_GKR_NATIVE_INCLUDE})
+        INCLUDE_DIRS ${GPU_CORE_NATIVE_INCLUDE} ${GPU_HASH_NATIVE_INCLUDE} ${GPU_GKR_NATIVE_INCLUDE} ${GPU_NTT_NATIVE_INCLUDE})

--- a/gpu/whir/native/whir/leaves.cu
+++ b/gpu/whir/native/whir/leaves.cu
@@ -2,9 +2,12 @@
 #include <hash.cuh>
 #include <primitives/field.cuh>
 #include <primitives/memory.cuh>
+#include <primitives/vectorized.cuh>
+#include <whir_leaf_transform.cuh>
 
 using namespace ::airbender::primitives::field;
 using namespace ::airbender::primitives::memory;
+using namespace ::airbender::primitives::vectorized;
 using ::airbender::hash::bitreverse_low_bits;
 
 namespace airbender::whir {
@@ -44,6 +47,168 @@ EXTERN __global__ void ab_pack_rows_for_whir_leaves_multi_coset_bf_kernel(const 
   const unsigned src_row = row + bitreverse_low_bits(value_slot, log_values_per_leaf) * dst_rows_per_slot;
   const unsigned dst_row = row + bitrev_coset * dst_rows_per_slot;
   dst.set(dst_row, col, src.get(src_row, src_col_global));
+}
+
+struct query_leaf_destination {
+  static constexpr bool ALIASES_VALUES_SMEM = false;
+
+  bf *dst;
+  unsigned query_slot;
+  unsigned log_values_per_leaf;
+  bool enabled;
+
+  DEVICE_FORCEINLINE void set_at_slot(const unsigned transform_slot, const e4 value) {
+    if (!enabled)
+      return;
+    // Match the committed leaf reader's bit-reversed value-slot order.
+    const unsigned output_slot = bitreverse_low_bits(transform_slot, log_values_per_leaf);
+    bf *output = dst + ((size_t)query_slot << (log_values_per_leaf + 2)) + (output_slot << 2);
+#pragma unroll
+    for (unsigned coeff = 0; coeff < 4; coeff++)
+      output[coeff] = value.base_coefficient_from_flat_idx(coeff);
+  }
+};
+
+struct shared_query_leaf_destination {
+  static constexpr bool ALIASES_VALUES_SMEM = true;
+
+  e4 *values;
+  unsigned log_values_per_leaf;
+
+  DEVICE_FORCEINLINE void set_at_slot(const unsigned transform_slot, const e4 value) {
+    const unsigned output_slot = bitreverse_low_bits(transform_slot, log_values_per_leaf);
+    values[output_slot * blockDim.x + threadIdx.x] = value;
+  }
+};
+
+EXTERN __launch_bounds__(512, 2) __global__
+    void ab_gather_coefficient_leaves_for_queries_from_ntt_kernel(vectorized_e4_matrix_getter<ld_modifier::cs> ntt_output, bf *slab_dst,
+                                                                  const ::airbender::ntt::whir_leaf_transform_params transform_params,
+                                                                  const unsigned log_trace_len, const unsigned log_lde_factor,
+                                                                  const unsigned log_values_per_leaf, const unsigned *query_indexes,
+                                                                  const unsigned indexes_count) {
+  const unsigned query_slot = blockIdx.x * blockDim.x + threadIdx.x;
+  // The transform contains block-wide barriers. Inactive x lanes therefore
+  // transform a valid leaf and suppress their stores instead of returning.
+  const bool enabled = query_slot < indexes_count;
+  const unsigned safe_query_slot = enabled ? query_slot : indexes_count - 1;
+  const unsigned q = query_indexes[safe_query_slot];
+  const unsigned log_packed_leaf_count = log_trace_len - log_values_per_leaf;
+  const unsigned packed_leaf_count = 1u << log_packed_leaf_count;
+  const unsigned input_row = q & (packed_leaf_count - 1u);
+  const unsigned bitrev_coset = q >> log_packed_leaf_count;
+  const unsigned natural_coset = bitreverse_low_bits(bitrev_coset, log_lde_factor);
+
+  ntt_output.add_col(natural_coset);
+  ntt_output.add_row(input_row);
+
+  extern __shared__ __align__(16) uint8_t smem[];
+  e4 *values_smem = reinterpret_cast<e4 *>(smem);
+  bf *x_invs_smem = reinterpret_cast<bf *>(values_smem + 2 * blockDim.x * blockDim.y);
+  query_leaf_destination destination{slab_dst, query_slot, log_values_per_leaf, enabled};
+  const ::airbender::ntt::params_inverse_power_source inverse_power_source{transform_params};
+  ::airbender::ntt::transform_whir_leaf_from_ntt(ntt_output, destination, log_trace_len, log_lde_factor, log_values_per_leaf, natural_coset, input_row,
+                                                 values_smem, x_invs_smem, transform_params.two_inv_power, inverse_power_source);
+}
+
+// Partial-cache query path: transform the 32-leaf subtree containing each
+// query, retain only those coefficient leaves in shared memory, hash the five
+// omitted Merkle layers warp-cooperatively, then walk the cached upper tree.
+EXTERN __launch_bounds__(512, 2) __global__ void ab_gather_coefficient_leaves_and_merkle_paths_partial_for_queries_from_ntt_kernel(
+    vectorized_e4_matrix_getter<ld_modifier::cs> ntt_output, const u32 *partial_tree, bf *leaf_dst, u32 *path_dst,
+    const ::airbender::ntt::whir_leaf_transform_params transform_params, const unsigned log_trace_len, const unsigned log_lde_factor,
+    const unsigned log_values_per_leaf, const unsigned log_total_leaves_count, const unsigned layers_count, const unsigned *query_indexes,
+    const unsigned indexes_count) {
+  const unsigned query_slot = blockIdx.x;
+  if (query_slot >= indexes_count)
+    return;
+
+  const unsigned q = query_indexes[query_slot];
+  const unsigned lane_idx = threadIdx.x;
+  const unsigned subtree_leaf = (q & ~::airbender::hash::WARP_MASK) | lane_idx;
+  const unsigned log_packed_leaf_count = log_trace_len - log_values_per_leaf;
+  const unsigned packed_leaf_count = 1u << log_packed_leaf_count;
+  const unsigned input_row = subtree_leaf & (packed_leaf_count - 1u);
+  const unsigned bitrev_coset = subtree_leaf >> log_packed_leaf_count;
+  const unsigned natural_coset = bitreverse_low_bits(bitrev_coset, log_lde_factor);
+
+  ntt_output.add_col(natural_coset);
+  ntt_output.add_row(input_row);
+
+  extern __shared__ __align__(16) uint8_t smem[];
+  e4 *coefficient_leaves = reinterpret_cast<e4 *>(smem);
+  bf *x_invs_smem = reinterpret_cast<bf *>(coefficient_leaves + (blockDim.x << log_values_per_leaf));
+  shared_query_leaf_destination destination{coefficient_leaves, log_values_per_leaf};
+  const ::airbender::ntt::params_inverse_power_source inverse_power_source{transform_params};
+  ::airbender::ntt::transform_whir_leaf_from_ntt(ntt_output, destination, log_trace_len, log_lde_factor, log_values_per_leaf, natural_coset, input_row,
+                                                 coefficient_leaves, x_invs_smem, transform_params.two_inv_power, inverse_power_source);
+  __syncthreads();
+
+  if (threadIdx.y != 0)
+    return;
+
+  const bool is_output_lane = subtree_leaf == q;
+  if (is_output_lane) {
+    bf *output = leaf_dst + ((size_t)query_slot << (log_values_per_leaf + 2));
+    for (unsigned value_slot = 0; value_slot < (1u << log_values_per_leaf); value_slot++) {
+      const e4 value = coefficient_leaves[value_slot * blockDim.x + lane_idx];
+#pragma unroll
+      for (unsigned coeff = 0; coeff < 4; coeff++)
+        output[(value_slot << 2) + coeff] = value.base_coefficient_from_flat_idx(coeff);
+    }
+  }
+
+  auto read_e4 = [=](const unsigned value_slot) -> e4 { return coefficient_leaves[value_slot * blockDim.x + lane_idx]; };
+  u32 state[::airbender::hash::STATE_SIZE];
+  ::airbender::hash::initialize(state);
+  u32 t = 0;
+  ::airbender::hash::absorb_e4_stream(state, t, 1u << log_values_per_leaf, read_e4);
+  u32 *merkle_paths = path_dst + query_slot * layers_count * ::airbender::hash::STATE_SIZE;
+  ::airbender::hash::collect_merkle_path_warp(state, merkle_paths, ::airbender::hash::STATE_SIZE, lane_idx, is_output_lane, q, log_total_leaves_count,
+                                              layers_count, partial_tree);
+}
+
+// Source columns are tile-local; twiddles and tree placement use global cosets.
+EXTERN __launch_bounds__(512, 2) __global__
+    void ab_transform_and_hash_whir_leaves_from_ntt_multi_coset_kernel(vectorized_e4_matrix_getter<ld_modifier::cs> ntt_output, u32 *results,
+                                                                       const ::airbender::ntt::whir_leaf_transform_params transform_params,
+                                                                       const unsigned log_trace_len, const unsigned log_lde_factor,
+                                                                       const unsigned log_values_per_leaf, const unsigned coset_index_base,
+                                                                       const unsigned leaves_count) {
+  const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
+  // The transform contains block-wide barriers, so a partial final block uses
+  // a valid source leaf for inactive x lanes and suppresses their hashes.
+  const bool enabled = gid < leaves_count;
+  const unsigned safe_gid = enabled ? gid : leaves_count - 1;
+  const unsigned log_packed_leaf_count = log_trace_len - log_values_per_leaf;
+  const unsigned packed_leaf_count = 1u << log_packed_leaf_count;
+  const unsigned coset_in_tile = safe_gid >> log_packed_leaf_count;
+  const unsigned leaf_in_coset = safe_gid & (packed_leaf_count - 1u);
+  const unsigned natural_coset = coset_index_base + coset_in_tile;
+
+  ntt_output.add_col(coset_in_tile);
+  ntt_output.add_row(leaf_in_coset);
+
+  extern __shared__ __align__(16) uint8_t smem[];
+  e4 *coefficient_leaves = reinterpret_cast<e4 *>(smem);
+  bf *x_invs_smem = reinterpret_cast<bf *>(coefficient_leaves + (blockDim.x << log_values_per_leaf));
+  shared_query_leaf_destination destination{coefficient_leaves, log_values_per_leaf};
+  const ::airbender::ntt::params_inverse_power_source inverse_power_source{transform_params};
+  ::airbender::ntt::transform_whir_leaf_from_ntt(ntt_output, destination, log_trace_len, log_lde_factor, log_values_per_leaf, natural_coset, leaf_in_coset,
+                                                 coefficient_leaves, x_invs_smem, transform_params.two_inv_power, inverse_power_source);
+  __syncthreads();
+
+  if (threadIdx.y != 0 || !enabled)
+    return;
+
+  auto read_e4 = [=](const unsigned value_slot) -> e4 { return coefficient_leaves[value_slot * blockDim.x + threadIdx.x]; };
+  ::airbender::hash::digest state;
+  ::airbender::hash::initialize(state.words);
+  u32 t = 0;
+  ::airbender::hash::absorb_e4_stream(state.words, t, 1u << log_values_per_leaf, read_e4);
+  const unsigned bitrev_coset = bitreverse_low_bits(natural_coset, log_lde_factor);
+  const unsigned output_leaf = bitrev_coset * packed_leaf_count + leaf_in_coset;
+  store_cs(reinterpret_cast<::airbender::hash::digest *>(results) + output_leaf, state);
 }
 
 } // namespace airbender::whir

--- a/gpu/whir/src/kernels/mod.rs
+++ b/gpu/whir/src/kernels/mod.rs
@@ -10,6 +10,8 @@ use gpu_core::primitives::device_structures::{
     DeviceMatrixChunkImpl, DeviceMatrixChunkMutImpl, MutPtrAndStride, PtrAndStride,
 };
 use gpu_core::primitives::field::{BF, E4};
+use gpu_hash::blake2s::Digest;
+use gpu_ntt::ntt_twiddles::WhirLeafTransformParams;
 use gpu_ops::simple::pow;
 // Production: the (de)serialize / accumulate launchers here read `EXT4_DEGREE`
 // via `<E4 as FieldExtension<BF>>::DEGREE`.
@@ -316,6 +318,270 @@ pub(crate) fn whir_fold_split_half_in_place(
     let config = CudaLaunchConfig::basic(grid_dim, block_dim, stream);
     let args = WhirFoldSplitHalfArguments::new(values.as_mut_ptr(), challenge.as_ptr(), half_len);
     WhirFoldSplitHalfFunction(ab_whir_fold_split_half_e4_kernel).launch(&config, &args)
+}
+
+cuda_kernel_signature_arguments_and_function!(
+    GatherCoefficientLeavesForQueriesFromNtt,
+    src: PtrAndStride<BF>,
+    leaf_dst: *mut BF,
+    transform_params: WhirLeafTransformParams,
+    log_trace_len: u32,
+    log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    query_indexes: *const u32,
+    indexes_count: u32,
+);
+
+cuda_kernel_declaration!(
+    ab_gather_coefficient_leaves_for_queries_from_ntt_kernel(
+        src: PtrAndStride<BF>,
+        leaf_dst: *mut BF,
+        transform_params: WhirLeafTransformParams,
+        log_trace_len: u32,
+        log_lde_factor: u32,
+        log_values_per_leaf: u32,
+        query_indexes: *const u32,
+        indexes_count: u32,
+    )
+);
+
+pub(crate) fn gather_coefficient_leaves_for_queries_from_ntt(
+    ntt_output: &DeviceSlice<BF>,
+    leaf_dst: &mut DeviceSlice<BF>,
+    log_trace_len: u32,
+    log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    log_src_cols_per_coset: u32,
+    transform_params: WhirLeafTransformParams,
+    query_indexes: &DeviceSlice<u32>,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    assert!((1..=5).contains(&log_values_per_leaf));
+    assert!(log_trace_len > log_values_per_leaf);
+    assert_eq!(log_src_cols_per_coset, 2, "coefficient queries require E4");
+    assert!(!query_indexes.is_empty());
+    assert!(query_indexes.len() <= u32::MAX as usize);
+    let trace_len = 1usize << log_trace_len;
+    let lde_factor = 1usize << log_lde_factor;
+    assert_eq!(ntt_output.len(), trace_len * lde_factor * 4);
+    let values_per_leaf = 1usize << log_values_per_leaf;
+    assert_eq!(leaf_dst.len(), query_indexes.len() * values_per_leaf * 4);
+
+    let block_dim_x = (query_indexes.len() as u32).min(WARP_SIZE);
+    let block_dim_y = (values_per_leaf / 2) as u32;
+    let grid_dim_x = (query_indexes.len() as u32).div_ceil(block_dim_x);
+    let mut config = CudaLaunchConfig::basic(grid_dim_x, (block_dim_x, block_dim_y), stream);
+    if log_values_per_leaf > 1 {
+        config.dynamic_smem_bytes =
+            2 * block_dim_x as usize * block_dim_y as usize * core::mem::size_of::<E4>()
+                + block_dim_x as usize * block_dim_y as usize * core::mem::size_of::<BF>();
+    }
+    let args = GatherCoefficientLeavesForQueriesFromNttArguments::new(
+        PtrAndStride::new(ntt_output.as_ptr(), trace_len),
+        leaf_dst.as_mut_ptr(),
+        transform_params,
+        log_trace_len,
+        log_lde_factor,
+        log_values_per_leaf,
+        query_indexes.as_ptr(),
+        query_indexes.len() as u32,
+    );
+    GatherCoefficientLeavesForQueriesFromNttFunction(
+        ab_gather_coefficient_leaves_for_queries_from_ntt_kernel,
+    )
+    .launch(&config, &args)
+}
+
+cuda_kernel_signature_arguments_and_function!(
+    GatherCoefficientLeavesAndMerklePathsPartialForQueriesFromNtt,
+    src: PtrAndStride<BF>,
+    partial_tree: *const u32,
+    leaf_dst: *mut BF,
+    path_dst: *mut u32,
+    transform_params: WhirLeafTransformParams,
+    log_trace_len: u32,
+    log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    log_total_leaves_count: u32,
+    layers_count: u32,
+    query_indexes: *const u32,
+    indexes_count: u32,
+);
+
+cuda_kernel_declaration!(
+    ab_gather_coefficient_leaves_and_merkle_paths_partial_for_queries_from_ntt_kernel(
+        src: PtrAndStride<BF>,
+        partial_tree: *const u32,
+        leaf_dst: *mut BF,
+        path_dst: *mut u32,
+        transform_params: WhirLeafTransformParams,
+        log_trace_len: u32,
+        log_lde_factor: u32,
+        log_values_per_leaf: u32,
+        log_total_leaves_count: u32,
+        layers_count: u32,
+        query_indexes: *const u32,
+        indexes_count: u32,
+    )
+);
+
+pub(crate) fn gather_coefficient_leaves_and_merkle_paths_partial_for_queries_from_ntt(
+    ntt_output: &DeviceSlice<BF>,
+    partial_tree: &DeviceSlice<u32>,
+    leaf_dst: &mut DeviceSlice<BF>,
+    path_dst: &mut DeviceSlice<u32>,
+    log_trace_len: u32,
+    log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    log_src_cols_per_coset: u32,
+    log_packed_leaf_count: u32,
+    log_total_leaves_count: u32,
+    layers_count: u32,
+    transform_params: WhirLeafTransformParams,
+    query_indexes: &DeviceSlice<u32>,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    assert!((1..=5).contains(&log_values_per_leaf));
+    assert!(log_trace_len > log_values_per_leaf);
+    assert_eq!(log_src_cols_per_coset, 2, "coefficient queries require E4");
+    assert_eq!(log_packed_leaf_count, log_trace_len - log_values_per_leaf);
+    assert_eq!(
+        log_total_leaves_count,
+        log_packed_leaf_count + log_lde_factor
+    );
+    assert!(log_total_leaves_count >= 6);
+    assert!(layers_count > 5);
+    assert!(!query_indexes.is_empty());
+    assert!(query_indexes.len() <= u32::MAX as usize);
+    let trace_len = 1usize << log_trace_len;
+    let lde_factor = 1usize << log_lde_factor;
+    assert_eq!(ntt_output.len(), trace_len * lde_factor * 4);
+    let values_per_leaf = 1usize << log_values_per_leaf;
+    assert_eq!(leaf_dst.len(), query_indexes.len() * values_per_leaf * 4);
+    assert_eq!(
+        path_dst.len(),
+        query_indexes.len() * layers_count as usize * gpu_hash::blake2s::STATE_SIZE
+    );
+    assert_eq!(
+        partial_tree.len(),
+        (1usize << (log_total_leaves_count + 1 - 5)) * gpu_hash::blake2s::STATE_SIZE
+    );
+
+    let block_dim = (WARP_SIZE, (values_per_leaf / 2) as u32);
+    let mut config = CudaLaunchConfig::basic(query_indexes.len() as u32, block_dim, stream);
+    config.dynamic_smem_bytes = WARP_SIZE as usize * values_per_leaf * core::mem::size_of::<E4>()
+        + if log_values_per_leaf > 1 {
+            WARP_SIZE as usize * (values_per_leaf / 2) * core::mem::size_of::<BF>()
+        } else {
+            0
+        };
+    let args = GatherCoefficientLeavesAndMerklePathsPartialForQueriesFromNttArguments::new(
+        PtrAndStride::new(ntt_output.as_ptr(), trace_len),
+        partial_tree.as_ptr(),
+        leaf_dst.as_mut_ptr(),
+        path_dst.as_mut_ptr(),
+        transform_params,
+        log_trace_len,
+        log_lde_factor,
+        log_values_per_leaf,
+        log_total_leaves_count,
+        layers_count,
+        query_indexes.as_ptr(),
+        query_indexes.len() as u32,
+    );
+    GatherCoefficientLeavesAndMerklePathsPartialForQueriesFromNttFunction(
+        ab_gather_coefficient_leaves_and_merkle_paths_partial_for_queries_from_ntt_kernel,
+    )
+    .launch(&config, &args)
+}
+
+cuda_kernel_signature_arguments_and_function!(
+    TransformAndHashWhirLeavesFromNttMultiCoset,
+    src: PtrAndStride<BF>,
+    results: *mut u32,
+    transform_params: WhirLeafTransformParams,
+    log_trace_len: u32,
+    log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    coset_index_base: u32,
+    leaves_count: u32,
+);
+
+cuda_kernel_declaration!(
+    ab_transform_and_hash_whir_leaves_from_ntt_multi_coset_kernel(
+        src: PtrAndStride<BF>,
+        results: *mut u32,
+        transform_params: WhirLeafTransformParams,
+        log_trace_len: u32,
+        log_lde_factor: u32,
+        log_values_per_leaf: u32,
+        coset_index_base: u32,
+        leaves_count: u32,
+    )
+);
+
+pub(crate) fn transform_and_hash_whir_leaves_from_ntt_multi_coset(
+    ntt_output: &DeviceSlice<BF>,
+    results: &mut DeviceSlice<Digest>,
+    log_trace_len: u32,
+    log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    coset_index_base: u32,
+    cosets_in_tile: u32,
+    transform_params: WhirLeafTransformParams,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    assert!(log_lde_factor >= 1);
+    assert!((1..=5).contains(&log_values_per_leaf));
+    assert!(log_trace_len > log_values_per_leaf);
+    assert!(cosets_in_tile >= 1);
+    assert!(coset_index_base + cosets_in_tile <= 1u32 << log_lde_factor);
+    let trace_len = 1usize << log_trace_len;
+    let packed_leaf_count = 1usize << (log_trace_len - log_values_per_leaf);
+    let leaves_count = packed_leaf_count
+        .checked_mul(cosets_in_tile as usize)
+        .expect("tile leaf count overflow");
+    assert!(leaves_count <= u32::MAX as usize);
+    assert!(ntt_output.len() >= trace_len * 4 * cosets_in_tile as usize);
+
+    let max_bitrev_coset = (0..cosets_in_tile)
+        .map(|offset| (coset_index_base + offset).reverse_bits() >> (u32::BITS - log_lde_factor))
+        .max()
+        .unwrap();
+    assert!(
+        results.len() >= (max_bitrev_coset as usize + 1) * packed_leaf_count,
+        "results do not cover the tile's highest bit-reversed coset",
+    );
+
+    let values_per_leaf = 1usize << log_values_per_leaf;
+    let block_dim_x = if values_per_leaf == 2 {
+        (leaves_count as u32).min(4 * WARP_SIZE)
+    } else {
+        WARP_SIZE
+    };
+    let block_dim_y = (values_per_leaf / 2) as u32;
+    let grid_dim_x = (leaves_count as u32).div_ceil(block_dim_x);
+    let mut config = CudaLaunchConfig::basic(grid_dim_x, (block_dim_x, block_dim_y), stream);
+    config.dynamic_smem_bytes = block_dim_x as usize * values_per_leaf * core::mem::size_of::<E4>()
+        + if log_values_per_leaf > 1 {
+            block_dim_x as usize * block_dim_y as usize * core::mem::size_of::<BF>()
+        } else {
+            0
+        };
+    let args = TransformAndHashWhirLeavesFromNttMultiCosetArguments::new(
+        PtrAndStride::new(ntt_output.as_ptr(), trace_len),
+        results.as_mut_ptr() as *mut u32,
+        transform_params,
+        log_trace_len,
+        log_lde_factor,
+        log_values_per_leaf,
+        coset_index_base,
+        leaves_count as u32,
+    );
+    TransformAndHashWhirLeavesFromNttMultiCosetFunction(
+        ab_transform_and_hash_whir_leaves_from_ntt_multi_coset_kernel,
+    )
+    .launch(&config, &args)
 }
 
 cuda_kernel_signature_arguments_and_function!(

--- a/gpu/whir/src/lib.rs
+++ b/gpu/whir/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub mod fold;
 pub(crate) mod kernels;
+mod oracle_commit;
 pub mod pow;
 pub(crate) mod upstream;
 
@@ -31,7 +32,9 @@ use crate::upstream::FieldExtension;
 use gpu_core::primitives::device_structures::{DeviceMatrixChunk, DeviceMatrixImpl};
 use gpu_core::primitives::field::{BF, E4};
 use gpu_prover_context::ProverContext;
-use gpu_trace::trace::holder::{TraceHolder, TreesCacheMode, PARTIAL_TREE_REDUCTION_LAYERS};
+use gpu_trace::trace::holder::{
+    TraceHolder, TreesCacheMode, TreesHolder, PARTIAL_TREE_REDUCTION_LAYERS,
+};
 
 #[cfg(test)]
 use crate::upstream::PathQueriable;
@@ -45,7 +48,9 @@ use fft::bitreverse_enumeration_inplace;
 use gpu_core::allocator::tracker::AllocationPlacement;
 #[cfg(test)]
 use gpu_core::primitives::{
-    callbacks::Callbacks, context::HostAllocation, device_structures::DeviceMatrix,
+    callbacks::Callbacks,
+    context::HostAllocation,
+    device_structures::{DeviceMatrix, DeviceMatrixMut},
     static_host::alloc_static_pinned_box_from_slice,
 };
 #[cfg(test)]
@@ -74,6 +79,7 @@ pub(crate) struct GpuWhirExtensionOracle {
     lde_factor: usize,
     trace_len_log2: u32,
     packed_leaf_count: usize,
+    transform_leaves_to_multilinear_coeffs: bool,
 }
 
 /// Holds the retired oracle's trace holder (and therefore its unified device
@@ -209,8 +215,20 @@ impl GpuWhirExtensionOracle {
         match cap_target {
             #[cfg(test)]
             CapTarget::OwnAllocation => {
-                trace_holder.whir_lde_and_commit_all(
+                let mut unified_cap = context.alloc(
+                    tree_cap_size,
+                    gpu_core::allocator::tracker::AllocationPlacement::BestFit,
+                )?;
+                let cap_dst_u32 = unsafe {
+                    era_cudart::slice::DeviceSlice::from_raw_parts_mut(
+                        unified_cap.as_mut_ptr() as *mut u32,
+                        tree_cap_size * gpu_hash::blake2s::STATE_SIZE,
+                    )
+                };
+                oracle_commit::schedule_recursive_oracle_commit(
+                    &mut trace_holder,
                     &inputs_matrix,
+                    cap_dst_u32,
                     trace_len_log2,
                     log_lde_factor,
                     log_values_per_leaf,
@@ -218,9 +236,11 @@ impl GpuWhirExtensionOracle {
                     transform_leaves_to_multilinear_coeffs,
                     context,
                 )?;
+                trace_holder.install_unified_device_cap(unified_cap);
             }
             CapTarget::Slab(dst_u32) => {
-                trace_holder.whir_lde_and_commit_all_into(
+                oracle_commit::schedule_recursive_oracle_commit(
+                    &mut trace_holder,
                     &inputs_matrix,
                     dst_u32,
                     trace_len_log2,
@@ -240,6 +260,7 @@ impl GpuWhirExtensionOracle {
             lde_factor,
             trace_len_log2,
             packed_leaf_count,
+            transform_leaves_to_multilinear_coeffs,
         })
     }
 
@@ -255,6 +276,108 @@ impl GpuWhirExtensionOracle {
         let Self { trace_holder, .. } = self;
         GpuWhirExtensionOracleKeepalive {
             _trace_holder: trace_holder,
+        }
+    }
+
+    fn schedule_query_leaves_and_paths_into_from_ntt(
+        &mut self,
+        tree_indexes: &era_cudart::slice::DeviceSlice<u32>,
+        leaves_dst: &mut era_cudart::slice::DeviceSlice<BF>,
+        paths_dst: &mut era_cudart::slice::DeviceSlice<u32>,
+        context: &ProverContext,
+    ) -> CudaResult<()> {
+        let queries_count = tree_indexes.len();
+        let log_values_per_leaf = self.values_per_leaf.trailing_zeros();
+        let log_lde_factor = self.lde_factor.trailing_zeros();
+        let log_packed_leaf_count = self.packed_leaf_count.trailing_zeros();
+        let log_total_leaves = log_packed_leaf_count + log_lde_factor;
+        let layers_count = self.trace_holder.log_domain_size
+            - self.trace_holder.log_rows_per_leaf
+            - (self.trace_holder.log_tree_cap_size - self.trace_holder.log_lde_factor);
+        assert_eq!(
+            leaves_dst.len(),
+            queries_count * self.values_per_leaf * EXT4_DEGREE,
+        );
+        assert_eq!(
+            paths_dst.len(),
+            queries_count * layers_count as usize * gpu_hash::blake2s::STATE_SIZE,
+        );
+
+        if !self.transform_leaves_to_multilinear_coeffs {
+            self.trace_holder.schedule_query_leaves_into_from_ntt(
+                tree_indexes,
+                leaves_dst,
+                self.trace_len_log2,
+                log_lde_factor,
+                log_values_per_leaf,
+                LOG_SRC_COLS_PER_COSET,
+                context,
+            )?;
+            return self.trace_holder.schedule_query_merkle_paths_into_from_ntt(
+                tree_indexes,
+                paths_dst,
+                self.trace_len_log2,
+                log_lde_factor,
+                log_values_per_leaf,
+                LOG_SRC_COLS_PER_COSET,
+                context,
+            );
+        }
+
+        let transform_params = context
+            .ntt_device_context()
+            .whir_leaf_transform_params(log_values_per_leaf);
+        if matches!(&self.trace_holder.trees, TreesHolder::Full(_)) {
+            kernels::gather_coefficient_leaves_for_queries_from_ntt(
+                self.trace_holder.get_consolidated_cosets(),
+                leaves_dst,
+                self.trace_len_log2,
+                log_lde_factor,
+                log_values_per_leaf,
+                LOG_SRC_COLS_PER_COSET,
+                transform_params,
+                tree_indexes,
+                context.get_exec_stream(),
+            )?;
+            return self.trace_holder.schedule_query_merkle_paths_into_from_ntt(
+                tree_indexes,
+                paths_dst,
+                self.trace_len_log2,
+                log_lde_factor,
+                log_values_per_leaf,
+                LOG_SRC_COLS_PER_COSET,
+                context,
+            );
+        }
+
+        let evaluations = self.trace_holder.get_consolidated_cosets();
+        match &self.trace_holder.trees {
+            TreesHolder::Partial(tree) => {
+                let tree_u32 = unsafe {
+                    era_cudart::slice::DeviceSlice::from_raw_parts(
+                        tree.as_ptr() as *const u32,
+                        tree.len() * gpu_hash::blake2s::STATE_SIZE,
+                    )
+                };
+                kernels::gather_coefficient_leaves_and_merkle_paths_partial_for_queries_from_ntt(
+                    evaluations,
+                    tree_u32,
+                    leaves_dst,
+                    paths_dst,
+                    self.trace_len_log2,
+                    log_lde_factor,
+                    log_values_per_leaf,
+                    LOG_SRC_COLS_PER_COSET,
+                    log_packed_leaf_count,
+                    log_total_leaves,
+                    layers_count,
+                    transform_params,
+                    tree_indexes,
+                    context.get_exec_stream(),
+                )
+            }
+            TreesHolder::Full(_) => unreachable!(),
+            TreesHolder::None => panic!("recursive WHIR oracle has no Merkle tree"),
         }
     }
 
@@ -296,31 +419,48 @@ impl GpuWhirExtensionOracle {
         // (read-only) and run after the kernel above on the same stream, so
         // they observe the tree-indexes that were just written.
         let slab_indices_view: &era_cudart::slice::DeviceSlice<u32> = slab_indices_dst;
-        // Recursive WHIR trace holders use `log_lde_factor = 0`, so only
-        // coset 0 exists; the consolidated gather kernels resolve every
-        // query into that single coset (lde_mask == 0).
-        let log_values_per_leaf = self.values_per_leaf.trailing_zeros();
-        let natural_log_lde_factor = log_lde_factor;
-        self.trace_holder.schedule_query_leaves_into_from_ntt(
+        self.schedule_query_leaves_and_paths_into_from_ntt(
             slab_indices_view,
             slab_leaves_dst_bf,
-            self.trace_len_log2,
-            natural_log_lde_factor,
-            log_values_per_leaf,
-            LOG_SRC_COLS_PER_COSET,
+            slab_paths_dst,
+            context,
+        )
+    }
+
+    #[cfg(test)]
+    fn schedule_query_outputs_to_host(
+        &mut self,
+        tree_indexes: &era_cudart::slice::DeviceSlice<u32>,
+        context: &ProverContext,
+    ) -> CudaResult<(HostAllocation<[BF]>, HostAllocation<[Digest]>)> {
+        let queries_count = tree_indexes.len();
+        let leaf_len = queries_count * self.values_per_leaf * EXT4_DEGREE;
+        let layers_count = self.trace_holder.log_domain_size
+            - self.trace_holder.log_rows_per_leaf
+            - (self.trace_holder.log_tree_cap_size - self.trace_holder.log_lde_factor);
+        let paths_len = queries_count * layers_count as usize;
+        let mut device_leaves = context.alloc(leaf_len, AllocationPlacement::BestFit)?;
+        let mut device_paths: gpu_core::primitives::context::DeviceAllocation<Digest> =
+            context.alloc(paths_len, AllocationPlacement::BestFit)?;
+        let device_paths_u32 = unsafe {
+            era_cudart::slice::DeviceSlice::from_raw_parts_mut(
+                device_paths.as_mut_ptr() as *mut u32,
+                paths_len * gpu_hash::blake2s::STATE_SIZE,
+            )
+        };
+        self.schedule_query_leaves_and_paths_into_from_ntt(
+            tree_indexes,
+            &mut device_leaves,
+            device_paths_u32,
             context,
         )?;
-        self.trace_holder
-            .schedule_query_merkle_paths_into_from_ntt(
-                slab_indices_view,
-                slab_paths_dst,
-                self.trace_len_log2,
-                natural_log_lde_factor,
-                log_values_per_leaf,
-                LOG_SRC_COLS_PER_COSET,
-                context,
-            )?;
-        Ok(())
+
+        let stream = context.get_exec_stream();
+        let mut leaves = unsafe { context.alloc_host_uninit_slice(leaf_len) };
+        let mut paths = unsafe { context.alloc_host_uninit_slice(paths_len) };
+        memory_copy_async(&mut leaves, &device_leaves, stream)?;
+        memory_copy_async(&mut paths, &device_paths, stream)?;
+        Ok((leaves, paths))
     }
 
     #[cfg(test)]
@@ -356,37 +496,8 @@ impl GpuWhirExtensionOracle {
             context.get_exec_stream(),
         )?;
         drop(tree_index_host);
-        // Use the NTT-aware query path (same reason as `schedule_query_for_folded_index`).
-        let leaf_len = self.values_per_leaf * EXT4_DEGREE;
-        let mut d_leafs = context.alloc(leaf_len, AllocationPlacement::BestFit)?;
-        {
-            let natural_log_lde_factor = self.lde_factor.trailing_zeros();
-            let log_values_per_leaf = self.values_per_leaf.trailing_zeros();
-            self.trace_holder.schedule_query_leaves_into_from_ntt(
-                &device_tree_index,
-                &mut d_leafs[..],
-                self.trace_len_log2,
-                natural_log_lde_factor,
-                log_values_per_leaf,
-                LOG_SRC_COLS_PER_COSET,
-                context,
-            )?;
-        }
-        let stream_ref = context.get_exec_stream();
-        let mut value_query = unsafe { context.alloc_host_uninit_slice(leaf_len) };
-        memory_copy_async(&mut value_query, &d_leafs[..], stream_ref)?;
-        let path_query = {
-            let natural_log_lde_factor = self.lde_factor.trailing_zeros();
-            let log_values_per_leaf = self.values_per_leaf.trailing_zeros();
-            self.trace_holder.get_query_merkle_paths_from_ntt(
-                &device_tree_index,
-                self.trace_len_log2,
-                natural_log_lde_factor,
-                log_values_per_leaf,
-                LOG_SRC_COLS_PER_COSET,
-                context,
-            )?
-        };
+        let (value_query, path_query) =
+            self.schedule_query_outputs_to_host(&device_tree_index, context)?;
         Ok(GpuWhirScheduledExtensionQuery {
             index: 0,
             coset_index: 0,
@@ -538,40 +649,8 @@ impl GpuWhirExtensionOracle {
             context.get_exec_stream(),
         )?;
         drop(host_tree_index);
-        // Use the NTT-aware query path: the trace holder's cosets backing
-        // now holds the natural multi-coset NTT output, which `get_query_leafs`
-        // (packed-layout reader) would misinterpret. Switch to the new
-        // `schedule_query_leaves_into_from_ntt` path used by production.
-        let leaf_len = self.values_per_leaf * EXT4_DEGREE;
-        let mut d_leafs = context.alloc(leaf_len, AllocationPlacement::BestFit)?;
-        {
-            let natural_log_lde_factor = self.lde_factor.trailing_zeros();
-            let log_values_per_leaf = self.values_per_leaf.trailing_zeros();
-            self.trace_holder.schedule_query_leaves_into_from_ntt(
-                &device_tree_index,
-                &mut d_leafs[..],
-                self.trace_len_log2,
-                natural_log_lde_factor,
-                log_values_per_leaf,
-                LOG_SRC_COLS_PER_COSET,
-                context,
-            )?;
-        }
-        let stream_ref = context.get_exec_stream();
-        let mut value_query = unsafe { context.alloc_host_uninit_slice(leaf_len) };
-        memory_copy_async(&mut value_query, &d_leafs[..], stream_ref)?;
-        let path_query = {
-            let natural_log_lde_factor = self.lde_factor.trailing_zeros();
-            let log_values_per_leaf = self.values_per_leaf.trailing_zeros();
-            self.trace_holder.get_query_merkle_paths_from_ntt(
-                &device_tree_index,
-                self.trace_len_log2,
-                natural_log_lde_factor,
-                log_values_per_leaf,
-                LOG_SRC_COLS_PER_COSET,
-                context,
-            )?
-        };
+        let (value_query, path_query) =
+            self.schedule_query_outputs_to_host(&device_tree_index, context)?;
         Ok(GpuWhirScheduledExtensionQuery {
             index: tree_index,
             coset_index,
@@ -806,6 +885,302 @@ pub(crate) mod tests {
         }
     }
 
+    fn assert_coefficient_query_kernels_from_evaluation_backing_match_cpu(
+        log_coeff_size: u32,
+        lde_factor: usize,
+        values_per_leaf: usize,
+        tree_cap_size: usize,
+        expected_partial_cache: bool,
+    ) {
+        let worker = Worker::new();
+        let context = make_test_context(256, 32);
+        let monomial_coeffs = sample_monomial_coeffs(1 << log_coeff_size);
+        let twiddles = Twiddles::<BF, Global>::new(monomial_coeffs.len(), &worker);
+        let cpu = cpu_extension_oracle_from_monomial_form(
+            &monomial_coeffs,
+            &twiddles,
+            lde_factor,
+            values_per_leaf,
+            tree_cap_size,
+            true,
+            &worker,
+        );
+        let mut coefficient = GpuWhirExtensionOracle::from_monomial_coeffs(
+            &monomial_coeffs,
+            lde_factor,
+            values_per_leaf,
+            tree_cap_size,
+            true,
+            &context,
+        )
+        .unwrap();
+
+        match (&coefficient.trace_holder.trees, expected_partial_cache) {
+            (TreesHolder::Partial(_), true) | (TreesHolder::Full(_), false) => {}
+            _ => panic!("unexpected recursive cache mode"),
+        }
+
+        let total_leaves = monomial_coeffs.len() * lde_factor / values_per_leaf;
+        let mut folded_indexes = vec![0, total_leaves - 1, total_leaves / 2];
+        folded_indexes.push(31.min(total_leaves - 1));
+        folded_indexes.push(32.min(total_leaves - 1));
+        folded_indexes.sort_unstable();
+        folded_indexes.dedup();
+
+        let mut tree_indexes = Vec::with_capacity(folded_indexes.len());
+        let mut expected_values = Vec::with_capacity(folded_indexes.len());
+        let mut expected_paths = Vec::with_capacity(folded_indexes.len());
+        for folded_index in folded_indexes {
+            let (_, values, query) = cpu.query_for_folded_index(folded_index);
+            tree_indexes.push(query.index as u32);
+            expected_values.push(values);
+            expected_paths.push(query.path);
+        }
+        let queries_count = tree_indexes.len();
+        let layers_count = expected_paths[0].len();
+        assert!(expected_paths.iter().all(|path| path.len() == layers_count));
+
+        let stream = context.get_exec_stream();
+        let mut device_indexes = context
+            .alloc::<u32>(tree_indexes.len(), AllocationPlacement::BestFit)
+            .unwrap();
+        memory_copy_async(&mut device_indexes, &tree_indexes, stream).unwrap();
+        let (host_leaves, host_paths) = coefficient
+            .schedule_query_outputs_to_host(&device_indexes, &context)
+            .unwrap();
+        stream.synchronize().unwrap();
+        let host_leaves_accessor = host_leaves.get_accessor();
+        let host_paths_accessor = host_paths.get_accessor();
+        let host_leaves = unsafe { host_leaves_accessor.get() };
+        let host_paths = unsafe { host_paths_accessor.get() };
+
+        for query_index in 0..queries_count {
+            let leaf_start = query_index * values_per_leaf * EXT4_DEGREE;
+            let leaf_end = leaf_start + values_per_leaf * EXT4_DEGREE;
+            assert_eq!(
+                decode_leaf_values(&host_leaves[leaf_start..leaf_end], values_per_leaf),
+                expected_values[query_index],
+                "query {query_index} coefficient leaf mismatch",
+            );
+            let path_start = query_index * layers_count;
+            let path_end = path_start + layers_count;
+            assert_eq!(
+                &host_paths[path_start..path_end],
+                expected_paths[query_index].as_slice(),
+                "query {query_index} Merkle path mismatch",
+            );
+        }
+    }
+
+    #[test]
+    fn coefficient_query_kernels_from_evaluation_backing_match_cpu() {
+        assert_coefficient_query_kernels_from_evaluation_backing_match_cpu(6, 4, 2, 4, false);
+        assert_coefficient_query_kernels_from_evaluation_backing_match_cpu(7, 4, 2, 4, true);
+        assert_coefficient_query_kernels_from_evaluation_backing_match_cpu(6, 32, 32, 1, true);
+    }
+
+    #[test]
+    fn fused_coefficient_leaf_hash_matches_materialized_reference() {
+        let context = make_test_context(256, 32);
+        let monomial_coeffs = sample_monomial_coeffs(1 << 8);
+        const LDE_FACTOR: usize = 4;
+        const TREE_CAP_SIZE: usize = 16;
+
+        for log_values_per_leaf in 1..=5 {
+            let values_per_leaf = 1usize << log_values_per_leaf;
+            let evaluation = GpuWhirExtensionOracle::from_monomial_coeffs(
+                &monomial_coeffs,
+                LDE_FACTOR,
+                values_per_leaf,
+                TREE_CAP_SIZE,
+                false,
+                &context,
+            )
+            .unwrap();
+
+            let evaluations = evaluation.trace_holder.get_consolidated_cosets();
+            let stream = context.get_exec_stream();
+            let mut backing_before = vec![BF::ZERO; evaluations.len()];
+            memory_copy_async(&mut backing_before, evaluations, stream).unwrap();
+
+            let leaves_count = monomial_coeffs.len() * LDE_FACTOR / values_per_leaf;
+            let mut materialized = context
+                .alloc::<BF>(evaluations.len(), AllocationPlacement::BestFit)
+                .unwrap();
+            memory_copy_async(&mut materialized, evaluations, stream).unwrap();
+            {
+                let mut materialized_matrix =
+                    DeviceMatrixMut::new(&mut materialized, monomial_coeffs.len());
+                gpu_ntt::ntt::transform_whir_leaves_from_ntt_in_place_multi_coset(
+                    &mut materialized_matrix,
+                    8,
+                    LDE_FACTOR.trailing_zeros(),
+                    log_values_per_leaf,
+                    0,
+                    LDE_FACTOR as u32,
+                    stream,
+                )
+                .unwrap();
+            }
+            let mut reference_digests = context
+                .alloc::<Digest>(leaves_count, AllocationPlacement::BestFit)
+                .unwrap();
+            gpu_hash::blake2s::hash_leaves_from_ntt_multi_coset(
+                &materialized,
+                &mut reference_digests,
+                log_values_per_leaf,
+                EXT4_DEGREE as u32,
+                LDE_FACTOR.trailing_zeros(),
+                0,
+                LDE_FACTOR,
+                monomial_coeffs.len() / values_per_leaf,
+                monomial_coeffs.len() as u32,
+                stream,
+            )
+            .unwrap();
+
+            let mut fused_digests = context
+                .alloc::<Digest>(leaves_count, AllocationPlacement::BestFit)
+                .unwrap();
+            let transform_params = context
+                .ntt_device_context()
+                .whir_leaf_transform_params(log_values_per_leaf);
+            kernels::transform_and_hash_whir_leaves_from_ntt_multi_coset(
+                evaluations,
+                &mut fused_digests,
+                8,
+                LDE_FACTOR.trailing_zeros(),
+                log_values_per_leaf,
+                0,
+                LDE_FACTOR as u32,
+                transform_params,
+                stream,
+            )
+            .unwrap();
+
+            let mut actual_digests = vec![[0u32; gpu_hash::blake2s::STATE_SIZE]; leaves_count];
+            let mut expected_digests = vec![[0u32; gpu_hash::blake2s::STATE_SIZE]; leaves_count];
+            let mut backing_after = vec![BF::ZERO; evaluations.len()];
+            memory_copy_async(&mut actual_digests, &fused_digests, stream).unwrap();
+            memory_copy_async(&mut expected_digests, &reference_digests, stream).unwrap();
+            memory_copy_async(&mut backing_after, evaluations, stream).unwrap();
+            stream.synchronize().unwrap();
+
+            assert_eq!(
+                actual_digests, expected_digests,
+                "fused digest mismatch for values_per_leaf={values_per_leaf}",
+            );
+            assert_eq!(
+                backing_after, backing_before,
+                "fused commit mutated evaluation backing for values_per_leaf={values_per_leaf}",
+            );
+        }
+    }
+
+    fn assert_fused_coefficient_leaf_hash_matches_materialized_reference_under_load(
+        log_trace_len: u32,
+        lde_factor: usize,
+        values_per_leaf: usize,
+    ) {
+        const TREE_CAP_SIZE: usize = 16;
+
+        let context = make_test_context(256, 64);
+        let monomial_coeffs = sample_monomial_coeffs(1 << log_trace_len);
+        let oracle = GpuWhirExtensionOracle::from_monomial_coeffs(
+            &monomial_coeffs,
+            lde_factor,
+            values_per_leaf,
+            TREE_CAP_SIZE,
+            false,
+            &context,
+        )
+        .unwrap();
+
+        let stream = context.get_exec_stream();
+        let evaluations = oracle.trace_holder.get_consolidated_cosets();
+        let mut materialized = context
+            .alloc::<BF>(evaluations.len(), AllocationPlacement::BestFit)
+            .unwrap();
+        memory_copy_async(&mut materialized, evaluations, stream).unwrap();
+        {
+            let mut materialized_matrix =
+                DeviceMatrixMut::new(&mut materialized, 1 << log_trace_len);
+            gpu_ntt::ntt::transform_whir_leaves_from_ntt_in_place_multi_coset(
+                &mut materialized_matrix,
+                log_trace_len,
+                lde_factor.trailing_zeros(),
+                values_per_leaf.trailing_zeros(),
+                0,
+                lde_factor as u32,
+                stream,
+            )
+            .unwrap();
+        }
+
+        let total_leaves = (1usize << log_trace_len) * lde_factor / values_per_leaf;
+        let mut reference_leaves = context
+            .alloc::<Digest>(total_leaves, AllocationPlacement::BestFit)
+            .unwrap();
+        gpu_hash::blake2s::hash_leaves_from_ntt_multi_coset(
+            &materialized,
+            &mut reference_leaves,
+            values_per_leaf.trailing_zeros(),
+            EXT4_DEGREE as u32,
+            lde_factor.trailing_zeros(),
+            0,
+            lde_factor,
+            (1usize << log_trace_len) / values_per_leaf,
+            1 << log_trace_len,
+            stream,
+        )
+        .unwrap();
+        let mut fused_leaves = context
+            .alloc::<Digest>(total_leaves, AllocationPlacement::BestFit)
+            .unwrap();
+        let transform_params = context
+            .ntt_device_context()
+            .whir_leaf_transform_params(values_per_leaf.trailing_zeros());
+        kernels::transform_and_hash_whir_leaves_from_ntt_multi_coset(
+            evaluations,
+            &mut fused_leaves,
+            log_trace_len,
+            lde_factor.trailing_zeros(),
+            values_per_leaf.trailing_zeros(),
+            0,
+            lde_factor as u32,
+            transform_params,
+            stream,
+        )
+        .unwrap();
+        let mut reference_leaves_host = vec![Digest::default(); total_leaves];
+        let mut fused_leaves_host = vec![Digest::default(); total_leaves];
+        memory_copy_async(&mut reference_leaves_host, &reference_leaves, stream).unwrap();
+        memory_copy_async(&mut fused_leaves_host, &fused_leaves, stream).unwrap();
+        stream.synchronize().unwrap();
+        if let Some((leaf_idx, (fused, reference))) = fused_leaves_host
+            .iter()
+            .zip(&reference_leaves_host)
+            .enumerate()
+            .find(|(_, (fused, reference))| fused != reference)
+        {
+            panic!(
+                "fused coefficient leaf mismatch at leaf {leaf_idx} for log_trace_len={log_trace_len}, lde_factor={lde_factor}, values_per_leaf={values_per_leaf}: fused={fused:?}, reference={reference:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn fused_coefficient_leaf_hash_matches_materialized_reference_under_load() {
+        for _ in 0..8 {
+            assert_fused_coefficient_leaf_hash_matches_materialized_reference_under_load(
+                11, 2048, 32,
+            );
+            assert_fused_coefficient_leaf_hash_matches_materialized_reference_under_load(
+                3, 65536, 4,
+            );
+        }
+    }
+
     fn recursive_oracle_lde_matches_cpu_impl(
         log_coeff_sizes: &[usize],
         values_per_leafs: &[usize],
@@ -835,7 +1210,18 @@ pub(crate) mod tests {
                     transform_leaves_to_multilinear_coeffs,
                     &worker,
                 );
-                let gpu = GpuWhirExtensionOracle::from_monomial_coeffs(
+                let evaluation_cpu = transform_leaves_to_multilinear_coeffs.then(|| {
+                    cpu_extension_oracle_from_monomial_form(
+                        &monomial_coeffs,
+                        &twiddles,
+                        LDE_FACTOR,
+                        values_per_leaf,
+                        4,
+                        false,
+                        &worker,
+                    )
+                });
+                let mut gpu = GpuWhirExtensionOracle::from_monomial_coeffs(
                     &monomial_coeffs,
                     LDE_FACTOR,
                     values_per_leaf,
@@ -846,12 +1232,38 @@ pub(crate) mod tests {
                 .unwrap();
 
                 for coset_index in 0..LDE_FACTOR {
+                    let retained_backing_reference = evaluation_cpu.as_ref().unwrap_or(&cpu);
                     assert_eq!(
                         gpu.copy_coset_values(coset_index, &context),
-                        cpu.cosets[coset_index].values_normal_order.column.to_vec(),
+                        retained_backing_reference.cosets[coset_index]
+                            .values_normal_order
+                            .column
+                            .to_vec(),
                         "coset {} diverged",
                         coset_index
                     );
+                }
+
+                if transform_leaves_to_multilinear_coeffs {
+                    assert_eq!(
+                        gpu.get_tree_cap(&context).unwrap(),
+                        PathQueriable::get_cap(&cpu.tree),
+                    );
+                    let leaves_count = monomial_coeffs.len() * LDE_FACTOR / values_per_leaf;
+                    for query_index in [0, leaves_count / 2, leaves_count - 1] {
+                        let (_, cpu_values, cpu_query) = cpu.query_for_folded_index(query_index);
+                        let (_, gpu_values, gpu_query) =
+                            gpu.query_for_folded_index(query_index, &context).unwrap();
+                        assert_eq!(gpu_values, cpu_values);
+                        assert_eq!(
+                            gpu_query,
+                            GpuWhirExtensionQuery {
+                                index: cpu_query.index,
+                                leaf_values_concatenated: cpu_query.leaf_values_concatenated,
+                                path: cpu_query.path,
+                            }
+                        );
+                    }
                 }
             }
         }

--- a/gpu/whir/src/oracle_commit.rs
+++ b/gpu/whir/src/oracle_commit.rs
@@ -1,0 +1,342 @@
+use era_cudart::event::{CudaEvent, CudaEventCreateFlags};
+use era_cudart::result::CudaResult;
+use era_cudart::slice::DeviceSlice;
+use era_cudart::stream::CudaStreamWaitEventFlags;
+
+use gpu_core::allocator::tracker::AllocationPlacement;
+use gpu_core::primitives::device_structures::{
+    DeviceMatrixChunk, DeviceMatrixImpl, DeviceMatrixMut, DeviceMatrixMutImpl,
+};
+use gpu_core::primitives::field::BF;
+use gpu_hash::blake2s::{gather_tree_caps_inline, Digest, STATE_SIZE};
+use gpu_ntt::ntt::{lde_with_coset_range, MAX_LOG_N_FOR_SINGLE_KERNEL_LDE};
+use gpu_prover_context::ProverContext;
+use gpu_trace::trace::holder::{TraceHolder, TreesHolder, PARTIAL_TREE_REDUCTION_LAYERS};
+
+/// Schedules the recursive WHIR oracle's natural multi-coset LDE, leaf
+/// commitment, tree construction, and cap gather. The holder uses the WHIR
+/// shape (`log_lde_factor = log_rows_per_leaf = 0`); the actual LDE and leaf
+/// widths are explicit protocol inputs.
+pub(crate) fn schedule_recursive_oracle_commit(
+    trace_holder: &mut TraceHolder<BF>,
+    inputs_matrix: &DeviceMatrixChunk<BF>,
+    cap_dst_u32: &mut DeviceSlice<u32>,
+    log_trace_len: u32,
+    natural_log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    src_cols_per_coset: usize,
+    transform_leaves_to_multilinear_coeffs: bool,
+    context: &ProverContext,
+) -> CudaResult<()> {
+    assert_eq!(
+        trace_holder.log_lde_factor, 0,
+        "recursive WHIR commit requires TraceHolder log_lde_factor = 0",
+    );
+    assert_eq!(
+        trace_holder.log_rows_per_leaf, 0,
+        "recursive WHIR commit requires TraceHolder log_rows_per_leaf = 0",
+    );
+    let log_tree_cap_size = trace_holder.log_tree_cap_size;
+    let cap_size = 1usize << log_tree_cap_size;
+    assert_eq!(
+        cap_dst_u32.len(),
+        cap_size * STATE_SIZE,
+        "recursive WHIR cap destination has the wrong length",
+    );
+
+    let lde_factor = 1usize << natural_log_lde_factor;
+    let trace_len = 1usize << log_trace_len;
+    let evals_total_len = lde_factor * trace_len * src_cols_per_coset;
+    let total_leaf_count_log2 = (log_trace_len - log_values_per_leaf) + natural_log_lde_factor;
+    let total_leaf_count = 1usize << total_leaf_count_log2;
+    let full_tree_len = total_leaf_count << 1;
+    let cap_words = (cap_size * STATE_SIZE) as u32;
+    let stream = context.get_exec_stream();
+
+    let (ntt_output, trees) = trace_holder.get_uninit_cosets_and_tree_mut();
+    assert_eq!(ntt_output.len(), evals_total_len);
+
+    match trees {
+        TreesHolder::Full(backing) => {
+            commit_trace_from_ntt_single_tree(
+                inputs_matrix,
+                ntt_output,
+                backing,
+                log_trace_len,
+                natural_log_lde_factor,
+                log_values_per_leaf,
+                log_tree_cap_size,
+                src_cols_per_coset,
+                transform_leaves_to_multilinear_coeffs,
+                context,
+            )?;
+        }
+        TreesHolder::Partial(backing) => {
+            // The transient top contains leaves plus the four node layers
+            // omitted by the persistent partial-tree cache.
+            let mut tree_top =
+                context.alloc::<Digest>(full_tree_len, AllocationPlacement::BestFit)?;
+            let top_log_cap = total_leaf_count_log2 + 1 - PARTIAL_TREE_REDUCTION_LAYERS;
+            commit_trace_from_ntt_single_tree(
+                inputs_matrix,
+                ntt_output,
+                &mut tree_top,
+                log_trace_len,
+                natural_log_lde_factor,
+                log_values_per_leaf,
+                top_log_cap,
+                src_cols_per_coset,
+                transform_leaves_to_multilinear_coeffs,
+                context,
+            )?;
+
+            let bottom_layers_count =
+                total_leaf_count_log2 + 1 - PARTIAL_TREE_REDUCTION_LAYERS - log_tree_cap_size;
+            let tree_bottom_len = full_tree_len >> PARTIAL_TREE_REDUCTION_LAYERS;
+            assert_eq!(backing.len(), tree_bottom_len);
+            let values = &tree_top[full_tree_len - 2 * tree_bottom_len..][..tree_bottom_len];
+            gpu_hash::blake2s::build_merkle_tree_nodes(
+                values,
+                backing,
+                bottom_layers_count,
+                stream,
+            )?;
+        }
+        TreesHolder::None => {
+            panic!("recursive WHIR commit does not support TreesCacheMode::CacheNone",)
+        }
+    }
+
+    match &*trees {
+        TreesHolder::Full(backing) => {
+            let cap_offset_digests = full_tree_len - (1usize << (log_tree_cap_size + 1));
+            let cap_offset_words = cap_offset_digests * STATE_SIZE;
+            let stride_words = (full_tree_len * STATE_SIZE) as u32;
+            let base_words = backing.as_ptr() as *const u32;
+            let cap_base = unsafe { base_words.add(cap_offset_words) };
+            gather_tree_caps_inline(cap_base, cap_words, stride_words, 0, cap_dst_u32, stream)?;
+        }
+        TreesHolder::Partial(backing) => {
+            let tree_bottom_len = full_tree_len >> PARTIAL_TREE_REDUCTION_LAYERS;
+            let cap_offset_digests = tree_bottom_len - (1usize << (log_tree_cap_size + 1));
+            let cap_offset_words = cap_offset_digests * STATE_SIZE;
+            let stride_words = (tree_bottom_len * STATE_SIZE) as u32;
+            let base_words = backing.as_ptr() as *const u32;
+            let cap_base = unsafe { base_words.add(cap_offset_words) };
+            gather_tree_caps_inline(cap_base, cap_words, stride_words, 0, cap_dst_u32, stream)?;
+        }
+        TreesHolder::None => unreachable!(),
+    }
+
+    Ok(())
+}
+
+/// Builds a single flat Merkle tree across every natural LDE coset.
+/// Coefficient leaves are transformed into shared memory and hashed without
+/// overwriting the natural evaluation backing.
+fn commit_trace_from_ntt_single_tree(
+    inputs_matrix: &DeviceMatrixChunk<BF>,
+    ntt_output: &mut DeviceSlice<BF>,
+    trees_backing: &mut DeviceSlice<Digest>,
+    log_trace_len: u32,
+    natural_log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    log_tree_cap_size: u32,
+    src_cols_per_coset: usize,
+    transform_leaves_to_multilinear_coeffs: bool,
+    context: &ProverContext,
+) -> CudaResult<()> {
+    assert!(natural_log_lde_factor >= 1);
+    assert!(log_trace_len >= log_values_per_leaf);
+    let trace_len = 1 << log_trace_len;
+    let packed_leaf_count = 1usize << (log_trace_len - log_values_per_leaf);
+    let total_leaf_count = packed_leaf_count
+        .checked_mul(1 << natural_log_lde_factor)
+        .expect("total_leaf_count overflow");
+    assert_eq!(trees_backing.len(), total_leaf_count << 1);
+    let total_leaf_count_log2 = (log_trace_len - log_values_per_leaf) + natural_log_lde_factor;
+    assert!(log_tree_cap_size <= total_leaf_count_log2);
+    let layers_count = total_leaf_count_log2 + 1 - log_tree_cap_size;
+    let (leaves, nodes) = trees_backing.split_at_mut(total_leaf_count);
+
+    let device_properties = context.get_device_properties();
+    let ntt_ctx = context.ntt_device_context();
+    // Recursive WHIR folds to a small trace (trace_len_log2 <= 13), the DIT
+    // forward-NTT range, which needs a pooled d-table scratch (len >= N).
+    let mut d_scratch = if log_trace_len <= 13 {
+        Some(context.alloc::<BF>(trace_len, AllocationPlacement::BestFit)?)
+    } else {
+        None
+    };
+
+    let include_lde_in_l2_persistence_chain =
+        log_trace_len as usize > MAX_LOG_N_FOR_SINGLE_KERNEL_LDE;
+    let total_cosets = 1 << natural_log_lde_factor;
+    // The L2 fractions and power-of-two tile rounding are empirically tuned.
+    let l2_bytes_with_safety_margin = if include_lde_in_l2_persistence_chain {
+        device_properties.l2_cache_size_bytes >> 1
+    } else {
+        device_properties.l2_cache_size_bytes >> 2
+    };
+    let single_bf_col_bytes = std::mem::size_of::<BF>() << log_trace_len;
+    let single_coset_bytes = src_cols_per_coset * single_bf_col_bytes;
+
+    let half_l2_bytes_with_safety_margin = l2_bytes_with_safety_margin >> 1;
+    let (mut cosets_in_tile_chunk, mut num_streams) =
+        if single_coset_bytes > half_l2_bytes_with_safety_margin {
+            (1, 1)
+        } else {
+            let nearest = half_l2_bytes_with_safety_margin / single_coset_bytes;
+            if nearest.is_power_of_two() {
+                (nearest, 2)
+            } else {
+                (nearest.next_power_of_two() >> 1, 2)
+            }
+        };
+
+    if total_cosets > cosets_in_tile_chunk {
+        assert_eq!(total_cosets % cosets_in_tile_chunk, 0);
+    }
+
+    let is_last_production_whir_stage = (log_trace_len - log_values_per_leaf) == 1;
+    if (!include_lde_in_l2_persistence_chain && !transform_leaves_to_multilinear_coeffs)
+        || is_last_production_whir_stage
+    {
+        num_streams = 1;
+        cosets_in_tile_chunk = total_cosets;
+    }
+
+    let mut ntt_output_matrix = DeviceMatrixMut::new(ntt_output, trace_len);
+    let (start_event, end_event) = if num_streams > 1 {
+        (
+            Some(CudaEvent::create_with_flags(
+                CudaEventCreateFlags::DISABLE_TIMING,
+            )?),
+            Some(CudaEvent::create_with_flags(
+                CudaEventCreateFlags::DISABLE_TIMING,
+            )?),
+        )
+    } else {
+        (None, None)
+    };
+
+    let mut occupancy_hint_numerator = 1;
+    let mut occupancy_hint_denominator = 1;
+    let exec_stream = context.get_exec_stream();
+    let side_stream = context.get_side_stream();
+    let streams = [exec_stream, side_stream];
+
+    if !include_lde_in_l2_persistence_chain {
+        let scratch_opt = d_scratch.as_mut().map(|scratch| &mut scratch[..]);
+        lde_with_coset_range(
+            inputs_matrix,
+            ntt_output_matrix.slice_mut(),
+            log_trace_len as usize,
+            natural_log_lde_factor as usize,
+            total_cosets,
+            0,
+            src_cols_per_coset,
+            occupancy_hint_numerator,
+            occupancy_hint_denominator,
+            ntt_ctx,
+            scratch_opt,
+            streams[0],
+            device_properties,
+        )?;
+    }
+
+    if num_streams > 1 {
+        occupancy_hint_numerator = 5;
+        occupancy_hint_denominator = 8;
+        start_event.as_ref().unwrap().record(streams[0])?;
+        streams[1].wait_event(
+            start_event.as_ref().unwrap(),
+            CudaStreamWaitEventFlags::DEFAULT,
+        )?;
+    }
+
+    for coset_index_base in (0..total_cosets).step_by(num_streams * cosets_in_tile_chunk) {
+        let mut helpers_per_stream = Vec::with_capacity(2);
+        for i in 0..num_streams {
+            let coset_index_base_this_stream = coset_index_base + i * cosets_in_tile_chunk;
+            if coset_index_base_this_stream < total_cosets {
+                let cosets_in_tile = std::cmp::min(
+                    cosets_in_tile_chunk,
+                    total_cosets - coset_index_base_this_stream,
+                );
+                let offset = src_cols_per_coset * trace_len * coset_index_base_this_stream;
+                helpers_per_stream.push((coset_index_base_this_stream, cosets_in_tile, offset));
+            }
+        }
+
+        // Preserve the breadth-first two-stream launch order.
+        for (i, &(coset_index_base_this_stream, cosets_in_tile, offset)) in
+            helpers_per_stream.iter().enumerate()
+        {
+            if include_lde_in_l2_persistence_chain {
+                let scratch_opt = d_scratch.as_mut().map(|scratch| &mut scratch[..]);
+                lde_with_coset_range(
+                    inputs_matrix,
+                    &mut ntt_output_matrix.slice_mut()[offset..],
+                    log_trace_len as usize,
+                    natural_log_lde_factor as usize,
+                    cosets_in_tile,
+                    coset_index_base_this_stream,
+                    src_cols_per_coset,
+                    occupancy_hint_numerator,
+                    occupancy_hint_denominator,
+                    ntt_ctx,
+                    scratch_opt,
+                    streams[i],
+                    device_properties,
+                )?;
+            }
+        }
+        if transform_leaves_to_multilinear_coeffs {
+            assert_eq!(src_cols_per_coset, 4, "coefficient WHIR leaves require E4");
+            let transform_params = ntt_ctx.whir_leaf_transform_params(log_values_per_leaf);
+            for (i, &(coset_index_base_this_stream, cosets_in_tile, offset)) in
+                helpers_per_stream.iter().enumerate()
+            {
+                crate::kernels::transform_and_hash_whir_leaves_from_ntt_multi_coset(
+                    &ntt_output_matrix.slice()[offset..],
+                    leaves,
+                    log_trace_len,
+                    natural_log_lde_factor,
+                    log_values_per_leaf,
+                    coset_index_base_this_stream as u32,
+                    cosets_in_tile as u32,
+                    transform_params,
+                    streams[i],
+                )?;
+            }
+        } else {
+            for (i, &(coset_index_base_this_stream, cosets_in_tile, offset)) in
+                helpers_per_stream.iter().enumerate()
+            {
+                gpu_hash::blake2s::hash_leaves_from_ntt_multi_coset(
+                    &ntt_output_matrix.slice()[offset..],
+                    leaves,
+                    log_values_per_leaf,
+                    src_cols_per_coset as u32,
+                    natural_log_lde_factor,
+                    coset_index_base_this_stream as u32,
+                    cosets_in_tile,
+                    packed_leaf_count,
+                    trace_len as u32,
+                    streams[i],
+                )?;
+            }
+        }
+    }
+
+    if num_streams > 1 {
+        end_event.as_ref().unwrap().record(side_stream)?;
+        exec_stream.wait_event(
+            end_event.as_ref().unwrap(),
+            CudaStreamWaitEventFlags::DEFAULT,
+        )?;
+    }
+
+    gpu_hash::blake2s::build_merkle_tree_nodes(leaves, nodes, layers_count - 1, exec_stream)
+}


### PR DESCRIPTION
## What ❔

Fuses recursive WHIR coefficient-leaf transformation with GPU hashing, retaining evaluation-form backing and reconstructing coefficient query leaves on demand. The recursive commitment scheduler moves from `gpu_trace` to `gpu_whir`, which owns the protocol-specific path.

## Why ❔

This removes the global coefficient materialization pass. Median GPU timings improve by 38.65% for transform plus leaf hashing, 9.78% for `gkr.whir.schedule`, and 1.92% for the full proof.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
