### PR TITLE
perf(gkr): count lookup multiplicities with sharded atomics

### DIFF
--- a/gpu/AGENTS.md
+++ b/gpu/AGENTS.md
@@ -115,8 +115,8 @@ root in `gkr_eval_ir`; `gpu_gkr_compiler` depends on it.
   upward threads a `&ProverContext` through its scheduling functions. See
   [`prover_context/AGENTS.md`](prover_context/AGENTS.md).
 - **`gpu_trace`** = witness generation (`witness/**`) + trace commit/holder
-  (`trace/**`), with its own `gpu_trace_native` (28 kernels: 17 literal + 11
-  token-pasted via the `KERNEL_NAME(NAME)` macro, one per circuit under
+  (`trace/**`), with its own `gpu_trace_native` (40 kernels: 18 literal + 22
+  token-pasted witness and fused stage-1 kernels, two per circuit under
   `witness/circuits/`), namespace `airbender::trace::witness::*`.
   Self-contained (only `gpu_core`'s base headers; no `export_include`, no
   PoW kernel). Owns the upstream-constant drift guards (compile-time asserts

--- a/gpu/gkr/src/stage1/mod.rs
+++ b/gpu/gkr/src/stage1/mod.rs
@@ -28,7 +28,7 @@ use gpu_trace::witness::memory_unrolled::{
     generate_memory_and_witness_values_unrolled_unified,
 };
 use gpu_trace::witness::multiplicities::{
-    allocate_range_check_lookup_mappings, generate_generic_lookup_multiplicities,
+    allocate_range_check_lookup_mappings, generate_lookup_multiplicities,
     generate_range_check_lookup_mappings,
 };
 use gpu_trace::witness::trace_unrolled::{
@@ -262,10 +262,11 @@ impl GpuGKRStage1Output {
         let use_fused_delegation = strategy == WitnessGenerationStrategy::Fused
             && matches!(circuit_type, CircuitType::Delegation(_));
         let produces_all_mappings_early = use_fused_unrolled || use_fused_delegation;
-        let mut generic_family = context.alloc(
-            num_generic_family_cols * trace_len,
-            AllocationPlacement::Top,
-        )?;
+        let generic_family_len = num_generic_family_cols
+            .checked_mul(trace_len)
+            .expect("generic lookup mapping length overflow");
+        let mut generic_family = context.alloc(generic_family_len, AllocationPlacement::Top)?;
+        assert_eq!(generic_family.len(), generic_family_len);
         let (mut early_range_check_16, mut early_timestamp) = if produces_all_mappings_early {
             let (range_check_16, timestamp) =
                 allocate_range_check_lookup_mappings(compiled_circuit, context)?;
@@ -659,10 +660,10 @@ impl GpuGKRStage1Output {
             let generic_lookup_multiplicities = &mut witness_matrix.slice_mut()
                 [generic_lookup_multiplicities_range.start * trace_len
                     ..generic_lookup_multiplicities_range.end * trace_len];
-            generate_generic_lookup_multiplicities(
+            generate_lookup_multiplicities(
                 &mut DeviceMatrixMut::new(&mut generic_family, trace_len),
                 &mut DeviceMatrixMut::new(generic_lookup_multiplicities, trace_len),
-                u32::BITS as i32, // generic lookups: full 32-bit sort
+                compiled_circuit.total_tables_size,
                 context,
             )?;
             multiplicities_range.end(stream)?;

--- a/gpu/gkr/src/stage1/mod.rs
+++ b/gpu/gkr/src/stage1/mod.rs
@@ -251,7 +251,9 @@ impl GpuGKRStage1Output {
 
         let num_generic_sets = compiled_circuit.generic_lookups.len();
         let has_decoder = compiled_circuit.has_decoder_lookup;
-        let num_generic_family_cols = num_generic_sets + usize::from(has_decoder);
+        let num_generic_family_cols = num_generic_sets
+            .checked_add(usize::from(has_decoder))
+            .expect("generic lookup mapping column count overflow");
         let use_fused_unrolled = strategy == WitnessGenerationStrategy::Fused
             && matches!(
                 circuit_type,
@@ -292,7 +294,9 @@ impl GpuGKRStage1Output {
         };
 
         {
-            let generic_prefix_len = num_generic_sets * trace_len;
+            let generic_prefix_len = num_generic_sets
+                .checked_mul(trace_len)
+                .expect("generic lookup mapping prefix length overflow");
             let (generic_mapping_prefix, decoder_mapping_suffix) =
                 generic_family.split_at_mut(generic_prefix_len);
             let decoder_lookup_mapping = if has_decoder {

--- a/gpu/gkr/src/stage1/mod.rs
+++ b/gpu/gkr/src/stage1/mod.rs
@@ -251,9 +251,7 @@ impl GpuGKRStage1Output {
 
         let num_generic_sets = compiled_circuit.generic_lookups.len();
         let has_decoder = compiled_circuit.has_decoder_lookup;
-        let num_generic_family_cols = num_generic_sets
-            .checked_add(usize::from(has_decoder))
-            .expect("generic lookup mapping column count overflow");
+        let num_generic_family_cols = num_generic_sets + usize::from(has_decoder);
         let use_fused_unrolled = strategy == WitnessGenerationStrategy::Fused
             && matches!(
                 circuit_type,
@@ -264,11 +262,10 @@ impl GpuGKRStage1Output {
         let use_fused_delegation = strategy == WitnessGenerationStrategy::Fused
             && matches!(circuit_type, CircuitType::Delegation(_));
         let produces_all_mappings_early = use_fused_unrolled || use_fused_delegation;
-        let generic_family_len = num_generic_family_cols
-            .checked_mul(trace_len)
-            .expect("generic lookup mapping length overflow");
-        let mut generic_family = context.alloc(generic_family_len, AllocationPlacement::Top)?;
-        assert_eq!(generic_family.len(), generic_family_len);
+        let mut generic_family = context.alloc(
+            num_generic_family_cols * trace_len,
+            AllocationPlacement::Top,
+        )?;
         let (mut early_range_check_16, mut early_timestamp) = if produces_all_mappings_early {
             let (range_check_16, timestamp) =
                 allocate_range_check_lookup_mappings(compiled_circuit, context)?;
@@ -294,9 +291,7 @@ impl GpuGKRStage1Output {
         };
 
         {
-            let generic_prefix_len = num_generic_sets
-                .checked_mul(trace_len)
-                .expect("generic lookup mapping prefix length overflow");
+            let generic_prefix_len = num_generic_sets * trace_len;
             let (generic_mapping_prefix, decoder_mapping_suffix) =
                 generic_family.split_at_mut(generic_prefix_len);
             let decoder_lookup_mapping = if has_decoder {

--- a/gpu/gkr/src/stage1/multiplicities.rs
+++ b/gpu/gkr/src/stage1/multiplicities.rs
@@ -3,7 +3,9 @@ use era_cudart::result::CudaResult;
 use gpu_core::primitives::device_structures::{DeviceMatrixMut, DeviceMatrixMutImpl};
 use gpu_core::primitives::field::BF;
 use gpu_prover_context::ProverContext;
-use gpu_trace::witness::multiplicities::generate_generic_lookup_multiplicities;
+use gpu_trace::witness::multiplicities::{
+    generate_lookup_multiplicities, RANGE_CHECK_16_DOMAIN_SIZE, TIMESTAMP_RANGE_CHECK_DOMAIN_SIZE,
+};
 
 pub(crate) fn generate_range_check_multiplicities_from_mappings(
     circuit: &GKRCircuitArtifact<BF>,
@@ -27,10 +29,10 @@ pub(crate) fn generate_range_check_multiplicities_from_mappings(
     let range_check_16_lookup_multiplicities = &mut witness.slice_mut()
         [range_check_16_lookup_multiplicities_range.start * trace_len
             ..range_check_16_lookup_multiplicities_range.end * trace_len];
-    generate_generic_lookup_multiplicities(
+    generate_lookup_multiplicities(
         range_check_16_lookup_mapping,
         &mut DeviceMatrixMut::new(range_check_16_lookup_multiplicities, trace_len),
-        17, // 16-bit values + 1 sentinel bit
+        RANGE_CHECK_16_DOMAIN_SIZE,
         context,
     )?;
     let range_check_timestamp_lookup_multiplicities_range = circuit
@@ -40,10 +42,10 @@ pub(crate) fn generate_range_check_multiplicities_from_mappings(
     let range_check_timestamp_lookup_multiplicities = &mut witness.slice_mut()
         [range_check_timestamp_lookup_multiplicities_range.start * trace_len
             ..range_check_timestamp_lookup_multiplicities_range.end * trace_len];
-    generate_generic_lookup_multiplicities(
+    generate_lookup_multiplicities(
         range_check_timestamp_lookup_mapping,
         &mut DeviceMatrixMut::new(range_check_timestamp_lookup_multiplicities, trace_len),
-        20, // 19-bit values (TIMESTAMP_COLUMNS_NUM_BITS) + 1 sentinel bit
+        TIMESTAMP_RANGE_CHECK_DOMAIN_SIZE,
         context,
     )?;
     Ok(())

--- a/gpu/trace/AGENTS.md
+++ b/gpu/trace/AGENTS.md
@@ -12,7 +12,7 @@ transform, Merkle-tree build). It carries the `gpu_trace_native` CUDA archive
 gpu_trace < gpu_gkr < gpu_whir < gpu_circuit_prover < gpu_execution_prover <
 gpu_program_prover` — see [`../AGENTS.md`](../AGENTS.md) for the full cluster
 DAG. Dependencies point only down: this crate depends on `gpu_core`,
-`gpu_ntt`, `gpu_ops`, `gpu_hash`, `gpu_cub`, and `gpu_prover_context`, plus
+`gpu_ntt`, `gpu_ops`, `gpu_hash`, and `gpu_prover_context`, plus
 the upstream crates below; `gpu_gkr`/`gpu_whir`/`gpu_circuit_prover` depend on
 it, never the reverse.
 
@@ -64,13 +64,11 @@ because the witness CUDA it guards moved here.
 - **Archive / `links` key**: `gpu_trace_native` (`build.rs` is a one-line
   `gpu_native_build::CudaArchive::new("gpu_trace_native", "GPU_TRACE").build()`
   call — no `export_include`, no `deterministic_pow`).
-- **Kernel count**: 31 (`__global__` kernels, verified by grep) — 20 literal
-  (`memory_delegation.cu` 8, `memory_unrolled.cu` 7, `multiplicities.cu` 2,
-  `circuits/add_sub_lui_auipc_mop.cuh` 3)
-  plus 11 token-pasted `ab_generate_witness_values_<NAME>_kernel` symbols
-  (never appear as literals in native — formed by the `KERNEL_NAME(NAME)`
-  macro in `witness_generation.cuh`, one per circuit under
-  `witness/circuits/`). No `__device__ __constant__` symbols in this archive
+- **Kernel count**: 40 — 18 literal (`memory_delegation.cu` 8,
+  `memory_unrolled.cu` 7, `multiplicities.cu` 3) plus 22 token-pasted witness
+  and fused stage-1 kernels (two per circuit under `witness/circuits/`). The
+  three macro declarations make a source-level `__global__` grep report 21.
+  No `__device__ __constant__` symbols in this archive
   (all 8 cluster-wide ones live in `gpu_gkr`).
 - **Namespace**: `airbender::trace::witness::*` (sub-namespaces per concern:
   `memory`, `memory::delegation`, `memory::unrolled`, `multiplicities`,

--- a/gpu/trace/Cargo.toml
+++ b/gpu/trace/Cargo.toml
@@ -16,7 +16,6 @@ gpu_core = { workspace = true }
 gpu_ntt = { workspace = true }
 gpu_ops = { workspace = true }
 gpu_hash = { workspace = true }
-gpu_cub = { workspace = true }
 gpu_prover_context = { workspace = true }
 
 era_cudart = "=0.156.0"

--- a/gpu/trace/native/witness/multiplicities.cu
+++ b/gpu/trace/native/witness/multiplicities.cu
@@ -8,6 +8,9 @@ using namespace ::airbender::trace::witness::memory;
 
 namespace airbender::trace::witness::multiplicities {
 
+static_assert(sizeof(bf) == sizeof(u32));
+static_assert(alignof(bf) == alignof(u32));
+
 EXTERN __global__ void ab_count_multiplicities_kernel(u32 *const __restrict__ lookup_mapping, const unsigned lookup_mapping_size,
                                                       bf *const __restrict__ multiplicities, const unsigned active_counts_len) {
   const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
@@ -30,8 +33,7 @@ EXTERN __global__ void ab_count_multiplicities_kernel(u32 *const __restrict__ lo
   const unsigned lane = threadIdx.x & (warpSize - 1);
   const unsigned leader = __ffs(peers) - 1;
   if (lane == leader) {
-    auto *raw_counts = reinterpret_cast<u32 *>(multiplicities);
-    (void)atomicAdd(raw_counts + index, __popc(peers));
+    (void)atomicAdd(&multiplicities[index].limb, __popc(peers));
   }
 }
 
@@ -39,8 +41,7 @@ EXTERN __global__ void ab_convert_multiplicities_kernel(bf *const __restrict__ m
   const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
   if (gid >= active_counts_len)
     return;
-  auto *raw_counts = reinterpret_cast<u32 *>(multiplicities);
-  multiplicities[gid] = bf::from_u32_unchecked(raw_counts[gid]);
+  multiplicities[gid] = bf::from_u32_unchecked(multiplicities[gid].limb);
 }
 
 EXTERN __launch_bounds__(128, 8) __global__

--- a/gpu/trace/native/witness/multiplicities.cu
+++ b/gpu/trace/native/witness/multiplicities.cu
@@ -12,7 +12,8 @@ static_assert(sizeof(bf) == sizeof(u32));
 static_assert(alignof(bf) == alignof(u32));
 
 EXTERN __global__ void ab_count_multiplicities_kernel(u32 *const __restrict__ lookup_mapping, const unsigned lookup_mapping_size,
-                                                      bf *const __restrict__ multiplicities, const unsigned active_counts_len) {
+                                                      bf *const __restrict__ counter_shards, const unsigned active_counts_len,
+                                                      const unsigned counter_replicas) {
   const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
   const unsigned active_mask = __activemask();
   const bool in_bounds = gid < lookup_mapping_size;
@@ -33,15 +34,21 @@ EXTERN __global__ void ab_count_multiplicities_kernel(u32 *const __restrict__ lo
   const unsigned lane = threadIdx.x & (warpSize - 1);
   const unsigned leader = __ffs(peers) - 1;
   if (lane == leader) {
-    (void)atomicAdd(&multiplicities[index].limb, __popc(peers));
+    const unsigned replica = blockIdx.x & (counter_replicas - 1);
+    (void)atomicAdd(&counter_shards[replica * active_counts_len + index].limb, __popc(peers));
   }
 }
 
-EXTERN __global__ void ab_convert_multiplicities_kernel(bf *const __restrict__ multiplicities, const unsigned active_counts_len) {
+// counter_shards may alias multiplicities when the output tail stores the replicas.
+EXTERN __global__ void ab_reduce_convert_multiplicities_kernel(const bf *const counter_shards, bf *const multiplicities, const unsigned active_counts_len,
+                                                               const unsigned counter_replicas) {
   const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
   if (gid >= active_counts_len)
     return;
-  multiplicities[gid] = bf::from_u32_unchecked(multiplicities[gid].limb);
+  u32 count = 0;
+  for (unsigned replica = 0; replica < counter_replicas; ++replica)
+    count += counter_shards[replica * active_counts_len + gid].limb;
+  multiplicities[gid] = bf::from_u32_unchecked(count);
 }
 
 EXTERN __launch_bounds__(128, 8) __global__

--- a/gpu/trace/native/witness/multiplicities.cu
+++ b/gpu/trace/native/witness/multiplicities.cu
@@ -11,17 +11,28 @@ namespace airbender::trace::witness::multiplicities {
 EXTERN __global__ void ab_count_multiplicities_kernel(u32 *const __restrict__ lookup_mapping, const unsigned lookup_mapping_size,
                                                       bf *const __restrict__ multiplicities, const unsigned active_counts_len) {
   const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
-  if (gid >= lookup_mapping_size)
-    return;
-  const u32 index = load<u32, ld_modifier::cs>(lookup_mapping + gid);
-  if (index == 0xffffffffu) {
+  const unsigned active_mask = __activemask();
+  const bool in_bounds = gid < lookup_mapping_size;
+  const u32 index = in_bounds ? load<u32, ld_modifier::cs>(lookup_mapping + gid) : 0xffffffffu;
+  const bool countable = in_bounds && index != 0xffffffffu;
+  const bool invalid = countable && index >= active_counts_len;
+  const unsigned invalid_mask = __ballot_sync(active_mask, invalid);
+  const unsigned countable_mask = __ballot_sync(active_mask, countable);
+
+  if (in_bounds && index == 0xffffffffu)
     store<u32, st_modifier::cs>(lookup_mapping + gid, 0);
-    return;
-  }
-  if (index >= active_counts_len)
+  if (invalid_mask != 0)
     __trap();
-  auto *raw_counts = reinterpret_cast<u32 *>(multiplicities);
-  (void)atomicAdd(raw_counts + index, 1u);
+  if (!countable)
+    return;
+
+  const unsigned peers = __match_any_sync(countable_mask, index);
+  const unsigned lane = threadIdx.x & (warpSize - 1);
+  const unsigned leader = __ffs(peers) - 1;
+  if (lane == leader) {
+    auto *raw_counts = reinterpret_cast<u32 *>(multiplicities);
+    (void)atomicAdd(raw_counts + index, __popc(peers));
+  }
 }
 
 EXTERN __global__ void ab_convert_multiplicities_kernel(bf *const __restrict__ multiplicities, const unsigned active_counts_len) {

--- a/gpu/trace/native/witness/multiplicities.cu
+++ b/gpu/trace/native/witness/multiplicities.cu
@@ -8,25 +8,28 @@ using namespace ::airbender::trace::witness::memory;
 
 namespace airbender::trace::witness::multiplicities {
 
-EXTERN __global__ void ab_generate_multiplicities_kernel(const u32 *const __restrict__ unique_indexes, const u32 *const __restrict__ counts,
-                                                         const u32 *const __restrict__ num_runs, u32 *const __restrict__ lookup_mapping,
-                                                         const unsigned lookup_mapping_size, const matrix_setter<bf, st_modifier::cs> multiplicities,
-                                                         const unsigned multiplicities_size) {
+EXTERN __global__ void ab_count_multiplicities_kernel(u32 *const __restrict__ lookup_mapping, const unsigned lookup_mapping_size,
+                                                      bf *const __restrict__ multiplicities, const unsigned active_counts_len) {
   const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
-  if (gid < lookup_mapping_size && lookup_mapping[gid] == 0xffffffffu)
-    lookup_mapping[gid] = 0;
-  if (gid >= multiplicities_size)
+  if (gid >= lookup_mapping_size)
     return;
-  if (gid >= num_runs[0])
+  const u32 index = load<u32, ld_modifier::cs>(lookup_mapping + gid);
+  if (index == 0xffffffffu) {
+    store<u32, st_modifier::cs>(lookup_mapping + gid, 0);
     return;
-  const unsigned stride = multiplicities.stride;
-  const u32 index = unique_indexes[gid];
-  if (index == 0xffffffffu)
+  }
+  if (index >= active_counts_len)
+    __trap();
+  auto *raw_counts = reinterpret_cast<u32 *>(multiplicities);
+  (void)atomicAdd(raw_counts + index, 1u);
+}
+
+EXTERN __global__ void ab_convert_multiplicities_kernel(bf *const __restrict__ multiplicities, const unsigned active_counts_len) {
+  const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (gid >= active_counts_len)
     return;
-  const unsigned row = index % stride;
-  const unsigned col = index / stride;
-  const bf value = bf::from_u32_unchecked(counts[gid]);
-  multiplicities.set(row, col, value);
+  auto *raw_counts = reinterpret_cast<u32 *>(multiplicities);
+  multiplicities[gid] = bf::from_u32_unchecked(raw_counts[gid]);
 }
 
 EXTERN __launch_bounds__(128, 8) __global__

--- a/gpu/trace/src/witness/multiplicities.rs
+++ b/gpu/trace/src/witness/multiplicities.rs
@@ -17,20 +17,24 @@ use gpu_prover_context::ProverContext;
 
 pub const RANGE_CHECK_16_DOMAIN_SIZE: usize = 1 << 16;
 pub const TIMESTAMP_RANGE_CHECK_DOMAIN_SIZE: usize = 1 << TIMESTAMP_COLUMNS_NUM_BITS;
+const COUNTER_REPLICAS: usize = 8;
 
 cuda_kernel!(CountMultiplicities,
     ab_count_multiplicities_kernel(
         lookup_mapping: *mut u32,
         lookup_mapping_size: u32,
-        multiplicities: *mut BF,
+        counter_shards: *mut BF,
         active_counts_len: u32,
+        counter_replicas: u32,
     )
 );
 
-cuda_kernel!(ConvertMultiplicities,
-    ab_convert_multiplicities_kernel(
+cuda_kernel!(ReduceConvertMultiplicities,
+    ab_reduce_convert_multiplicities_kernel(
+        counter_shards: *const BF,
         multiplicities: *mut BF,
         active_counts_len: u32,
+        counter_replicas: u32,
     )
 );
 
@@ -45,35 +49,60 @@ pub fn generate_lookup_multiplicities(
     assert_eq!(stride, multiplicities.stride());
     let mapping_len = lookup_mapping.slice().len();
     let multiplicities_len = multiplicities.slice().len();
-    assert!(mapping_len <= u32::MAX as usize);
     let stream = context.get_exec_stream();
     set_to_zero(multiplicities.slice_mut(), stream)?;
     if mapping_len == 0 {
         return Ok(());
     }
     assert!(mapping_len < BF::CHARACTERISTICS_U32 as usize);
-    assert!(multiplicities_len > 0);
     assert!(active_counts_len > 0);
     assert!(active_counts_len <= multiplicities_len);
-    assert!(active_counts_len <= u32::MAX as usize);
+    let counter_storage_len = active_counts_len * COUNTER_REPLICAS;
+    assert!(counter_storage_len <= u32::MAX as usize);
 
     let mapping_len = mapping_len as u32;
     let active_counts_len = active_counts_len as u32;
+    let counter_replicas = COUNTER_REPLICAS as u32;
+    let multiplicities_ptr = multiplicities.as_mut_ptr();
+    let mut counter_storage = if counter_storage_len > multiplicities_len {
+        let mut storage: DeviceAllocation<BF> =
+            context.alloc(counter_storage_len, AllocationPlacement::BestFit)?;
+        set_to_zero(&mut storage, stream)?;
+        Some(storage)
+    } else {
+        None
+    };
+    let counter_shards = counter_storage
+        .as_mut()
+        .map_or(multiplicities_ptr, |storage| storage.as_mut_ptr());
     let (grid_dim, block_dim) = get_grid_block_dims_for_threads_count(WARP_SIZE * 4, mapping_len);
     let config = CudaLaunchConfig::basic(grid_dim, block_dim, stream);
     let args = CountMultiplicitiesArguments::new(
         lookup_mapping.as_mut_ptr(),
         mapping_len,
-        multiplicities.as_mut_ptr(),
+        counter_shards,
         active_counts_len,
+        counter_replicas,
     );
     CountMultiplicitiesFunction::default().launch(&config, &args)?;
 
     let (grid_dim, block_dim) =
         get_grid_block_dims_for_threads_count(WARP_SIZE * 4, active_counts_len);
     let config = CudaLaunchConfig::basic(grid_dim, block_dim, stream);
-    let args = ConvertMultiplicitiesArguments::new(multiplicities.as_mut_ptr(), active_counts_len);
-    ConvertMultiplicitiesFunction::default().launch(&config, &args)
+    let args = ReduceConvertMultiplicitiesArguments::new(
+        counter_shards,
+        multiplicities_ptr,
+        active_counts_len,
+        counter_replicas,
+    );
+    ReduceConvertMultiplicitiesFunction::default().launch(&config, &args)?;
+    if counter_storage.is_none() {
+        set_to_zero(
+            &mut multiplicities.slice_mut()[active_counts_len as usize..counter_storage_len],
+            stream,
+        )?;
+    }
+    Ok(())
 }
 
 // Sized for delegation layouts that need many lookup expressions per circuit.
@@ -187,20 +216,14 @@ pub fn allocate_range_check_lookup_mappings(
 ) -> CudaResult<(DeviceAllocation<u32>, DeviceAllocation<u32>)> {
     let trace_len = circuit.trace_len;
     assert!(trace_len.is_power_of_two());
-    let range_check_16_mapping_len = circuit
-        .range_check_16_lookup_expressions
-        .len()
-        .checked_mul(trace_len)
-        .expect("range-check-16 lookup mapping length overflow");
-    let timestamp_mapping_len = circuit
-        .timestamp_range_check_lookup_expressions
-        .len()
-        .checked_mul(trace_len)
-        .expect("timestamp lookup mapping length overflow");
-    let range_check_16_lookup_mapping_allocation =
-        context.alloc(range_check_16_mapping_len, AllocationPlacement::BestFit)?;
-    let range_check_timestamp_lookup_mapping_allocation =
-        context.alloc(timestamp_mapping_len, AllocationPlacement::BestFit)?;
+    let range_check_16_lookup_mapping_allocation = context.alloc(
+        circuit.range_check_16_lookup_expressions.len() * trace_len,
+        AllocationPlacement::BestFit,
+    )?;
+    let range_check_timestamp_lookup_mapping_allocation = context.alloc(
+        circuit.timestamp_range_check_lookup_expressions.len() * trace_len,
+        AllocationPlacement::BestFit,
+    )?;
     Ok((
         range_check_16_lookup_mapping_allocation,
         range_check_timestamp_lookup_mapping_allocation,
@@ -235,27 +258,26 @@ mod tests {
         ProverContext::new(&config).unwrap()
     }
 
-    #[test]
-    fn atomic_counts_normalizes_and_clears_tail() {
-        const STRIDE: usize = 64;
-        const MAPPING_COLS: usize = 3;
-        const MULTIPLICITY_COLS: usize = 2;
-        const ACTIVE_COUNTS_LEN: usize = 96;
-
-        let mut mapping_host = vec![0u32; STRIDE * MAPPING_COLS];
+    fn assert_replicated_atomic_counts(
+        stride: usize,
+        mapping_cols: usize,
+        multiplicity_cols: usize,
+        active_counts_len: usize,
+    ) {
+        let mut mapping_host = vec![0u32; stride * mapping_cols];
         for (i, value) in mapping_host.iter_mut().enumerate() {
             *value = match i {
                 0..=79 => 7,
-                80..=95 => 65,
+                80..=95 => (active_counts_len / 2) as u32,
                 96..=111 => u32::MAX,
-                _ => (i % ACTIVE_COUNTS_LEN) as u32,
+                _ => (i % active_counts_len) as u32,
             };
         }
         let expected_mapping = mapping_host
             .iter()
             .map(|&value| if value == u32::MAX { 0 } else { value })
             .collect::<Vec<_>>();
-        let mut expected_counts = vec![0u32; ACTIVE_COUNTS_LEN];
+        let mut expected_counts = vec![0u32; active_counts_len];
         for &value in &mapping_host {
             if value != u32::MAX {
                 expected_counts[value as usize] += 1;
@@ -265,7 +287,7 @@ mod tests {
             .into_iter()
             .map(BF::from_u32_unchecked)
             .collect::<Vec<_>>();
-        expected_multiplicities.resize(STRIDE * MULTIPLICITY_COLS, BF::ZERO);
+        expected_multiplicities.resize(stride * multiplicity_cols, BF::ZERO);
 
         let context = make_test_context();
         let stream = context.get_exec_stream();
@@ -277,26 +299,33 @@ mod tests {
             .unwrap();
         let poisoned_multiplicities = vec![BF::ONE; expected_multiplicities.len()];
 
-        for _ in 0..2 {
-            memory_copy_async(&mut mapping_device, &mapping_host, stream).unwrap();
-            memory_copy_async(&mut multiplicities_device, &poisoned_multiplicities, stream)
-                .unwrap();
-            generate_lookup_multiplicities(
-                &mut DeviceMatrixMut::new(&mut mapping_device, STRIDE),
-                &mut DeviceMatrixMut::new(&mut multiplicities_device, STRIDE),
-                ACTIVE_COUNTS_LEN,
-                &context,
-            )
-            .unwrap();
+        memory_copy_async(&mut mapping_device, &mapping_host, stream).unwrap();
+        memory_copy_async(&mut multiplicities_device, &poisoned_multiplicities, stream).unwrap();
+        generate_lookup_multiplicities(
+            &mut DeviceMatrixMut::new(&mut mapping_device, stride),
+            &mut DeviceMatrixMut::new(&mut multiplicities_device, stride),
+            active_counts_len,
+            &context,
+        )
+        .unwrap();
 
-            let mut actual_mapping = vec![0u32; mapping_host.len()];
-            let mut actual_multiplicities = vec![BF::ZERO; expected_multiplicities.len()];
-            memory_copy_async(&mut actual_mapping, &mapping_device, stream).unwrap();
-            memory_copy_async(&mut actual_multiplicities, &multiplicities_device, stream).unwrap();
-            stream.synchronize().unwrap();
+        let mut actual_mapping = vec![0u32; mapping_host.len()];
+        let mut actual_multiplicities = vec![BF::ZERO; expected_multiplicities.len()];
+        memory_copy_async(&mut actual_mapping, &mapping_device, stream).unwrap();
+        memory_copy_async(&mut actual_multiplicities, &multiplicities_device, stream).unwrap();
+        stream.synchronize().unwrap();
 
-            assert_eq!(actual_mapping, expected_mapping);
-            assert_eq!(actual_multiplicities, expected_multiplicities);
-        }
+        assert_eq!(actual_mapping, expected_mapping);
+        assert_eq!(actual_multiplicities, expected_multiplicities);
+    }
+
+    #[test]
+    fn replicated_atomic_counts_reuse_output_storage() {
+        assert_replicated_atomic_counts(512, 3, 1, 64);
+    }
+
+    #[test]
+    fn replicated_atomic_counts_use_transient_storage() {
+        assert_replicated_atomic_counts(64, 3, 2, 96);
     }
 }

--- a/gpu/trace/src/witness/multiplicities.rs
+++ b/gpu/trace/src/witness/multiplicities.rs
@@ -1,9 +1,10 @@
-use crate::upstream::{GKRCircuitArtifact, NoFieldSingleColumnLookupRelation};
+use crate::upstream::{
+    GKRCircuitArtifact, NoFieldSingleColumnLookupRelation, PrimeField, TIMESTAMP_COLUMNS_NUM_BITS,
+};
 use crate::witness::NoFieldLinearRelation;
 use era_cudart::cuda_kernel;
 use era_cudart::execution::{CudaLaunchConfig, KernelFunction};
 use era_cudart::result::CudaResult;
-use era_cudart::slice::CudaSlice;
 use gpu_core::allocator::tracker::AllocationPlacement;
 use gpu_core::primitives::context::DeviceAllocation;
 use gpu_core::primitives::device_structures::{
@@ -11,108 +12,68 @@ use gpu_core::primitives::device_structures::{
 };
 use gpu_core::primitives::field::BF;
 use gpu_core::primitives::utils::{get_grid_block_dims_for_threads_count, WARP_SIZE};
-use gpu_cub::cub::device_radix_sort::{get_sort_keys_temp_storage_bytes, sort_keys};
-use gpu_cub::cub::device_run_length_encode::{encode, get_encode_temp_storage_bytes};
-use gpu_cub::cub::CUB_TEMP_STORAGE_EXTRA_ALIGNMENT_LOG2;
 use gpu_ops::simple::set_to_zero;
 use gpu_prover_context::ProverContext;
 
-cuda_kernel!(GenerateMultiplicities,
-    ab_generate_multiplicities_kernel(
-        unique_indexes: *const u32,
-        counts: *const u32,
-        num_runs: *const u32,
+pub const RANGE_CHECK_16_DOMAIN_SIZE: usize = 1 << 16;
+pub const TIMESTAMP_RANGE_CHECK_DOMAIN_SIZE: usize = 1 << TIMESTAMP_COLUMNS_NUM_BITS;
+
+cuda_kernel!(CountMultiplicities,
+    ab_count_multiplicities_kernel(
         lookup_mapping: *mut u32,
         lookup_mapping_size: u32,
-        multiplicities: MutPtrAndStride<BF>,
-        multiplicities_size: u32,
+        multiplicities: *mut BF,
+        active_counts_len: u32,
     )
 );
 
-pub fn generate_generic_lookup_multiplicities(
+cuda_kernel!(ConvertMultiplicities,
+    ab_convert_multiplicities_kernel(
+        multiplicities: *mut BF,
+        active_counts_len: u32,
+    )
+);
+
+pub fn generate_lookup_multiplicities(
     lookup_mapping: &mut impl DeviceMatrixMutImpl<u32>,
     multiplicities: &mut impl DeviceMatrixMutImpl<BF>,
-    lookup_mapping_bits_count: i32,
+    active_counts_len: usize,
     context: &ProverContext,
 ) -> CudaResult<()> {
     let stride = lookup_mapping.stride();
     assert!(stride.is_power_of_two());
     assert_eq!(stride, multiplicities.stride());
+    let mapping_len = lookup_mapping.slice().len();
+    let multiplicities_len = multiplicities.slice().len();
+    assert!(mapping_len <= u32::MAX as usize);
     let stream = context.get_exec_stream();
-    // Multiplicity generation only writes entries present in lookup mappings.
-    // Clear the whole destination first to avoid stale values in untouched rows.
     set_to_zero(multiplicities.slice_mut(), stream)?;
-    let lookup_mapping_slice = lookup_mapping.slice();
-    let lookup_mapping_len = lookup_mapping_slice.len();
-    let multiplicities_size = multiplicities.slice().len();
-    if lookup_mapping_len == 0 || multiplicities_size == 0 {
+    if mapping_len == 0 {
         return Ok(());
     }
-    let mut sorted_lookup_mapping =
-        context.alloc(lookup_mapping_len, AllocationPlacement::BestFit)?;
-    assert!(lookup_mapping_len <= u32::MAX as usize);
-    let lookup_mapping_size = lookup_mapping_len as u32;
-    let lookup_mapping_sort_temp_storage_size = get_sort_keys_temp_storage_bytes::<u32>(
-        false,
-        lookup_mapping_size,
-        0,
-        lookup_mapping_bits_count,
-    )?;
-    let mut mapping_sort_temp_storage = context
-        .alloc_with_extra_alignment::<u8, CUB_TEMP_STORAGE_EXTRA_ALIGNMENT_LOG2>(
-            lookup_mapping_sort_temp_storage_size,
-            AllocationPlacement::BestFit,
-        )?;
-    sort_keys(
-        false,
-        &mut mapping_sort_temp_storage,
-        lookup_mapping_slice,
-        &mut sorted_lookup_mapping,
-        0,
-        lookup_mapping_bits_count,
-        stream,
-    )?;
-    drop(mapping_sort_temp_storage);
-    let mut unique_lookup_mapping =
-        context.alloc(multiplicities_size, AllocationPlacement::BestFit)?;
-    let mut counts = context.alloc(multiplicities_size, AllocationPlacement::BestFit)?;
-    let mut num_runs = context.alloc(1, AllocationPlacement::BestFit)?;
-    let encode_temp_storage_bytes =
-        get_encode_temp_storage_bytes::<u32>(lookup_mapping_size as i32)?;
-    let mut encode_temp_storage = context
-        .alloc_with_extra_alignment::<u8, CUB_TEMP_STORAGE_EXTRA_ALIGNMENT_LOG2>(
-            encode_temp_storage_bytes,
-            AllocationPlacement::BestFit,
-        )?;
-    encode(
-        &mut encode_temp_storage,
-        &sorted_lookup_mapping,
-        &mut unique_lookup_mapping,
-        &mut counts,
-        &mut num_runs[0],
-        stream,
-    )?;
-    drop(encode_temp_storage);
-    let unique_indexes = unique_lookup_mapping.as_ptr();
-    let counts = counts.as_ptr();
-    let num_runs = num_runs.as_ptr();
-    let lookup_mapping_ptr = lookup_mapping.as_mut_ptr();
-    let multiplicities_ptr = multiplicities.as_mut_ptr_and_stride();
-    assert!(multiplicities_size <= u32::MAX as usize);
-    let multiplicities_size = multiplicities_size as u32;
-    let count = lookup_mapping_size.max(multiplicities_size);
-    let (grid_dim, block_dim) = get_grid_block_dims_for_threads_count(WARP_SIZE * 4, count);
+    assert!(mapping_len < BF::CHARACTERISTICS_U32 as usize);
+    assert!(multiplicities_len > 0);
+    assert!(active_counts_len > 0);
+    assert!(active_counts_len <= multiplicities_len);
+    assert!(active_counts_len <= u32::MAX as usize);
+
+    let mapping_len = mapping_len as u32;
+    let active_counts_len = active_counts_len as u32;
+    let (grid_dim, block_dim) = get_grid_block_dims_for_threads_count(WARP_SIZE * 4, mapping_len);
     let config = CudaLaunchConfig::basic(grid_dim, block_dim, stream);
-    let args = GenerateMultiplicitiesArguments::new(
-        unique_indexes,
-        counts,
-        num_runs,
-        lookup_mapping_ptr,
-        lookup_mapping_size,
-        multiplicities_ptr,
-        multiplicities_size,
+    let args = CountMultiplicitiesArguments::new(
+        lookup_mapping.as_mut_ptr(),
+        mapping_len,
+        multiplicities.as_mut_ptr(),
+        active_counts_len,
     );
-    GenerateMultiplicitiesFunction::default().launch(&config, &args)
+    CountMultiplicitiesFunction::default().launch(&config, &args)?;
+
+    let (grid_dim, block_dim) =
+        get_grid_block_dims_for_threads_count(WARP_SIZE * 4, active_counts_len);
+    let config = CudaLaunchConfig::basic(grid_dim, block_dim, stream);
+    let args = ConvertMultiplicitiesArguments::new(multiplicities.as_mut_ptr(), active_counts_len);
+    ConvertMultiplicitiesFunction::default().launch(&config, &args)
 }
 
 // Sized for delegation layouts that need many lookup expressions per circuit.
@@ -226,16 +187,116 @@ pub fn allocate_range_check_lookup_mappings(
 ) -> CudaResult<(DeviceAllocation<u32>, DeviceAllocation<u32>)> {
     let trace_len = circuit.trace_len;
     assert!(trace_len.is_power_of_two());
-    let range_check_16_lookup_mapping_allocation = context.alloc(
-        circuit.range_check_16_lookup_expressions.len() * trace_len,
-        AllocationPlacement::BestFit,
-    )?;
-    let range_check_timestamp_lookup_mapping_allocation = context.alloc(
-        circuit.timestamp_range_check_lookup_expressions.len() * trace_len,
-        AllocationPlacement::BestFit,
-    )?;
+    let range_check_16_mapping_len = circuit
+        .range_check_16_lookup_expressions
+        .len()
+        .checked_mul(trace_len)
+        .expect("range-check-16 lookup mapping length overflow");
+    let timestamp_mapping_len = circuit
+        .timestamp_range_check_lookup_expressions
+        .len()
+        .checked_mul(trace_len)
+        .expect("timestamp lookup mapping length overflow");
+    let range_check_16_lookup_mapping_allocation =
+        context.alloc(range_check_16_mapping_len, AllocationPlacement::BestFit)?;
+    let range_check_timestamp_lookup_mapping_allocation =
+        context.alloc(timestamp_mapping_len, AllocationPlacement::BestFit)?;
     Ok((
         range_check_16_lookup_mapping_allocation,
         range_check_timestamp_lookup_mapping_allocation,
     ))
+}
+
+#[cfg(all(test, not(no_cuda)))]
+mod tests {
+    use super::*;
+    use crate::upstream::Field;
+    use era_cudart::memory::memory_copy_async;
+    use gpu_prover_context::ProverContextConfig;
+
+    fn make_test_context() -> ProverContext {
+        const BLOCK_LOG: u32 = 20;
+        let default_block_log = ProverContextConfig::default().allocator_block_log_size;
+        let arena_bytes = 256usize << default_block_log;
+        let blocks_count = arena_bytes >> BLOCK_LOG;
+        let mut config = ProverContextConfig {
+            allocator_block_log_size: BLOCK_LOG,
+            max_device_allocation_blocks_count: Some(blocks_count),
+            ..Default::default()
+        };
+        let host_block_size = 1usize << config.host_allocator_block_log_size;
+        config.host_allocator_blocks_count = (32 * 1024 * 1024) / host_block_size;
+        if config
+            .small_allocator_log_chunk_size
+            .is_some_and(|size| size >= BLOCK_LOG)
+        {
+            config.small_allocator_log_chunk_size = None;
+        }
+        ProverContext::new(&config).unwrap()
+    }
+
+    #[test]
+    fn atomic_counts_normalizes_and_clears_tail() {
+        const STRIDE: usize = 64;
+        const MAPPING_COLS: usize = 3;
+        const MULTIPLICITY_COLS: usize = 2;
+        const ACTIVE_COUNTS_LEN: usize = 96;
+
+        let mut mapping_host = vec![0u32; STRIDE * MAPPING_COLS];
+        for (i, value) in mapping_host.iter_mut().enumerate() {
+            *value = match i {
+                0..=79 => 7,
+                80..=95 => 65,
+                96..=111 => u32::MAX,
+                _ => (i % ACTIVE_COUNTS_LEN) as u32,
+            };
+        }
+        let expected_mapping = mapping_host
+            .iter()
+            .map(|&value| if value == u32::MAX { 0 } else { value })
+            .collect::<Vec<_>>();
+        let mut expected_counts = vec![0u32; ACTIVE_COUNTS_LEN];
+        for &value in &mapping_host {
+            if value != u32::MAX {
+                expected_counts[value as usize] += 1;
+            }
+        }
+        let mut expected_multiplicities = expected_counts
+            .into_iter()
+            .map(BF::from_u32_unchecked)
+            .collect::<Vec<_>>();
+        expected_multiplicities.resize(STRIDE * MULTIPLICITY_COLS, BF::ZERO);
+
+        let context = make_test_context();
+        let stream = context.get_exec_stream();
+        let mut mapping_device = context
+            .alloc(mapping_host.len(), AllocationPlacement::BestFit)
+            .unwrap();
+        let mut multiplicities_device = context
+            .alloc(expected_multiplicities.len(), AllocationPlacement::BestFit)
+            .unwrap();
+        let poisoned_multiplicities = vec![BF::ONE; expected_multiplicities.len()];
+
+        for _ in 0..2 {
+            memory_copy_async(&mut mapping_device, &mapping_host, stream).unwrap();
+            memory_copy_async(&mut multiplicities_device, &poisoned_multiplicities, stream)
+                .unwrap();
+            generate_lookup_multiplicities(
+                &mut DeviceMatrixMut::new(&mut mapping_device, STRIDE),
+                &mut DeviceMatrixMut::new(&mut multiplicities_device, STRIDE),
+                ACTIVE_COUNTS_LEN,
+                &context,
+            )
+            .unwrap();
+
+            let mut actual_mapping = vec![0u32; mapping_host.len()];
+            let mut actual_multiplicities = vec![BF::ZERO; expected_multiplicities.len()];
+            memory_copy_async(&mut actual_mapping, &mapping_device, stream).unwrap();
+            memory_copy_async(&mut actual_multiplicities, &multiplicities_device, stream).unwrap();
+            stream.synchronize().unwrap();
+
+            assert_eq!(actual_mapping, expected_mapping);
+            assert_eq!(actual_multiplicities, expected_multiplicities);
+        }
+    }
 }


### PR DESCRIPTION
## What ❔

Replace radix sort and run-length encoding for GPU lookup multiplicities with warp-aggregated atomic counters sharded eight ways. Reduce the shards directly into BabyBear values and remove the unused `gpu_cub` dependency.

## Why ❔

This avoids sorting lookup mappings while limiting contention on repeated timestamp values. On the zkOS base proof, median stage-1 GPU time improved by 20.0% and the captured GPU span by 2.54%; add/sub stage-1 improved by 27.0%.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.