### PR TITLE
fix(ci): bound unit test runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   tests:
     name: tests
     runs-on: [matterlabs-ci-runner-high-performance]
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -30,7 +31,7 @@ jobs:
       - name: Unit tests (CI)
         env:
           CI: "true"
-        run: cargo test --profile cli -- --nocapture --test-threads 1
+        run: cargo test --profile cli -- --nocapture
       - name: GPU test serialization drift guard
         run: cargo test -p gpu_core --profile cli cpu_nextest_config_covers_all_gpu_crates
       - name: GKR compiler feature tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   tests:
     name: tests
-    runs-on: [matterlabs-ci-runner-highmem]
+    runs-on: [matterlabs-ci-runner-high-performance]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -30,7 +30,7 @@ jobs:
       - name: Unit tests (CI)
         env:
           CI: "true"
-        run: cargo test --profile cli -- --nocapture
+        run: cargo test --profile cli -- --nocapture --test-threads 1
       - name: GPU test serialization drift guard
         run: cargo test -p gpu_core --profile cli cpu_nextest_config_covers_all_gpu_crates
       - name: GKR compiler feature tests

--- a/prover/src/gkr/prover_config/mod.rs
+++ b/prover/src/gkr/prover_config/mod.rs
@@ -303,6 +303,7 @@ mod test {
     use super::*;
 
     #[test]
+    #[ignore = "unfinished exhaustive WHIR config search"]
     fn test_try_compute_some_config() {
         let prover_config = compute_best_prover_config_guess(
             20,

--- a/prover/src/gkr/whir/proth120_evm_gen.rs
+++ b/prover/src/gkr/whir/proth120_evm_gen.rs
@@ -617,6 +617,7 @@ fn pessimistic_config_reproduces_variant4_and_aggressive() {
 /// variable (non-6) round count — exercising `run_generation`'s round-agnostic path
 /// end-to-end (whir_fold + schedule-driven serializer) cheaply.
 #[test]
+#[ignore = "expensive real-PoW smoke; run explicitly"]
 fn generate_whir_smoke_aggressive() {
     let worker = Worker::new_with_num_threads(4);
     let cfg = pessimistic_config(12, 4, 2, 3, 16, 3, "_aggsmoke");

--- a/prover/src/tests/gkr/family_circuits.rs
+++ b/prover/src/tests/gkr/family_circuits.rs
@@ -35,11 +35,13 @@ const PROVE_EMPTY: bool = true;
 pub use crate::definitions::SecurityLevel;
 
 #[test]
+#[ignore = "production-scale 2^24 proof; run explicitly"]
 fn gkr_run_basic_unrolled_test_sec_80() {
     gkr_run_basic_unrolled_test_impl(SecurityLevel::Sec80, None, None);
 }
 
 #[test]
+#[ignore = "production-scale 2^24 proof; run explicitly"]
 fn gkr_run_basic_unrolled_test_sec_100() {
     gkr_run_basic_unrolled_test_impl(SecurityLevel::Sec100, None, None);
 }
@@ -920,6 +922,7 @@ fn add_sub_family_bench_in_memory() {
 /// The storage policy is orthogonal to the (fixed) `CommitmentMode`, so it must not
 /// change the proof.
 #[test]
+#[ignore = "production-scale 2^24 RS storage parity; run explicitly"]
 fn add_sub_family_rs_codeword_source_parity() {
     use crate::gkr::prover::WhirOracleStorage;
     use riscv_transpiler::vm::DelegationsAndFamiliesCounters;
@@ -1029,6 +1032,7 @@ fn add_sub_family_rs_codeword_source_parity() {
 /// NOTE: this writes the full setup RS codewords to disk (~all LDE cosets of the
 /// setup columns) and runs two 2^24 proofs; keep it a deliberately-run test.
 #[test]
+#[ignore = "production-scale 2^24 on-disk setup parity; run explicitly"]
 fn add_sub_family_on_disk_setup() {
     use riscv_transpiler::vm::DelegationsAndFamiliesCounters;
 

--- a/prover/src/tests/gkr/large_field.rs
+++ b/prover/src/tests/gkr/large_field.rs
@@ -130,6 +130,7 @@ fn load_boundary_transcript_prefix() -> (
 }
 
 #[test]
+#[ignore = "production-scale packed proof; run explicitly"]
 fn gkr_unified_packed_commitment_basic_fibonacci() {
     gkr_unified_packed_commitment_basic_fibonacci_impl(8, false, false);
 }


### PR DESCRIPTION
## What ❔

- Run Rust tests on the high-performance runner with normal libtest parallelism.
- Ignore the unfinished config search and six production-scale tests that exceed five minutes.
- Cap the tests job at 20 minutes.

## Why ❔

The previous suite OOMed 64 GB runners and took three hours when serialized. The reduced suite completed locally in 2m25s at 42.1 GiB peak RSS with 32 test threads.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
