### PR TITLE
perf(whir): avoid materializing partial tree tops

### DIFF
--- a/gpu/AGENTS.md
+++ b/gpu/AGENTS.md
@@ -134,7 +134,7 @@ root in `gkr_eval_ir`; `gpu_gkr_compiler` depends on it.
   for its own blake2s-dependent protocol kernels. See [`gkr/AGENTS.md`](gkr/AGENTS.md).
 - **`gpu_whir`** = WHIR folds (`fold/`) + PoW/query scheduling (`pow.rs`) +
   the recursive WHIR extension oracle and its side-stream LDE/Merkle commit
-  scheduler, with its own `gpu_whir_native` (20 kernels, no `__constant__`
+  scheduler, with its own `gpu_whir_native` (24 kernels, no `__constant__`
   symbols), namespace `airbender::whir`. Reads
   `gpu_gkr`'s exported headers (`accumulate_eq.cu`) and `gpu_hash`'s
   `hash.cuh` plus gpu_ntt's exported `whir_leaf_transform.cuh` (`leaves.cu`).

--- a/gpu/hash/native/hash.cu
+++ b/gpu/hash/native/hash.cu
@@ -110,6 +110,30 @@ EXTERN __global__ void ab_blake2s_leaves_multi_coset_kernel(const bf *values, u3
 // packed cosets backing; the existing blake-leaves kernel then hashes flat
 // row `dst_row` and stores at `dst_row * STATE_SIZE`. This kernel inlines the
 // source-side index math into `read()` and computes `dst_leaf_idx` directly.
+DEVICE_FORCEINLINE digest hash_leaf_from_ntt(const bf *ntt_output, const unsigned log_values_per_leaf, const unsigned src_cols_per_coset,
+                                             const unsigned src_coset, const unsigned leaf_in_coset, const unsigned per_coset_count, const unsigned trace_len) {
+  const unsigned cols_count = src_cols_per_coset << log_values_per_leaf;
+  const unsigned values_per_leaf = 1u << log_values_per_leaf;
+  const unsigned col_mask = src_cols_per_coset - 1u;
+  const unsigned log_src_cols_per_coset = __ffs(src_cols_per_coset) - 1u;
+
+  auto read = [=](const unsigned offset) -> u32 {
+    const unsigned col_in_leaf = offset & col_mask;               // FAST (low log_src_cols_per_coset bits)
+    const unsigned value_slot = offset >> log_src_cols_per_coset; // SLOW (high log_values_per_leaf bits)
+    if (value_slot >= values_per_leaf)
+      return 0;
+    const unsigned src_row = leaf_in_coset + bitreverse_low_bits(value_slot, log_values_per_leaf) * per_coset_count;
+    const unsigned src_col_global = src_coset * src_cols_per_coset + col_in_leaf;
+    return bf::into_raw_u32(load_cs(ntt_output + src_row + static_cast<size_t>(src_col_global) * trace_len));
+  };
+
+  digest state;
+  initialize(state.words);
+  u32 t = 0;
+  absorb_stream(state.words, t, cols_count, read);
+  return state;
+}
+
 EXTERN __global__ void ab_blake2s_leaves_from_ntt_multi_coset_kernel(const bf *ntt_output, u32 *results, const unsigned log_values_per_leaf,
                                                                      const unsigned src_cols_per_coset, const unsigned log_lde_factor,
                                                                      const unsigned coset_index_base, const unsigned per_coset_count,
@@ -122,30 +146,39 @@ EXTERN __global__ void ab_blake2s_leaves_from_ntt_multi_coset_kernel(const bf *n
   const unsigned leaf_in_coset = gid_global & (per_coset_count - 1u);
   const unsigned coset_global = coset_index_base + coset_in_tile;
   const unsigned bitrev_coset = bitreverse_low_bits(coset_global, log_lde_factor);
-
   const unsigned dst_leaf_idx = leaf_in_coset + bitrev_coset * per_coset_count;
   digest *results_d = reinterpret_cast<digest *>(results) + dst_leaf_idx;
-
-  const unsigned cols_count = src_cols_per_coset << log_values_per_leaf;
-  const unsigned values_per_leaf = 1u << log_values_per_leaf;
-  const unsigned col_mask = src_cols_per_coset - 1u;
-  const unsigned log_src_cols_per_coset = __ffs(src_cols_per_coset) - 1u;
-
-  auto read = [=](const unsigned offset) -> u32 {
-    const unsigned col_in_leaf = offset & col_mask;               // FAST (low log_src_cols_per_coset bits)
-    const unsigned value_slot = offset >> log_src_cols_per_coset; // SLOW (high log_values_per_leaf bits)
-    if (value_slot >= values_per_leaf)
-      return 0;
-    const unsigned src_row = leaf_in_coset + bitreverse_low_bits(value_slot, log_values_per_leaf) * per_coset_count;
-    const unsigned src_col_global = coset_in_tile * src_cols_per_coset + col_in_leaf;
-    return bf::into_raw_u32(load_cs(ntt_output + src_row + static_cast<size_t>(src_col_global) * trace_len));
-  };
-
-  digest state;
-  initialize(state.words);
-  u32 t = 0;
-  absorb_stream(state.words, t, cols_count, read);
+  const digest state = hash_leaf_from_ntt(ntt_output, log_values_per_leaf, src_cols_per_coset, coset_in_tile, leaf_in_coset, per_coset_count, trace_len);
   store_cs(results_d, state);
+}
+
+EXTERN __global__ void ab_blake2s_leaves_from_ntt_multi_coset_to_staging_kernel(const bf *ntt_output, u32 *staging, const unsigned log_values_per_leaf,
+                                                                                const unsigned src_cols_per_coset, const unsigned per_coset_count,
+                                                                                const unsigned log_per_coset_count, const unsigned trace_len,
+                                                                                const unsigned count) {
+  const unsigned gid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (gid >= count)
+    return;
+  const unsigned coset_in_tile = gid >> log_per_coset_count;
+  const unsigned leaf_in_coset = gid & (per_coset_count - 1u);
+  const digest state = hash_leaf_from_ntt(ntt_output, log_values_per_leaf, src_cols_per_coset, coset_in_tile, leaf_in_coset, per_coset_count, trace_len);
+  store_cs(reinterpret_cast<digest *>(staging) + gid, state);
+}
+
+EXTERN __global__ void ab_blake2s_leaves_from_ntt_flat_range_to_staging_kernel(const bf *ntt_output, u32 *staging, const unsigned log_values_per_leaf,
+                                                                               const unsigned src_cols_per_coset, const unsigned log_lde_factor,
+                                                                               const unsigned flat_leaf_base, const unsigned per_coset_count,
+                                                                               const unsigned log_per_coset_count, const unsigned trace_len,
+                                                                               const unsigned count) {
+  const unsigned gid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (gid >= count)
+    return;
+  const unsigned flat_leaf = flat_leaf_base + gid;
+  const unsigned bitrev_coset = flat_leaf >> log_per_coset_count;
+  const unsigned leaf_in_coset = flat_leaf & (per_coset_count - 1u);
+  const unsigned natural_coset = bitreverse_low_bits(bitrev_coset, log_lde_factor);
+  const digest state = hash_leaf_from_ntt(ntt_output, log_values_per_leaf, src_cols_per_coset, natural_coset, leaf_in_coset, per_coset_count, trace_len);
+  store_cs(reinterpret_cast<digest *>(staging) + gid, state);
 }
 
 EXTERN __global__ void ab_blake2s_nodes_kernel(const u32 *values, u32 *results, const unsigned count) {

--- a/gpu/hash/native/hash.cuh
+++ b/gpu/hash/native/hash.cuh
@@ -141,6 +141,28 @@ template <typename ReadE4> DEVICE_FORCEINLINE void absorb_e4_stream(u32 state[ST
   }
 }
 
+DEVICE_FORCEINLINE void reduce_merkle_subtrees_block(digest *values, unsigned active) {
+#pragma unroll
+  for (unsigned layer = 0; layer < LOG_WARP_SIZE; layer++) {
+    const bool enabled = threadIdx.x < active;
+    digest children[2];
+    if (enabled) {
+      children[0] = values[2 * threadIdx.x];
+      children[1] = values[2 * threadIdx.x + 1];
+    }
+    __syncthreads();
+    if (enabled) {
+      digest state;
+      initialize(state.words);
+      u32 t = 0;
+      compress<true>(state.words, t, reinterpret_cast<const u32 *>(children), BLOCK_SIZE);
+      values[threadIdx.x] = state;
+    }
+    __syncthreads();
+    active >>= 1;
+  }
+}
+
 // Rebuilds the bottom five layers with warp shuffles before walking the cached tree.
 DEVICE_FORCEINLINE void collect_merkle_path_warp(u32 state[STATE_SIZE], u32 *merkle_paths, const unsigned layer_stride_words, const unsigned lane_idx,
                                                  const bool is_output_lane, const unsigned query_index, const unsigned log_total_leaves_count,

--- a/gpu/hash/src/blake2s/hash.rs
+++ b/gpu/hash/src/blake2s/hash.rs
@@ -230,3 +230,122 @@ pub fn hash_leaves_from_ntt_multi_coset(
     );
     LeavesFromNttMultiCosetFunction::default().launch(&config, &args)
 }
+
+cuda_kernel!(
+    LeavesFromNttMultiCosetToStaging,
+    ab_blake2s_leaves_from_ntt_multi_coset_to_staging_kernel(
+        ntt_output: *const BF,
+        staging: *mut Digest,
+        log_values_per_leaf: u32,
+        src_cols_per_coset: u32,
+        per_coset_count: u32,
+        log_per_coset_count: u32,
+        trace_len: u32,
+        count: u32,
+    )
+);
+
+pub fn hash_leaves_from_ntt_multi_coset_to_staging(
+    ntt_output: &DeviceSlice<BF>,
+    staging: &mut DeviceSlice<Digest>,
+    log_values_per_leaf: u32,
+    src_cols_per_coset: u32,
+    log_lde_factor: u32,
+    coset_index_base: u32,
+    cosets_in_tile: usize,
+    per_coset_leaves_count: usize,
+    trace_len: u32,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    assert!(cosets_in_tile >= 1);
+    assert!(src_cols_per_coset.is_power_of_two());
+    assert!(trace_len.is_power_of_two());
+    assert!(per_coset_leaves_count.is_power_of_two());
+    assert_eq!(
+        per_coset_leaves_count,
+        trace_len as usize >> log_values_per_leaf
+    );
+    assert!(coset_index_base as usize + cosets_in_tile <= 1usize << log_lde_factor);
+    let count = per_coset_leaves_count
+        .checked_mul(cosets_in_tile)
+        .expect("leaf count overflow");
+    assert_eq!(staging.len(), count);
+    assert!(ntt_output.len() >= trace_len as usize * src_cols_per_coset as usize * cosets_in_tile);
+    let count = checked_u32(count);
+    let (grid_dim, block_dim) = get_grid_block_dims_for_threads_count(WARP_SIZE * 4, count);
+    let config = CudaLaunchConfig::basic(grid_dim, block_dim, stream);
+    let args = LeavesFromNttMultiCosetToStagingArguments::new(
+        ntt_output.as_ptr(),
+        staging.as_mut_ptr(),
+        log_values_per_leaf,
+        src_cols_per_coset,
+        checked_u32(per_coset_leaves_count),
+        per_coset_leaves_count.trailing_zeros(),
+        trace_len,
+        count,
+    );
+    LeavesFromNttMultiCosetToStagingFunction::default().launch(&config, &args)
+}
+
+cuda_kernel!(
+    LeavesFromNttFlatRangeToStaging,
+    ab_blake2s_leaves_from_ntt_flat_range_to_staging_kernel(
+        ntt_output: *const BF,
+        staging: *mut Digest,
+        log_values_per_leaf: u32,
+        src_cols_per_coset: u32,
+        log_lde_factor: u32,
+        flat_leaf_base: u32,
+        per_coset_count: u32,
+        log_per_coset_count: u32,
+        trace_len: u32,
+        count: u32,
+    )
+);
+
+pub fn hash_leaves_from_ntt_flat_range_to_staging(
+    ntt_output: &DeviceSlice<BF>,
+    staging: &mut DeviceSlice<Digest>,
+    log_values_per_leaf: u32,
+    src_cols_per_coset: u32,
+    log_lde_factor: u32,
+    flat_leaf_base: usize,
+    leaves_count: usize,
+    per_coset_leaves_count: usize,
+    trace_len: u32,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    assert!(src_cols_per_coset.is_power_of_two());
+    assert!(trace_len.is_power_of_two());
+    assert!(per_coset_leaves_count.is_power_of_two());
+    assert_eq!(
+        per_coset_leaves_count,
+        trace_len as usize >> log_values_per_leaf
+    );
+    assert_eq!(flat_leaf_base % WARP_SIZE as usize, 0);
+    assert!(leaves_count > 0);
+    assert_eq!(leaves_count % WARP_SIZE as usize, 0);
+    let total_leaves = per_coset_leaves_count << log_lde_factor;
+    assert!(flat_leaf_base + leaves_count <= total_leaves);
+    assert_eq!(staging.len(), leaves_count);
+    assert!(
+        ntt_output.len()
+            >= trace_len as usize * src_cols_per_coset as usize * (1usize << log_lde_factor)
+    );
+    let count = checked_u32(leaves_count);
+    let (grid_dim, block_dim) = get_grid_block_dims_for_threads_count(WARP_SIZE * 4, count);
+    let config = CudaLaunchConfig::basic(grid_dim, block_dim, stream);
+    let args = LeavesFromNttFlatRangeToStagingArguments::new(
+        ntt_output.as_ptr(),
+        staging.as_mut_ptr(),
+        log_values_per_leaf,
+        src_cols_per_coset,
+        log_lde_factor,
+        checked_u32(flat_leaf_base),
+        checked_u32(per_coset_leaves_count),
+        per_coset_leaves_count.trailing_zeros(),
+        trace_len,
+        count,
+    );
+    LeavesFromNttFlatRangeToStagingFunction::default().launch(&config, &args)
+}

--- a/gpu/whir/AGENTS.md
+++ b/gpu/whir/AGENTS.md
@@ -58,7 +58,7 @@ rather than letting the duplicate drift by convention.
 - **Archive / `links` key**: `gpu_whir_native` (`build.rs`:
   `gpu_native_build::CudaArchive::new("gpu_whir_native", "GPU_WHIR").build()`
   — no `export_include`; nothing above this crate includes its headers).
-- **Kernel count**: 20 `__global__` kernels (verified by grep, across
+- **Kernel count**: 24 `__global__` kernels (verified by grep, across
   `whir/{accumulate_eq,columns,fold,leaves}.cu`). No `__constant__` symbols
   (all 8 cluster-wide ones live in `gpu_gkr`).
 - **Namespace**: `airbender::whir`.

--- a/gpu/whir/native/whir/leaves.cu
+++ b/gpu/whir/native/whir/leaves.cu
@@ -211,4 +211,128 @@ EXTERN __launch_bounds__(512, 2) __global__
   store_cs(reinterpret_cast<::airbender::hash::digest *>(results) + output_leaf, state);
 }
 
+EXTERN __launch_bounds__(512, 2) __global__
+    void ab_transform_and_hash_whir_leaves_from_ntt_multi_coset_to_staging_kernel(vectorized_e4_matrix_getter<ld_modifier::cs> ntt_output, u32 *staging,
+                                                                                  const ::airbender::ntt::whir_leaf_transform_params transform_params,
+                                                                                  const unsigned log_trace_len, const unsigned log_lde_factor,
+                                                                                  const unsigned log_values_per_leaf, const unsigned coset_index_base) {
+  const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const unsigned log_packed_leaf_count = log_trace_len - log_values_per_leaf;
+  const unsigned packed_leaf_count = 1u << log_packed_leaf_count;
+  const unsigned coset_in_tile = gid >> log_packed_leaf_count;
+  const unsigned leaf_in_coset = gid & (packed_leaf_count - 1u);
+  const unsigned natural_coset = coset_index_base + coset_in_tile;
+  ntt_output.add_col(coset_in_tile);
+  ntt_output.add_row(leaf_in_coset);
+
+  extern __shared__ __align__(16) uint8_t smem[];
+  e4 *coefficient_leaves = reinterpret_cast<e4 *>(smem);
+  bf *x_invs_smem = reinterpret_cast<bf *>(coefficient_leaves + (blockDim.x << log_values_per_leaf));
+  shared_query_leaf_destination destination{coefficient_leaves, log_values_per_leaf};
+  const ::airbender::ntt::params_inverse_power_source inverse_power_source{transform_params};
+  ::airbender::ntt::transform_whir_leaf_from_ntt(ntt_output, destination, log_trace_len, log_lde_factor, log_values_per_leaf, natural_coset, leaf_in_coset,
+                                                 coefficient_leaves, x_invs_smem, transform_params.two_inv_power, inverse_power_source);
+  __syncthreads();
+  if (threadIdx.y != 0)
+    return;
+
+  auto read_e4 = [=](const unsigned value_slot) -> e4 { return coefficient_leaves[value_slot * blockDim.x + threadIdx.x]; };
+  ::airbender::hash::digest state;
+  ::airbender::hash::initialize(state.words);
+  u32 t = 0;
+  ::airbender::hash::absorb_e4_stream(state.words, t, 1u << log_values_per_leaf, read_e4);
+  store_cs(reinterpret_cast<::airbender::hash::digest *>(staging) + gid, state);
+}
+
+EXTERN __launch_bounds__(512, 2) __global__
+    void ab_transform_and_hash_whir_leaves_from_ntt_flat_range_to_staging_kernel(vectorized_e4_matrix_getter<ld_modifier::cs> ntt_output, u32 *staging,
+                                                                                 const ::airbender::ntt::whir_leaf_transform_params transform_params,
+                                                                                 const unsigned log_trace_len, const unsigned log_lde_factor,
+                                                                                 const unsigned log_values_per_leaf, const unsigned flat_leaf_base) {
+  const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const unsigned flat_leaf = flat_leaf_base + gid;
+  const unsigned log_packed_leaf_count = log_trace_len - log_values_per_leaf;
+  const unsigned packed_leaf_count = 1u << log_packed_leaf_count;
+  const unsigned bitrev_coset = flat_leaf >> log_packed_leaf_count;
+  const unsigned leaf_in_coset = flat_leaf & (packed_leaf_count - 1u);
+  const unsigned natural_coset = bitreverse_low_bits(bitrev_coset, log_lde_factor);
+  ntt_output.add_col(natural_coset);
+  ntt_output.add_row(leaf_in_coset);
+
+  extern __shared__ __align__(16) uint8_t smem[];
+  e4 *coefficient_leaves = reinterpret_cast<e4 *>(smem);
+  bf *x_invs_smem = reinterpret_cast<bf *>(coefficient_leaves + (blockDim.x << log_values_per_leaf));
+  shared_query_leaf_destination destination{coefficient_leaves, log_values_per_leaf};
+  const ::airbender::ntt::params_inverse_power_source inverse_power_source{transform_params};
+  ::airbender::ntt::transform_whir_leaf_from_ntt(ntt_output, destination, log_trace_len, log_lde_factor, log_values_per_leaf, natural_coset, leaf_in_coset,
+                                                 coefficient_leaves, x_invs_smem, transform_params.two_inv_power, inverse_power_source);
+  __syncthreads();
+  if (threadIdx.y != 0)
+    return;
+
+  auto read_e4 = [=](const unsigned value_slot) -> e4 { return coefficient_leaves[value_slot * blockDim.x + threadIdx.x]; };
+  ::airbender::hash::digest state;
+  ::airbender::hash::initialize(state.words);
+  u32 t = 0;
+  ::airbender::hash::absorb_e4_stream(state.words, t, 1u << log_values_per_leaf, read_e4);
+  store_cs(reinterpret_cast<::airbender::hash::digest *>(staging) + gid, state);
+}
+
+EXTERN __launch_bounds__(256) __global__ void ab_reduce_staged_whir_subtrees_flat_kernel(const u32 *staged, u32 *boundary_roots, const unsigned roots_count) {
+  constexpr unsigned ROOTS_PER_BLOCK = 16;
+  constexpr unsigned LEAVES_PER_BLOCK = ROOTS_PER_BLOCK << ::airbender::hash::LOG_WARP_SIZE;
+  const unsigned root_base = blockIdx.x * ROOTS_PER_BLOCK;
+  const unsigned valid_roots = min(ROOTS_PER_BLOCK, roots_count - root_base);
+  const unsigned valid_leaves = valid_roots << ::airbender::hash::LOG_WARP_SIZE;
+  const unsigned leaf_base = blockIdx.x * LEAVES_PER_BLOCK;
+  const auto staged_d = reinterpret_cast<const ::airbender::hash::digest *>(staged);
+  auto boundary_roots_d = reinterpret_cast<::airbender::hash::digest *>(boundary_roots);
+  extern __shared__ __align__(32) uint8_t reducer_smem[];
+  auto values = reinterpret_cast<::airbender::hash::digest *>(reducer_smem);
+  if (threadIdx.x < valid_leaves)
+    values[threadIdx.x] = load_cs(staged_d + leaf_base + threadIdx.x);
+  if (threadIdx.x + blockDim.x < valid_leaves)
+    values[threadIdx.x + blockDim.x] = load_cs(staged_d + leaf_base + threadIdx.x + blockDim.x);
+  __syncthreads();
+  ::airbender::hash::reduce_merkle_subtrees_block(values, valid_leaves >> 1);
+  if (threadIdx.x < valid_roots)
+    store_cs(boundary_roots_d + root_base + threadIdx.x, values[threadIdx.x]);
+}
+
+EXTERN __launch_bounds__(256) __global__
+    void ab_reduce_staged_whir_subtrees_natural_tiles_kernel(const u32 *staged, u32 *boundary_roots, const unsigned log_packed_leaf_count,
+                                                             const unsigned log_lde_factor, const unsigned first_tile_coset_base,
+                                                             const unsigned staged_tile_leaves, const unsigned tiles_count, const unsigned tile_coset_stride,
+                                                             const unsigned roots_count) {
+  constexpr unsigned ROOTS_PER_BLOCK = 16;
+  constexpr unsigned LEAVES_PER_BLOCK = ROOTS_PER_BLOCK << ::airbender::hash::LOG_WARP_SIZE;
+  const unsigned root_base = blockIdx.x * ROOTS_PER_BLOCK;
+  const unsigned valid_roots = min(ROOTS_PER_BLOCK, roots_count - root_base);
+  const unsigned valid_leaves = valid_roots << ::airbender::hash::LOG_WARP_SIZE;
+  const unsigned leaf_base = blockIdx.x * LEAVES_PER_BLOCK;
+  const auto staged_d = reinterpret_cast<const ::airbender::hash::digest *>(staged);
+  auto boundary_roots_d = reinterpret_cast<::airbender::hash::digest *>(boundary_roots);
+  extern __shared__ __align__(32) uint8_t reducer_smem[];
+  auto values = reinterpret_cast<::airbender::hash::digest *>(reducer_smem);
+  if (threadIdx.x < valid_leaves)
+    values[threadIdx.x] = load_cs(staged_d + leaf_base + threadIdx.x);
+  if (threadIdx.x + blockDim.x < valid_leaves)
+    values[threadIdx.x + blockDim.x] = load_cs(staged_d + leaf_base + threadIdx.x + blockDim.x);
+  __syncthreads();
+  ::airbender::hash::reduce_merkle_subtrees_block(values, valid_leaves >> 1);
+  if (threadIdx.x < valid_roots) {
+    const unsigned staged_root = root_base + threadIdx.x;
+    const unsigned staged_leaf = staged_root << ::airbender::hash::LOG_WARP_SIZE;
+    const unsigned tile = staged_leaf / staged_tile_leaves;
+    const unsigned leaf_in_tile = staged_leaf - tile * staged_tile_leaves;
+    const unsigned coset_in_tile = leaf_in_tile >> log_packed_leaf_count;
+    const unsigned leaf_in_coset = leaf_in_tile & ((1u << log_packed_leaf_count) - 1u);
+    const unsigned natural_coset = first_tile_coset_base + tile * tile_coset_stride + coset_in_tile;
+    const unsigned bitrev_coset = bitreverse_low_bits(natural_coset, log_lde_factor);
+    const unsigned roots_per_coset = 1u << (log_packed_leaf_count - ::airbender::hash::LOG_WARP_SIZE);
+    const unsigned output_root = bitrev_coset * roots_per_coset + (leaf_in_coset >> ::airbender::hash::LOG_WARP_SIZE);
+    store_cs(boundary_roots_d + output_root, values[threadIdx.x]);
+  }
+}
+
 } // namespace airbender::whir

--- a/gpu/whir/src/kernels/mod.rs
+++ b/gpu/whir/src/kernels/mod.rs
@@ -585,6 +585,297 @@ pub(crate) fn transform_and_hash_whir_leaves_from_ntt_multi_coset(
 }
 
 cuda_kernel_signature_arguments_and_function!(
+    TransformAndHashWhirLeavesFromNttMultiCosetToStaging,
+    src: PtrAndStride<BF>,
+    staging: *mut u32,
+    transform_params: WhirLeafTransformParams,
+    log_trace_len: u32,
+    log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    coset_index_base: u32,
+);
+
+cuda_kernel_declaration!(
+    ab_transform_and_hash_whir_leaves_from_ntt_multi_coset_to_staging_kernel(
+        src: PtrAndStride<BF>,
+        staging: *mut u32,
+        transform_params: WhirLeafTransformParams,
+        log_trace_len: u32,
+        log_lde_factor: u32,
+        log_values_per_leaf: u32,
+        coset_index_base: u32,
+    )
+);
+
+pub(crate) fn transform_and_hash_whir_leaves_from_ntt_multi_coset_to_staging(
+    ntt_output: &DeviceSlice<BF>,
+    staging: &mut DeviceSlice<Digest>,
+    log_trace_len: u32,
+    log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    coset_index_base: u32,
+    cosets_in_tile: u32,
+    transform_params: WhirLeafTransformParams,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    assert!(log_lde_factor >= 1);
+    assert!((1..=5).contains(&log_values_per_leaf));
+    assert!(log_trace_len > log_values_per_leaf);
+    assert!(cosets_in_tile >= 1);
+    assert!(coset_index_base + cosets_in_tile <= 1u32 << log_lde_factor);
+    let trace_len = 1usize << log_trace_len;
+    let packed_leaf_count = 1usize << (log_trace_len - log_values_per_leaf);
+    let leaves_count = packed_leaf_count
+        .checked_mul(cosets_in_tile as usize)
+        .expect("tile leaf count overflow");
+    assert_eq!(staging.len(), leaves_count);
+    assert!(leaves_count <= u32::MAX as usize);
+    assert!(ntt_output.len() >= trace_len * 4 * cosets_in_tile as usize);
+
+    let values_per_leaf = 1usize << log_values_per_leaf;
+    let block_dim_x = if values_per_leaf == 2 {
+        (leaves_count as u32).min(4 * WARP_SIZE)
+    } else {
+        WARP_SIZE
+    };
+    // The transform uses block-wide barriers, so the x-grid cannot have inactive lanes.
+    assert_eq!(leaves_count as u32 % block_dim_x, 0);
+    let block_dim_y = (values_per_leaf / 2) as u32;
+    let grid_dim_x = leaves_count as u32 / block_dim_x;
+    let mut config = CudaLaunchConfig::basic(grid_dim_x, (block_dim_x, block_dim_y), stream);
+    config.dynamic_smem_bytes = block_dim_x as usize * values_per_leaf * core::mem::size_of::<E4>()
+        + if log_values_per_leaf > 1 {
+            block_dim_x as usize * block_dim_y as usize * core::mem::size_of::<BF>()
+        } else {
+            0
+        };
+    let args = TransformAndHashWhirLeavesFromNttMultiCosetToStagingArguments::new(
+        PtrAndStride::new(ntt_output.as_ptr(), trace_len),
+        staging.as_mut_ptr() as *mut u32,
+        transform_params,
+        log_trace_len,
+        log_lde_factor,
+        log_values_per_leaf,
+        coset_index_base,
+    );
+    TransformAndHashWhirLeavesFromNttMultiCosetToStagingFunction(
+        ab_transform_and_hash_whir_leaves_from_ntt_multi_coset_to_staging_kernel,
+    )
+    .launch(&config, &args)
+}
+
+cuda_kernel_signature_arguments_and_function!(
+    TransformAndHashWhirLeavesFromNttFlatRangeToStaging,
+    src: PtrAndStride<BF>,
+    staging: *mut u32,
+    transform_params: WhirLeafTransformParams,
+    log_trace_len: u32,
+    log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    flat_leaf_base: u32,
+);
+
+cuda_kernel_declaration!(
+    ab_transform_and_hash_whir_leaves_from_ntt_flat_range_to_staging_kernel(
+        src: PtrAndStride<BF>,
+        staging: *mut u32,
+        transform_params: WhirLeafTransformParams,
+        log_trace_len: u32,
+        log_lde_factor: u32,
+        log_values_per_leaf: u32,
+        flat_leaf_base: u32,
+    )
+);
+
+pub(crate) fn transform_and_hash_whir_leaves_from_ntt_flat_range_to_staging(
+    ntt_output: &DeviceSlice<BF>,
+    staging: &mut DeviceSlice<Digest>,
+    log_trace_len: u32,
+    log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    flat_leaf_base: usize,
+    leaves_count: usize,
+    transform_params: WhirLeafTransformParams,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    assert!(log_lde_factor >= 1);
+    assert!((1..=5).contains(&log_values_per_leaf));
+    assert!(log_trace_len > log_values_per_leaf);
+    assert_eq!(flat_leaf_base % WARP_SIZE as usize, 0);
+    assert!(leaves_count > 0);
+    assert_eq!(leaves_count % WARP_SIZE as usize, 0);
+    let trace_len = 1usize << log_trace_len;
+    let packed_leaf_count = 1usize << (log_trace_len - log_values_per_leaf);
+    let total_leaves = packed_leaf_count << log_lde_factor;
+    assert!(flat_leaf_base + leaves_count <= total_leaves);
+    assert_eq!(staging.len(), leaves_count);
+    assert!(ntt_output.len() >= trace_len * 4 * (1usize << log_lde_factor));
+
+    let values_per_leaf = 1usize << log_values_per_leaf;
+    let block_dim_x = WARP_SIZE;
+    let block_dim_y = (values_per_leaf / 2) as u32;
+    // The transform uses block-wide barriers, so the x-grid cannot have inactive lanes.
+    let grid_dim_x = leaves_count as u32 / block_dim_x;
+    let mut config = CudaLaunchConfig::basic(grid_dim_x, (block_dim_x, block_dim_y), stream);
+    config.dynamic_smem_bytes = block_dim_x as usize * values_per_leaf * core::mem::size_of::<E4>()
+        + if log_values_per_leaf > 1 {
+            block_dim_x as usize * block_dim_y as usize * core::mem::size_of::<BF>()
+        } else {
+            0
+        };
+    let args = TransformAndHashWhirLeavesFromNttFlatRangeToStagingArguments::new(
+        PtrAndStride::new(ntt_output.as_ptr(), trace_len),
+        staging.as_mut_ptr() as *mut u32,
+        transform_params,
+        log_trace_len,
+        log_lde_factor,
+        log_values_per_leaf,
+        flat_leaf_base as u32,
+    );
+    TransformAndHashWhirLeavesFromNttFlatRangeToStagingFunction(
+        ab_transform_and_hash_whir_leaves_from_ntt_flat_range_to_staging_kernel,
+    )
+    .launch(&config, &args)
+}
+
+cuda_kernel_signature_arguments_and_function!(
+    ReduceStagedWhirSubtreesFlat,
+    staged: *const u32,
+    boundary_roots: *mut u32,
+    roots_count: u32,
+);
+
+cuda_kernel_declaration!(
+    ab_reduce_staged_whir_subtrees_flat_kernel(
+        staged: *const u32,
+        boundary_roots: *mut u32,
+        roots_count: u32,
+    )
+);
+
+pub(crate) fn reduce_staged_whir_subtrees_flat(
+    staged: &DeviceSlice<Digest>,
+    boundary_roots: &mut DeviceSlice<Digest>,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    const ROOTS_PER_BLOCK: u32 = 16;
+    const LEAVES_PER_BLOCK: usize = 512;
+    assert!(!staged.is_empty());
+    assert_eq!(staged.len() % WARP_SIZE as usize, 0);
+    let roots_count = staged.len() / WARP_SIZE as usize;
+    assert!(boundary_roots.len() >= roots_count);
+    assert!(roots_count <= u32::MAX as usize);
+    let mut config = CudaLaunchConfig::basic(
+        (roots_count as u32).div_ceil(ROOTS_PER_BLOCK),
+        256u32,
+        stream,
+    );
+    config.dynamic_smem_bytes = LEAVES_PER_BLOCK * core::mem::size_of::<Digest>();
+    let args = ReduceStagedWhirSubtreesFlatArguments::new(
+        staged.as_ptr() as *const u32,
+        boundary_roots.as_mut_ptr() as *mut u32,
+        roots_count as u32,
+    );
+    ReduceStagedWhirSubtreesFlatFunction(ab_reduce_staged_whir_subtrees_flat_kernel)
+        .launch(&config, &args)
+}
+
+cuda_kernel_signature_arguments_and_function!(
+    ReduceStagedWhirSubtreesNaturalTiles,
+    staged: *const u32,
+    boundary_roots: *mut u32,
+    log_packed_leaf_count: u32,
+    log_lde_factor: u32,
+    first_tile_coset_base: u32,
+    staged_tile_leaves: u32,
+    tiles_count: u32,
+    tile_coset_stride: u32,
+    roots_count: u32,
+);
+
+cuda_kernel_declaration!(
+    ab_reduce_staged_whir_subtrees_natural_tiles_kernel(
+        staged: *const u32,
+        boundary_roots: *mut u32,
+        log_packed_leaf_count: u32,
+        log_lde_factor: u32,
+        first_tile_coset_base: u32,
+        staged_tile_leaves: u32,
+        tiles_count: u32,
+        tile_coset_stride: u32,
+        roots_count: u32,
+    )
+);
+
+pub(crate) fn reduce_staged_whir_subtrees_natural_tiles(
+    staged: &DeviceSlice<Digest>,
+    boundary_roots: &mut DeviceSlice<Digest>,
+    log_packed_leaf_count: u32,
+    log_lde_factor: u32,
+    first_tile_coset_base: u32,
+    staged_tile_leaves: u32,
+    tiles_count: u32,
+    tile_coset_stride: u32,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    const ROOTS_PER_BLOCK: u32 = 16;
+    const LEAVES_PER_BLOCK: usize = 512;
+    assert!(log_packed_leaf_count >= WARP_SIZE.trailing_zeros());
+    assert!(log_lde_factor < 32);
+    assert!(tiles_count >= 1);
+    assert!(staged_tile_leaves >= WARP_SIZE);
+    assert_eq!(staged_tile_leaves % WARP_SIZE, 0);
+    assert_eq!(
+        staged.len(),
+        staged_tile_leaves as usize * tiles_count as usize
+    );
+    let packed_leaf_count = 1usize << log_packed_leaf_count;
+    let lde_factor = 1usize << log_lde_factor;
+    assert_eq!(staged_tile_leaves as usize % packed_leaf_count, 0);
+    let tile_cosets = staged_tile_leaves as usize / packed_leaf_count;
+    assert!(tiles_count == 1 || tile_coset_stride as usize >= tile_cosets);
+    let last_natural_coset = first_tile_coset_base as usize
+        + (tiles_count as usize - 1) * tile_coset_stride as usize
+        + tile_cosets
+        - 1;
+    assert!(last_natural_coset < lde_factor);
+    let roots_per_coset = packed_leaf_count / WARP_SIZE as usize;
+    let max_bitrev_coset = (0..tiles_count as usize)
+        .flat_map(|tile| {
+            let tile_base = first_tile_coset_base as usize + tile * tile_coset_stride as usize;
+            (0..tile_cosets).map(move |coset| {
+                (tile_base + coset).reverse_bits() >> (usize::BITS - log_lde_factor)
+            })
+        })
+        .max()
+        .unwrap();
+    assert!(boundary_roots.len() >= (max_bitrev_coset + 1) * roots_per_coset);
+    let roots_count = staged.len() / WARP_SIZE as usize;
+    assert!(roots_count <= u32::MAX as usize);
+    let mut config = CudaLaunchConfig::basic(
+        (roots_count as u32).div_ceil(ROOTS_PER_BLOCK),
+        256u32,
+        stream,
+    );
+    config.dynamic_smem_bytes = LEAVES_PER_BLOCK * core::mem::size_of::<Digest>();
+    let args = ReduceStagedWhirSubtreesNaturalTilesArguments::new(
+        staged.as_ptr() as *const u32,
+        boundary_roots.as_mut_ptr() as *mut u32,
+        log_packed_leaf_count,
+        log_lde_factor,
+        first_tile_coset_base,
+        staged_tile_leaves,
+        tiles_count,
+        tile_coset_stride,
+        roots_count as u32,
+    );
+    ReduceStagedWhirSubtreesNaturalTilesFunction(
+        ab_reduce_staged_whir_subtrees_natural_tiles_kernel,
+    )
+    .launch(&config, &args)
+}
+
+cuda_kernel_signature_arguments_and_function!(
     PackRowsForWhirLeavesMultiCoset,
     src: PtrAndStride<BF>,
     dst: MutPtrAndStride<BF>,

--- a/gpu/whir/src/kernels/tests.rs
+++ b/gpu/whir/src/kernels/tests.rs
@@ -4,7 +4,7 @@ use era_cudart::memory::{memory_copy_async, DeviceAllocation};
 use field::{Field, Rand};
 use gpu_core::primitives::device_structures::DeviceMatrix;
 use itertools::Itertools;
-use rand::rng;
+use rand::{rng, Rng};
 
 fn run_partially_evaluate_monomials_by_ref(log_count: usize) {
     use fft::utils::bitreverse_enumeration_inplace;
@@ -198,6 +198,99 @@ fn test_blake2s_leaves_from_ntt_medium() {
 fn test_blake2s_leaves_from_ntt_large() {
     // packed_leaf_count = 1024; large enough for warp coalescing analysis.
     run_blake2s_leaves_from_ntt_matches_pack_then_blake(15, 8, 5, 0);
+}
+
+#[test]
+#[cfg(not(no_cuda))]
+fn test_reduce_staged_whir_subtrees_matches_generic_tree() {
+    use gpu_hash::blake2s::{build_merkle_tree_nodes, Digest};
+
+    fn reference_roots(leaves: &[Digest], stream: &CudaStream) -> Vec<Digest> {
+        let mut leaves_device = DeviceAllocation::alloc(leaves.len()).unwrap();
+        let mut nodes_device = DeviceAllocation::alloc(leaves.len()).unwrap();
+        memory_copy_async(&mut leaves_device, leaves, stream).unwrap();
+        build_merkle_tree_nodes(&leaves_device, &mut nodes_device, 5, stream).unwrap();
+        let roots_count = leaves.len() / 32;
+        let roots_offset = 15 * leaves.len() / 16;
+        let mut roots = vec![Digest::default(); roots_count];
+        memory_copy_async(
+            &mut roots,
+            &nodes_device[roots_offset..roots_offset + roots_count],
+            stream,
+        )
+        .unwrap();
+        stream.synchronize().unwrap();
+        roots
+    }
+
+    let stream = CudaStream::default();
+    let random_digest = || std::array::from_fn(|_| rng().random());
+
+    let flat_leaves = (0..1usize << 12).map(|_| random_digest()).collect_vec();
+    let flat_expected = reference_roots(&flat_leaves, &stream);
+    let mut flat_staged = DeviceAllocation::alloc(flat_leaves.len()).unwrap();
+    let mut flat_roots = DeviceAllocation::alloc(flat_expected.len()).unwrap();
+    memory_copy_async(&mut flat_staged, &flat_leaves, &stream).unwrap();
+    reduce_staged_whir_subtrees_flat(&flat_staged, &mut flat_roots, &stream).unwrap();
+    let mut flat_actual = vec![Digest::default(); flat_expected.len()];
+    memory_copy_async(&mut flat_actual, &flat_roots, &stream).unwrap();
+
+    const LOG_PACKED_LEAF_COUNT: u32 = 6;
+    const LOG_LDE_FACTOR: u32 = 3;
+    let packed_leaf_count = 1usize << LOG_PACKED_LEAF_COUNT;
+    let natural_leaves = (0..packed_leaf_count << LOG_LDE_FACTOR)
+        .map(|_| random_digest())
+        .collect_vec();
+    let natural_expected = reference_roots(&natural_leaves, &stream);
+    let stage_cosets = |cosets: &[usize]| {
+        cosets
+            .iter()
+            .flat_map(|&natural_coset| {
+                let bitrev_coset = natural_coset.reverse_bits() >> (usize::BITS - LOG_LDE_FACTOR);
+                let start = bitrev_coset * packed_leaf_count;
+                natural_leaves[start..start + packed_leaf_count]
+                    .iter()
+                    .copied()
+            })
+            .collect_vec()
+    };
+    let natural_stage_a = stage_cosets(&[0, 1, 4, 5]);
+    let natural_stage_b = stage_cosets(&[2, 3, 6, 7]);
+    let mut natural_stage_a_device = DeviceAllocation::alloc(natural_stage_a.len()).unwrap();
+    let mut natural_stage_b_device = DeviceAllocation::alloc(natural_stage_b.len()).unwrap();
+    let mut natural_roots = DeviceAllocation::alloc(natural_expected.len()).unwrap();
+    memory_copy_async(&mut natural_stage_a_device, &natural_stage_a, &stream).unwrap();
+    memory_copy_async(&mut natural_stage_b_device, &natural_stage_b, &stream).unwrap();
+    reduce_staged_whir_subtrees_natural_tiles(
+        &natural_stage_a_device,
+        &mut natural_roots,
+        LOG_PACKED_LEAF_COUNT,
+        LOG_LDE_FACTOR,
+        0,
+        (2 * packed_leaf_count) as u32,
+        2,
+        4,
+        &stream,
+    )
+    .unwrap();
+    reduce_staged_whir_subtrees_natural_tiles(
+        &natural_stage_b_device,
+        &mut natural_roots,
+        LOG_PACKED_LEAF_COUNT,
+        LOG_LDE_FACTOR,
+        2,
+        (2 * packed_leaf_count) as u32,
+        2,
+        4,
+        &stream,
+    )
+    .unwrap();
+    let mut natural_actual = vec![Digest::default(); natural_expected.len()];
+    memory_copy_async(&mut natural_actual, &natural_roots, &stream).unwrap();
+    stream.synchronize().unwrap();
+
+    assert_eq!(flat_actual, flat_expected);
+    assert_eq!(natural_actual, natural_expected);
 }
 
 fn run_gather_leaves_for_queries_from_ntt_matches_packed(

--- a/gpu/whir/src/lib.rs
+++ b/gpu/whir/src/lib.rs
@@ -131,6 +131,7 @@ impl GpuWhirExtensionOracle {
             tree_cap_size,
             transform_leaves_to_multilinear_coeffs,
             CapTarget::OwnAllocation,
+            None,
             context,
         )
     }
@@ -160,6 +161,7 @@ impl GpuWhirExtensionOracle {
             tree_cap_size,
             transform_leaves_to_multilinear_coeffs,
             CapTarget::Slab(cap_dst_u32),
+            None,
             context,
         )
     }
@@ -172,6 +174,7 @@ impl GpuWhirExtensionOracle {
         tree_cap_size: usize,
         transform_leaves_to_multilinear_coeffs: bool,
         cap_target: CapTarget<'_>,
+        trees_cache_mode_override: Option<TreesCacheMode>,
         context: &ProverContext,
     ) -> CudaResult<Self> {
         assert!(!monomial_coeffs.slice().is_empty());
@@ -192,8 +195,9 @@ impl GpuWhirExtensionOracle {
         let packed_leaf_count = trace_len / values_per_leaf;
         let packed_leaf_count_log2 = packed_leaf_count.trailing_zeros();
         let total_leaf_count_log2 = packed_leaf_count_log2 + log_lde_factor;
-        let trees_cache_mode =
-            Self::recursive_tree_cache_mode(total_leaf_count_log2, log_tree_cap_size);
+        let trees_cache_mode = trees_cache_mode_override.unwrap_or_else(|| {
+            Self::recursive_tree_cache_mode(total_leaf_count_log2, log_tree_cap_size)
+        });
 
         let mut trace_holder = TraceHolder::new(
             total_leaf_count_log2,
@@ -572,6 +576,27 @@ impl GpuWhirExtensionOracle {
         transform_leaves_to_multilinear_coeffs: bool,
         context: &ProverContext,
     ) -> CudaResult<Self> {
+        Self::from_monomial_coeffs_with_cache_mode(
+            monomial_coeffs,
+            lde_factor,
+            values_per_leaf,
+            tree_cap_size,
+            transform_leaves_to_multilinear_coeffs,
+            None,
+            context,
+        )
+    }
+
+    #[cfg(test)]
+    fn from_monomial_coeffs_with_cache_mode(
+        monomial_coeffs: &[E4],
+        lde_factor: usize,
+        values_per_leaf: usize,
+        tree_cap_size: usize,
+        transform_leaves_to_multilinear_coeffs: bool,
+        trees_cache_mode_override: Option<TreesCacheMode>,
+        context: &ProverContext,
+    ) -> CudaResult<Self> {
         let trace_len = monomial_coeffs.len();
         let mut bitreversed_monomial_coeffs = monomial_coeffs.to_vec();
         bitreverse_enumeration_inplace(&mut bitreversed_monomial_coeffs);
@@ -584,35 +609,15 @@ impl GpuWhirExtensionOracle {
         let host = alloc_static_pinned_box_from_slice(&vectorized_monomial_coeffs[..])?;
         memory_copy_async(&mut monomial_coeffs_device_alloc, &host[..], stream)?;
         let monomial_coeffs_device = DeviceMatrix::new(&monomial_coeffs_device_alloc, trace_len);
-        Self::from_device_monomial_coeffs(
+        let oracle = Self::from_device_monomial_coeffs_impl(
             &monomial_coeffs_device,
             trace_len,
             lde_factor,
             values_per_leaf,
             tree_cap_size,
             transform_leaves_to_multilinear_coeffs,
-            context,
-        )
-    }
-
-    #[cfg(test)]
-    pub(crate) fn from_device_monomial_coeffs(
-        monomial_coeffs: &impl DeviceMatrixImpl<BF>,
-        trace_len: usize,
-        lde_factor: usize,
-        values_per_leaf: usize,
-        tree_cap_size: usize,
-        transform_leaves_to_multilinear_coeffs: bool,
-        context: &ProverContext,
-    ) -> CudaResult<Self> {
-        let oracle = Self::from_device_monomial_coeffs_impl(
-            monomial_coeffs,
-            trace_len,
-            lde_factor,
-            values_per_leaf,
-            tree_cap_size,
-            transform_leaves_to_multilinear_coeffs,
             CapTarget::OwnAllocation,
+            trees_cache_mode_override,
             context,
         )?;
         context.get_exec_stream().synchronize()?;
@@ -753,6 +758,83 @@ pub(crate) mod tests {
                 ])
             })
             .collect()
+    }
+
+    fn copy_tree(oracle: &GpuWhirExtensionOracle, context: &ProverContext) -> Vec<Digest> {
+        let tree = match &oracle.trace_holder.trees {
+            TreesHolder::Full(tree) | TreesHolder::Partial(tree) => tree,
+            TreesHolder::None => panic!("recursive oracle has no tree backing"),
+        };
+        let mut host = vec![Digest::default(); tree.len()];
+        memory_copy_async(&mut host, &tree[..], context.get_exec_stream()).unwrap();
+        context.get_exec_stream().synchronize().unwrap();
+        host
+    }
+
+    fn assert_partial_tree_prefix_matches_full(
+        log_trace_len: u32,
+        lde_factor: usize,
+        values_per_leaf: usize,
+        cap_size: usize,
+        transform: bool,
+    ) {
+        let context = make_test_context(512, 32);
+        let monomial_coeffs = sample_monomial_coeffs(1 << log_trace_len);
+        let mut full = GpuWhirExtensionOracle::from_monomial_coeffs_with_cache_mode(
+            &monomial_coeffs,
+            lde_factor,
+            values_per_leaf,
+            cap_size,
+            transform,
+            Some(TreesCacheMode::CacheFull),
+            &context,
+        )
+        .unwrap();
+        let mut partial = GpuWhirExtensionOracle::from_monomial_coeffs_with_cache_mode(
+            &monomial_coeffs,
+            lde_factor,
+            values_per_leaf,
+            cap_size,
+            transform,
+            Some(TreesCacheMode::CachePartial),
+            &context,
+        )
+        .unwrap();
+
+        let leaves = (1usize << log_trace_len) * lde_factor / values_per_leaf;
+        let partial_len = leaves / 16;
+        let initialized_len = partial_len - cap_size;
+        let full_start = 2 * leaves - partial_len;
+        let full_tree = copy_tree(&full, &context);
+        let partial_tree = copy_tree(&partial, &context);
+        assert_eq!(partial_tree.len(), partial_len);
+        assert_eq!(
+            &partial_tree[..initialized_len],
+            &full_tree[full_start..full_start + initialized_len],
+        );
+        assert_eq!(
+            partial.get_tree_cap(&context).unwrap(),
+            full.get_tree_cap(&context).unwrap(),
+        );
+
+        let mut query_indexes = vec![
+            0,
+            31.min(leaves - 1),
+            32.min(leaves - 1),
+            leaves / 2,
+            leaves - 1,
+        ];
+        query_indexes.sort_unstable();
+        query_indexes.dedup();
+        for query_index in query_indexes {
+            assert_eq!(
+                partial
+                    .query_for_folded_index(query_index, &context)
+                    .unwrap(),
+                full.query_for_folded_index(query_index, &context).unwrap(),
+                "query {query_index} differs between partial and full cache",
+            );
+        }
     }
 
     fn compute_column_major_lde_from_monomial_form_for_test(
@@ -1554,5 +1636,26 @@ pub(crate) mod tests {
                 "query {query_index} path helper diverged"
             );
         }
+    }
+
+    #[test]
+    fn partial_tree_prefix_matches_full_tree() {
+        let shapes = [
+            (11u32, 2048usize, 32usize),
+            (8u32, 8192usize, 16usize),
+            (6u32, 32usize, 32usize),
+        ];
+        for transform in [false, true] {
+            for (log_trace_len, lde_factor, values_per_leaf) in shapes {
+                assert_partial_tree_prefix_matches_full(
+                    log_trace_len,
+                    lde_factor,
+                    values_per_leaf,
+                    1,
+                    transform,
+                );
+            }
+        }
+        assert_partial_tree_prefix_matches_full(14, 256, 32, 1, false);
     }
 }

--- a/gpu/whir/src/oracle_commit.rs
+++ b/gpu/whir/src/oracle_commit.rs
@@ -13,6 +13,58 @@ use gpu_ntt::ntt::{lde_with_coset_range, MAX_LOG_N_FOR_SINGLE_KERNEL_LDE};
 use gpu_prover_context::ProverContext;
 use gpu_trace::trace::holder::{TraceHolder, TreesHolder, PARTIAL_TREE_REDUCTION_LAYERS};
 
+enum LeafCommitTarget<'a> {
+    FullTree(&'a mut DeviceSlice<Digest>),
+    PartialTree(&'a mut DeviceSlice<Digest>),
+}
+
+const PARTIAL_TREE_STAGING_BYTES: usize = 32 << 20;
+const PARTIAL_TREE_STAGING_DIGESTS: usize =
+    PARTIAL_TREE_STAGING_BYTES / core::mem::size_of::<Digest>();
+
+#[derive(Default)]
+struct PartialTreeBatch {
+    leaves_len: usize,
+    first_tile_coset_base: usize,
+    staged_tile_leaves: usize,
+    tiles_count: usize,
+    tile_coset_stride: usize,
+    flat_root_base: usize,
+}
+
+fn flush_partial_tree_batch(
+    batch: &mut PartialTreeBatch,
+    staging: &DeviceSlice<Digest>,
+    boundary_roots: &mut DeviceSlice<Digest>,
+    log_packed_leaf_count: u32,
+    log_lde_factor: u32,
+    stream: &era_cudart::stream::CudaStream,
+) -> CudaResult<()> {
+    if batch.leaves_len == 0 {
+        return Ok(());
+    }
+    let staged = &staging[..batch.leaves_len];
+    if batch.staged_tile_leaves == 0 {
+        let roots_count = batch.leaves_len >> PARTIAL_TREE_REDUCTION_LAYERS;
+        let roots = &mut boundary_roots[batch.flat_root_base..batch.flat_root_base + roots_count];
+        crate::kernels::reduce_staged_whir_subtrees_flat(staged, roots, stream)?;
+    } else {
+        crate::kernels::reduce_staged_whir_subtrees_natural_tiles(
+            staged,
+            boundary_roots,
+            log_packed_leaf_count,
+            log_lde_factor,
+            batch.first_tile_coset_base as u32,
+            batch.staged_tile_leaves as u32,
+            batch.tiles_count as u32,
+            batch.tile_coset_stride as u32,
+            stream,
+        )?;
+    }
+    *batch = PartialTreeBatch::default();
+    Ok(())
+}
+
 /// Schedules the recursive WHIR oracle's natural multi-coset LDE, leaf
 /// commitment, tree construction, and cap gather. The holder uses the WHIR
 /// shape (`log_lde_factor = log_rows_per_leaf = 0`); the actual LDE and leaf
@@ -72,33 +124,27 @@ pub(crate) fn schedule_recursive_oracle_commit(
             )?;
         }
         TreesHolder::Partial(backing) => {
-            // The transient top contains leaves plus the four node layers
-            // omitted by the persistent partial-tree cache.
-            let mut tree_top =
-                context.alloc::<Digest>(full_tree_len, AllocationPlacement::BestFit)?;
-            let top_log_cap = total_leaf_count_log2 + 1 - PARTIAL_TREE_REDUCTION_LAYERS;
-            commit_trace_from_ntt_single_tree(
+            let boundary_roots_count = total_leaf_count >> PARTIAL_TREE_REDUCTION_LAYERS;
+            assert_eq!(backing.len(), boundary_roots_count << 1);
+            let (boundary_roots, upper_nodes) = backing.split_at_mut(boundary_roots_count);
+            commit_trace_from_ntt_partial_tree(
                 inputs_matrix,
                 ntt_output,
-                &mut tree_top,
+                boundary_roots,
                 log_trace_len,
                 natural_log_lde_factor,
                 log_values_per_leaf,
-                top_log_cap,
                 src_cols_per_coset,
                 transform_leaves_to_multilinear_coeffs,
                 context,
             )?;
-
             let bottom_layers_count =
                 total_leaf_count_log2 + 1 - PARTIAL_TREE_REDUCTION_LAYERS - log_tree_cap_size;
-            let tree_bottom_len = full_tree_len >> PARTIAL_TREE_REDUCTION_LAYERS;
-            assert_eq!(backing.len(), tree_bottom_len);
-            let values = &tree_top[full_tree_len - 2 * tree_bottom_len..][..tree_bottom_len];
+            assert!(bottom_layers_count >= 1);
             gpu_hash::blake2s::build_merkle_tree_nodes(
-                values,
-                backing,
-                bottom_layers_count,
+                boundary_roots,
+                upper_nodes,
+                bottom_layers_count - 1,
                 stream,
             )?;
         }
@@ -146,9 +192,6 @@ fn commit_trace_from_ntt_single_tree(
     transform_leaves_to_multilinear_coeffs: bool,
     context: &ProverContext,
 ) -> CudaResult<()> {
-    assert!(natural_log_lde_factor >= 1);
-    assert!(log_trace_len >= log_values_per_leaf);
-    let trace_len = 1 << log_trace_len;
     let packed_leaf_count = 1usize << (log_trace_len - log_values_per_leaf);
     let total_leaf_count = packed_leaf_count
         .checked_mul(1 << natural_log_lde_factor)
@@ -158,6 +201,85 @@ fn commit_trace_from_ntt_single_tree(
     assert!(log_tree_cap_size <= total_leaf_count_log2);
     let layers_count = total_leaf_count_log2 + 1 - log_tree_cap_size;
     let (leaves, nodes) = trees_backing.split_at_mut(total_leaf_count);
+
+    schedule_trace_leaves_from_ntt(
+        inputs_matrix,
+        ntt_output,
+        LeafCommitTarget::FullTree(leaves),
+        log_trace_len,
+        natural_log_lde_factor,
+        log_values_per_leaf,
+        src_cols_per_coset,
+        transform_leaves_to_multilinear_coeffs,
+        context,
+    )?;
+    gpu_hash::blake2s::build_merkle_tree_nodes(
+        leaves,
+        nodes,
+        layers_count - 1,
+        context.get_exec_stream(),
+    )
+}
+
+fn commit_trace_from_ntt_partial_tree(
+    inputs_matrix: &DeviceMatrixChunk<BF>,
+    ntt_output: &mut DeviceSlice<BF>,
+    boundary_roots: &mut DeviceSlice<Digest>,
+    log_trace_len: u32,
+    natural_log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    src_cols_per_coset: usize,
+    transform_leaves_to_multilinear_coeffs: bool,
+    context: &ProverContext,
+) -> CudaResult<()> {
+    assert_eq!(
+        PARTIAL_TREE_REDUCTION_LAYERS,
+        gpu_core::primitives::utils::WARP_SIZE.trailing_zeros(),
+    );
+    let total_leaf_count =
+        1usize << ((log_trace_len - log_values_per_leaf) + natural_log_lde_factor);
+    assert_eq!(
+        boundary_roots.len(),
+        total_leaf_count >> PARTIAL_TREE_REDUCTION_LAYERS
+    );
+    schedule_trace_leaves_from_ntt(
+        inputs_matrix,
+        ntt_output,
+        LeafCommitTarget::PartialTree(boundary_roots),
+        log_trace_len,
+        natural_log_lde_factor,
+        log_values_per_leaf,
+        src_cols_per_coset,
+        transform_leaves_to_multilinear_coeffs,
+        context,
+    )
+}
+
+fn schedule_trace_leaves_from_ntt(
+    inputs_matrix: &DeviceMatrixChunk<BF>,
+    ntt_output: &mut DeviceSlice<BF>,
+    mut target: LeafCommitTarget<'_>,
+    log_trace_len: u32,
+    natural_log_lde_factor: u32,
+    log_values_per_leaf: u32,
+    src_cols_per_coset: usize,
+    transform_leaves_to_multilinear_coeffs: bool,
+    context: &ProverContext,
+) -> CudaResult<()> {
+    assert!(natural_log_lde_factor >= 1);
+    assert!(log_trace_len >= log_values_per_leaf);
+    let trace_len = 1 << log_trace_len;
+    let packed_leaf_count = 1usize << (log_trace_len - log_values_per_leaf);
+    let total_leaf_count = packed_leaf_count
+        .checked_mul(1 << natural_log_lde_factor)
+        .expect("total_leaf_count overflow");
+    match &target {
+        LeafCommitTarget::FullTree(leaves) => assert_eq!(leaves.len(), total_leaf_count),
+        LeafCommitTarget::PartialTree(roots) => assert_eq!(
+            roots.len(),
+            total_leaf_count >> PARTIAL_TREE_REDUCTION_LAYERS
+        ),
+    }
 
     let device_properties = context.get_device_properties();
     let ntt_ctx = context.ntt_device_context();
@@ -205,6 +327,52 @@ fn commit_trace_from_ntt_single_tree(
         num_streams = 1;
         cosets_in_tile_chunk = total_cosets;
     }
+
+    let helpers_for_base = |coset_index_base: usize| {
+        let mut helpers = Vec::with_capacity(2);
+        for i in 0..num_streams {
+            let stream_coset_base = coset_index_base + i * cosets_in_tile_chunk;
+            if stream_coset_base < total_cosets {
+                let cosets_in_tile =
+                    std::cmp::min(cosets_in_tile_chunk, total_cosets - stream_coset_base);
+                let offset = src_cols_per_coset * trace_len * stream_coset_base;
+                helpers.push((stream_coset_base, cosets_in_tile, offset));
+            }
+        }
+        helpers
+    };
+    let is_partial = matches!(&target, LeafCommitTarget::PartialTree(_));
+    let use_flat_partial =
+        is_partial && packed_leaf_count < (1usize << PARTIAL_TREE_REDUCTION_LAYERS);
+    let staging_capacity = std::cmp::min(PARTIAL_TREE_STAGING_DIGESTS, total_leaf_count);
+    let mut flat_leaves_per_stream = [0usize; 2];
+    if use_flat_partial {
+        for coset_index_base in (0..total_cosets).step_by(num_streams * cosets_in_tile_chunk) {
+            for (i, &(_, cosets_in_tile, _)) in
+                helpers_for_base(coset_index_base).iter().enumerate()
+            {
+                flat_leaves_per_stream[i] += cosets_in_tile * packed_leaf_count;
+            }
+        }
+        assert_eq!(
+            flat_leaves_per_stream[..num_streams].iter().sum::<usize>(),
+            total_leaf_count
+        );
+        for &leaves_count in &flat_leaves_per_stream[..num_streams] {
+            assert_eq!(leaves_count % (1usize << PARTIAL_TREE_REDUCTION_LAYERS), 0);
+        }
+    }
+    let mut flat_leaf_cursors = [0usize, flat_leaves_per_stream[0]];
+    let mut staging_buffers = Vec::with_capacity(num_streams);
+    if is_partial {
+        for _ in 0..num_streams {
+            staging_buffers
+                .push(context.alloc::<Digest>(staging_capacity, AllocationPlacement::BestFit)?);
+        }
+    }
+    let mut partial_tree_batches = (0..num_streams)
+        .map(|_| PartialTreeBatch::default())
+        .collect::<Vec<_>>();
 
     let mut ntt_output_matrix = DeviceMatrixMut::new(ntt_output, trace_len);
     let (start_event, end_event) = if num_streams > 1 {
@@ -256,18 +424,7 @@ fn commit_trace_from_ntt_single_tree(
     }
 
     for coset_index_base in (0..total_cosets).step_by(num_streams * cosets_in_tile_chunk) {
-        let mut helpers_per_stream = Vec::with_capacity(2);
-        for i in 0..num_streams {
-            let coset_index_base_this_stream = coset_index_base + i * cosets_in_tile_chunk;
-            if coset_index_base_this_stream < total_cosets {
-                let cosets_in_tile = std::cmp::min(
-                    cosets_in_tile_chunk,
-                    total_cosets - coset_index_base_this_stream,
-                );
-                let offset = src_cols_per_coset * trace_len * coset_index_base_this_stream;
-                helpers_per_stream.push((coset_index_base_this_stream, cosets_in_tile, offset));
-            }
-        }
+        let helpers_per_stream = helpers_for_base(coset_index_base);
 
         // Preserve the breadth-first two-stream launch order.
         for (i, &(coset_index_base_this_stream, cosets_in_tile, offset)) in
@@ -292,42 +449,221 @@ fn commit_trace_from_ntt_single_tree(
                 )?;
             }
         }
-        if transform_leaves_to_multilinear_coeffs {
-            assert_eq!(src_cols_per_coset, 4, "coefficient WHIR leaves require E4");
-            let transform_params = ntt_ctx.whir_leaf_transform_params(log_values_per_leaf);
-            for (i, &(coset_index_base_this_stream, cosets_in_tile, offset)) in
-                helpers_per_stream.iter().enumerate()
-            {
-                crate::kernels::transform_and_hash_whir_leaves_from_ntt_multi_coset(
-                    &ntt_output_matrix.slice()[offset..],
-                    leaves,
-                    log_trace_len,
-                    natural_log_lde_factor,
-                    log_values_per_leaf,
-                    coset_index_base_this_stream as u32,
-                    cosets_in_tile as u32,
-                    transform_params,
-                    streams[i],
-                )?;
-            }
-        } else {
-            for (i, &(coset_index_base_this_stream, cosets_in_tile, offset)) in
-                helpers_per_stream.iter().enumerate()
-            {
-                gpu_hash::blake2s::hash_leaves_from_ntt_multi_coset(
-                    &ntt_output_matrix.slice()[offset..],
-                    leaves,
-                    log_values_per_leaf,
-                    src_cols_per_coset as u32,
-                    natural_log_lde_factor,
-                    coset_index_base_this_stream as u32,
-                    cosets_in_tile,
-                    packed_leaf_count,
-                    trace_len as u32,
-                    streams[i],
-                )?;
+        for (i, &(stream_coset_base, cosets_in_tile, offset)) in
+            helpers_per_stream.iter().enumerate()
+        {
+            match &mut target {
+                LeafCommitTarget::FullTree(leaves) => {
+                    if transform_leaves_to_multilinear_coeffs {
+                        assert_eq!(src_cols_per_coset, 4, "coefficient WHIR leaves require E4");
+                        let transform_params =
+                            ntt_ctx.whir_leaf_transform_params(log_values_per_leaf);
+                        crate::kernels::transform_and_hash_whir_leaves_from_ntt_multi_coset(
+                            &ntt_output_matrix.slice()[offset..],
+                            leaves,
+                            log_trace_len,
+                            natural_log_lde_factor,
+                            log_values_per_leaf,
+                            stream_coset_base as u32,
+                            cosets_in_tile as u32,
+                            transform_params,
+                            streams[i],
+                        )?;
+                    } else {
+                        gpu_hash::blake2s::hash_leaves_from_ntt_multi_coset(
+                            &ntt_output_matrix.slice()[offset..],
+                            leaves,
+                            log_values_per_leaf,
+                            src_cols_per_coset as u32,
+                            natural_log_lde_factor,
+                            stream_coset_base as u32,
+                            cosets_in_tile,
+                            packed_leaf_count,
+                            trace_len as u32,
+                            streams[i],
+                        )?;
+                    }
+                }
+                LeafCommitTarget::PartialTree(boundary_roots) => {
+                    let staging = &mut staging_buffers[i];
+                    let batch = &mut partial_tree_batches[i];
+                    if use_flat_partial {
+                        let subtree_leaves = 1usize << PARTIAL_TREE_REDUCTION_LAYERS;
+                        let mut leaves_remaining = cosets_in_tile * packed_leaf_count;
+                        while leaves_remaining > 0 {
+                            if batch.leaves_len == staging_capacity {
+                                flush_partial_tree_batch(
+                                    batch,
+                                    staging,
+                                    boundary_roots,
+                                    log_trace_len - log_values_per_leaf,
+                                    natural_log_lde_factor,
+                                    streams[i],
+                                )?;
+                            }
+                            let flat_leaf_base = flat_leaf_cursors[i];
+                            let leaves_count = std::cmp::min(
+                                leaves_remaining,
+                                staging_capacity - batch.leaves_len,
+                            );
+                            assert_eq!(flat_leaf_base % subtree_leaves, 0);
+                            assert_eq!(leaves_count % subtree_leaves, 0);
+                            if batch.leaves_len == 0 {
+                                batch.flat_root_base =
+                                    flat_leaf_base >> PARTIAL_TREE_REDUCTION_LAYERS;
+                            } else {
+                                assert_eq!(
+                                    batch.flat_root_base
+                                        + (batch.leaves_len >> PARTIAL_TREE_REDUCTION_LAYERS),
+                                    flat_leaf_base >> PARTIAL_TREE_REDUCTION_LAYERS
+                                );
+                            }
+                            let stage_offset = batch.leaves_len;
+                            let stage_dst = &mut staging[stage_offset..stage_offset + leaves_count];
+                            if transform_leaves_to_multilinear_coeffs {
+                                assert_eq!(
+                                    src_cols_per_coset, 4,
+                                    "coefficient WHIR leaves require E4"
+                                );
+                                let transform_params =
+                                    ntt_ctx.whir_leaf_transform_params(log_values_per_leaf);
+                                crate::kernels::transform_and_hash_whir_leaves_from_ntt_flat_range_to_staging(
+                                    ntt_output_matrix.slice(),
+                                    stage_dst,
+                                    log_trace_len,
+                                    natural_log_lde_factor,
+                                    log_values_per_leaf,
+                                    flat_leaf_base,
+                                    leaves_count,
+                                    transform_params,
+                                    streams[i],
+                                )?;
+                            } else {
+                                gpu_hash::blake2s::hash_leaves_from_ntt_flat_range_to_staging(
+                                    ntt_output_matrix.slice(),
+                                    stage_dst,
+                                    log_values_per_leaf,
+                                    src_cols_per_coset as u32,
+                                    natural_log_lde_factor,
+                                    flat_leaf_base,
+                                    leaves_count,
+                                    packed_leaf_count,
+                                    trace_len as u32,
+                                    streams[i],
+                                )?;
+                            }
+                            batch.leaves_len += leaves_count;
+                            flat_leaf_cursors[i] += leaves_count;
+                            leaves_remaining -= leaves_count;
+                        }
+                    } else {
+                        let max_cosets_per_stage = staging_capacity / packed_leaf_count;
+                        assert!(max_cosets_per_stage >= 1);
+                        let mut cosets_staged = 0;
+                        while cosets_staged < cosets_in_tile {
+                            let sub_cosets =
+                                std::cmp::min(max_cosets_per_stage, cosets_in_tile - cosets_staged);
+                            let tile_leaves = sub_cosets * packed_leaf_count;
+                            let tile_coset_base = stream_coset_base + cosets_staged;
+                            let shape_matches = batch.leaves_len == 0
+                                || (batch.staged_tile_leaves == tile_leaves
+                                    && batch.leaves_len + tile_leaves <= staging_capacity
+                                    && (batch.tiles_count == 1
+                                        || tile_coset_base
+                                            == batch.first_tile_coset_base
+                                                + batch.tiles_count * batch.tile_coset_stride));
+                            if !shape_matches {
+                                flush_partial_tree_batch(
+                                    batch,
+                                    staging,
+                                    boundary_roots,
+                                    log_trace_len - log_values_per_leaf,
+                                    natural_log_lde_factor,
+                                    streams[i],
+                                )?;
+                            }
+                            if batch.leaves_len == 0 {
+                                batch.first_tile_coset_base = tile_coset_base;
+                                batch.staged_tile_leaves = tile_leaves;
+                            } else if batch.tiles_count == 1 {
+                                batch.tile_coset_stride =
+                                    tile_coset_base - batch.first_tile_coset_base;
+                            }
+                            let stage_offset = batch.leaves_len;
+                            let stage_dst = &mut staging[stage_offset..stage_offset + tile_leaves];
+                            let source_offset =
+                                offset + cosets_staged * src_cols_per_coset * trace_len;
+                            if transform_leaves_to_multilinear_coeffs {
+                                assert_eq!(
+                                    src_cols_per_coset, 4,
+                                    "coefficient WHIR leaves require E4"
+                                );
+                                let transform_params =
+                                    ntt_ctx.whir_leaf_transform_params(log_values_per_leaf);
+                                crate::kernels::transform_and_hash_whir_leaves_from_ntt_multi_coset_to_staging(
+                                    &ntt_output_matrix.slice()[source_offset..],
+                                    stage_dst,
+                                    log_trace_len,
+                                    natural_log_lde_factor,
+                                    log_values_per_leaf,
+                                    tile_coset_base as u32,
+                                    sub_cosets as u32,
+                                    transform_params,
+                                    streams[i],
+                                )?;
+                            } else {
+                                gpu_hash::blake2s::hash_leaves_from_ntt_multi_coset_to_staging(
+                                    &ntt_output_matrix.slice()[source_offset..],
+                                    stage_dst,
+                                    log_values_per_leaf,
+                                    src_cols_per_coset as u32,
+                                    natural_log_lde_factor,
+                                    tile_coset_base as u32,
+                                    sub_cosets,
+                                    packed_leaf_count,
+                                    trace_len as u32,
+                                    streams[i],
+                                )?;
+                            }
+                            batch.leaves_len += tile_leaves;
+                            batch.tiles_count += 1;
+                            cosets_staged += sub_cosets;
+                            if batch.leaves_len == staging_capacity {
+                                flush_partial_tree_batch(
+                                    batch,
+                                    staging,
+                                    boundary_roots,
+                                    log_trace_len - log_values_per_leaf,
+                                    natural_log_lde_factor,
+                                    streams[i],
+                                )?;
+                            }
+                        }
+                    }
+                }
             }
         }
+    }
+
+    if is_partial {
+        let LeafCommitTarget::PartialTree(boundary_roots) = &mut target else {
+            unreachable!()
+        };
+        for i in 0..num_streams {
+            flush_partial_tree_batch(
+                &mut partial_tree_batches[i],
+                &staging_buffers[i],
+                boundary_roots,
+                log_trace_len - log_values_per_leaf,
+                natural_log_lde_factor,
+                streams[i],
+            )?;
+        }
+    }
+
+    if use_flat_partial {
+        assert_eq!(flat_leaf_cursors[0], flat_leaves_per_stream[0]);
+        assert_eq!(flat_leaf_cursors[num_streams - 1], total_leaf_count);
     }
 
     if num_streams > 1 {
@@ -338,5 +674,5 @@ fn commit_trace_from_ntt_single_tree(
         )?;
     }
 
-    gpu_hash::blake2s::build_merkle_tree_nodes(leaves, nodes, layers_count - 1, exec_stream)
+    Ok(())
 }


### PR DESCRIPTION
## What ❔

Builds partial recursive WHIR commitments from bounded leaf-digest staging buffers, reducing each 32-leaf subtree directly into the stored boundary roots. Full-cache commitments and query reconstruction are unchanged.

## Why ❔

Avoids the transient full tree-top allocation. In the add_sub profile, peak GPU memory fell from 28.174 GiB to 27.957 GiB while WHIR time stayed neutral (34.108 ms to 33.800 ms median).

Validated with the gpu_hash and gpu_whir suites, the large transformed-oracle regression, and Sec100 proof parity for coefficient and evaluation leaves.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
