### PR TITLE
perf(trace): avoid materializing partial tree tops

### DIFF
--- a/gpu/hash/native/hash.cu
+++ b/gpu/hash/native/hash.cu
@@ -60,23 +60,12 @@ EXTERN __global__ void ab_blake2s_leaves_kernel(const bf *values, u32 *results, 
   store_cs(reinterpret_cast<digest *>(results) + gid, state);
 }
 
-// Multi-coset leaves kernel: hashes `(1 << log_per_coset_count) *
-// cosets_in_tile` leaves in one launch. Each coset's leaf inputs and tree
-// outputs sit in per-coset slabs offset by `per_coset_values_stride_bf` and
-// `per_coset_results_stride_digests` respectively; cosets are independent so
-// the kernel just decomposes `gid_global` into `(coset, gid_in_coset)` and
-// advances the base pointers by the coset stride.
-EXTERN __global__ void ab_blake2s_leaves_multi_coset_kernel(const bf *values, u32 *results, const unsigned log_rows_count, const unsigned cols_count,
-                                                            const unsigned log_per_coset_count, const unsigned per_coset_values_stride_bf,
-                                                            const unsigned per_coset_results_stride_digests, const unsigned count) {
-  const unsigned gid_global = threadIdx.x + blockIdx.x * blockDim.x;
-  if (gid_global >= count)
-    return;
+DEVICE_FORCEINLINE digest hash_leaf_multi_coset(const bf *values, const unsigned log_rows_count, const unsigned cols_count, const unsigned log_per_coset_count,
+                                                const unsigned per_coset_values_stride_bf, const unsigned gid_global) {
   const unsigned per_coset_count = 1u << log_per_coset_count;
   const unsigned coset = gid_global >> log_per_coset_count;
   const unsigned gid = gid_global & (per_coset_count - 1u);
   values += static_cast<size_t>(coset) * per_coset_values_stride_bf;
-  digest *results_d = reinterpret_cast<digest *>(results) + static_cast<size_t>(coset) * per_coset_results_stride_digests + gid;
   const unsigned row_mask = (1u << log_rows_count) - 1;
   const unsigned domain_size = per_coset_count << log_rows_count;
   auto read = [=](const unsigned offset) {
@@ -89,7 +78,51 @@ EXTERN __global__ void ab_blake2s_leaves_multi_coset_kernel(const bf *values, u3
   initialize(state.words);
   u32 t = 0;
   absorb_stream(state.words, t, cols_count << log_rows_count, read);
+  return state;
+}
+
+EXTERN __global__ void ab_blake2s_leaves_multi_coset_kernel(const bf *values, u32 *results, const unsigned log_rows_count, const unsigned cols_count,
+                                                            const unsigned log_per_coset_count, const unsigned per_coset_values_stride_bf,
+                                                            const unsigned per_coset_results_stride_digests, const unsigned count) {
+  const unsigned gid_global = threadIdx.x + blockIdx.x * blockDim.x;
+  if (gid_global >= count)
+    return;
+  const unsigned coset = gid_global >> log_per_coset_count;
+  const unsigned gid = gid_global & ((1u << log_per_coset_count) - 1u);
+  digest *results_d = reinterpret_cast<digest *>(results) + static_cast<size_t>(coset) * per_coset_results_stride_digests + gid;
+  const digest state = hash_leaf_multi_coset(values, log_rows_count, cols_count, log_per_coset_count, per_coset_values_stride_bf, gid_global);
   store_cs(results_d, state);
+}
+
+EXTERN __launch_bounds__(256) __global__
+    void ab_blake2s_partial_tree_multi_coset_kernel(const bf *values, u32 *tree_backing, const unsigned log_rows_count, const unsigned cols_count,
+                                                    const unsigned log_per_coset_count, const unsigned per_coset_values_stride_bf,
+                                                    const unsigned per_coset_tree_stride_digests, const unsigned count) {
+  constexpr unsigned ROOTS_PER_BLOCK = 16;
+  constexpr unsigned LEAVES_PER_BLOCK = ROOTS_PER_BLOCK << LOG_WARP_SIZE;
+  const unsigned leaf_base = blockIdx.x * LEAVES_PER_BLOCK;
+  const unsigned valid_leaves = min(LEAVES_PER_BLOCK, count - leaf_base);
+  extern __shared__ __align__(32) uint8_t reducer_smem[];
+  auto shared_values = reinterpret_cast<digest *>(reducer_smem);
+
+  const unsigned leaf = leaf_base + threadIdx.x;
+  if (threadIdx.x < valid_leaves)
+    shared_values[threadIdx.x] = hash_leaf_multi_coset(values, log_rows_count, cols_count, log_per_coset_count, per_coset_values_stride_bf, leaf);
+  if (threadIdx.x + blockDim.x < valid_leaves)
+    shared_values[threadIdx.x + blockDim.x] =
+        hash_leaf_multi_coset(values, log_rows_count, cols_count, log_per_coset_count, per_coset_values_stride_bf, leaf + blockDim.x);
+  __syncthreads();
+
+  reduce_merkle_subtrees_block(shared_values, valid_leaves >> 1);
+  const unsigned valid_roots = valid_leaves >> LOG_WARP_SIZE;
+  if (threadIdx.x < valid_roots) {
+    const unsigned global_root = blockIdx.x * ROOTS_PER_BLOCK + threadIdx.x;
+    const unsigned log_roots_per_coset = log_per_coset_count - LOG_WARP_SIZE;
+    const unsigned coset = global_root >> log_roots_per_coset;
+    const unsigned root_in_coset = global_root & ((1u << log_roots_per_coset) - 1u);
+    auto roots = reinterpret_cast<digest *>(tree_backing) + static_cast<size_t>(coset) * per_coset_tree_stride_digests;
+    store_cs(roots + root_in_coset, shared_values[threadIdx.x]);
+  }
 }
 
 // Fused leaves-from-NTT kernel: reads the natural multi-coset NTT output and

--- a/gpu/hash/src/blake2s/merkle.rs
+++ b/gpu/hash/src/blake2s/merkle.rs
@@ -69,95 +69,6 @@ cuda_kernel!(
     )
 );
 
-/// Shared tail of the two multi-coset node launchers below: grid/args
-/// construction from already-derived raw pointers. The entry points exist
-/// solely because the borrow checker cannot express both the separate-backing
-/// and same-backing (offset-aliased) cases with one safe signature.
-fn launch_nodes_kernel_multi_coset_raw(
-    src_ptr: *const Digest,
-    dst_ptr: *mut Digest,
-    cosets_in_tile: usize,
-    per_coset_src_stride_digests: usize,
-    per_coset_dst_stride_digests: usize,
-    output_per_coset_count: usize,
-    stream: &CudaStream,
-) -> CudaResult<()> {
-    assert!(cosets_in_tile >= 1);
-    assert!(
-        output_per_coset_count.is_power_of_two(),
-        "output_per_coset_count must be a power of two (got {output_per_coset_count})"
-    );
-    let log_per_coset_count = output_per_coset_count.trailing_zeros();
-    let total_count = checked_u32(
-        output_per_coset_count
-            .checked_mul(cosets_in_tile)
-            .expect("nodes total count overflow"),
-    );
-    let (grid_dim, block_dim) = get_grid_block_dims_for_threads_count(WARP_SIZE * 4, total_count);
-    let config = CudaLaunchConfig::basic(grid_dim, block_dim, stream);
-    let args = NodesMultiCosetArguments::new(
-        src_ptr,
-        dst_ptr,
-        log_per_coset_count,
-        checked_u32(per_coset_src_stride_digests),
-        checked_u32(per_coset_dst_stride_digests),
-        total_count,
-    );
-    NodesMultiCosetFunction::default().launch(&config, &args)
-}
-
-/// Launch the multi-coset nodes kernel reading from `src_backing` (at
-/// `src_offset_in_coset` within each coset's slab of stride
-/// `per_coset_src_stride_digests`) and writing to `dst_backing` (at
-/// `dst_offset_in_coset` within each coset's slab of stride
-/// `per_coset_dst_stride_digests`). When src and dst are the same allocation,
-/// use `launch_nodes_kernel_multi_coset_at_offsets` to avoid the aliased
-/// `&mut` borrow.
-fn launch_nodes_kernel_multi_coset_separate(
-    src_backing: &DeviceSlice<Digest>,
-    dst_backing: &mut DeviceSlice<Digest>,
-    cosets_in_tile: usize,
-    per_coset_src_stride_digests: usize,
-    per_coset_dst_stride_digests: usize,
-    src_offset_in_coset: usize,
-    dst_offset_in_coset: usize,
-    output_per_coset_count: usize,
-    stream: &CudaStream,
-) -> CudaResult<()> {
-    // Per-coset containment: each coset's read/write window must fit inside
-    // its own slab — the aggregate end checks below cannot see a window that
-    // spills into the next coset's slab.
-    let src_window_end = src_offset_in_coset
-        .checked_add(output_per_coset_count * 2)
-        .expect("src window overflow");
-    let dst_window_end = dst_offset_in_coset
-        .checked_add(output_per_coset_count)
-        .expect("dst window overflow");
-    assert!(src_window_end <= per_coset_src_stride_digests);
-    assert!(dst_window_end <= per_coset_dst_stride_digests);
-    let last_src_end = (cosets_in_tile - 1)
-        .checked_mul(per_coset_src_stride_digests)
-        .and_then(|x| x.checked_add(src_window_end))
-        .expect("src extent overflow");
-    let last_dst_end = (cosets_in_tile - 1)
-        .checked_mul(per_coset_dst_stride_digests)
-        .and_then(|x| x.checked_add(dst_window_end))
-        .expect("dst extent overflow");
-    assert!(src_backing.len() >= last_src_end);
-    assert!(dst_backing.len() >= last_dst_end);
-    let src_ptr = unsafe { src_backing.as_ptr().add(src_offset_in_coset) };
-    let dst_ptr = unsafe { dst_backing.as_mut_ptr().add(dst_offset_in_coset) };
-    launch_nodes_kernel_multi_coset_raw(
-        src_ptr,
-        dst_ptr,
-        cosets_in_tile,
-        per_coset_src_stride_digests,
-        per_coset_dst_stride_digests,
-        output_per_coset_count,
-        stream,
-    )
-}
-
 /// Launch the multi-coset nodes kernel against a single backing slab using
 /// per-coset src/dst offsets (in digests, relative to each coset's
 /// `per_coset_stride_digests` slab). Callers express a virtual src/dst view
@@ -209,15 +120,26 @@ fn launch_nodes_kernel_multi_coset_at_offsets(
     let base = backing.as_mut_ptr();
     let src_ptr = unsafe { base.add(src_offset_in_coset) } as *const Digest;
     let dst_ptr = unsafe { base.add(dst_offset_in_coset) };
-    launch_nodes_kernel_multi_coset_raw(
+    assert!(
+        output_per_coset_count.is_power_of_two(),
+        "output_per_coset_count must be a power of two (got {output_per_coset_count})"
+    );
+    let total_count = checked_u32(
+        output_per_coset_count
+            .checked_mul(cosets_in_tile)
+            .expect("nodes total count overflow"),
+    );
+    let (grid_dim, block_dim) = get_grid_block_dims_for_threads_count(WARP_SIZE * 4, total_count);
+    let config = CudaLaunchConfig::basic(grid_dim, block_dim, stream);
+    let args = NodesMultiCosetArguments::new(
         src_ptr,
         dst_ptr,
-        cosets_in_tile,
-        per_coset_stride_digests,
-        per_coset_stride_digests,
-        output_per_coset_count,
-        stream,
-    )
+        output_per_coset_count.trailing_zeros(),
+        checked_u32(per_coset_stride_digests),
+        checked_u32(per_coset_stride_digests),
+        total_count,
+    );
+    NodesMultiCosetFunction::default().launch(&config, &args)
 }
 
 /// Iteratively hash up `layers_count` Merkle layers across `cosets_in_tile`
@@ -255,44 +177,80 @@ fn build_merkle_tree_nodes_multi_coset(
     Ok(())
 }
 
-/// Multi-coset variant of `build_merkle_tree_nodes` for the partial-tree
-/// bottom-hashing case: the first layer's input lives in `src_backing` (a
-/// separate allocation, typically the tree_tops slab); subsequent layers hash
-/// up inside `dst_backing` (the tree_bottoms slab) starting at offset 0.
-pub fn build_merkle_tree_nodes_multi_coset_from_external_src(
-    src_backing: &DeviceSlice<Digest>,
-    dst_backing: &mut DeviceSlice<Digest>,
+cuda_kernel!(
+    PartialTreeMultiCoset,
+    ab_blake2s_partial_tree_multi_coset_kernel(
+        values: *const BF,
+        tree_backing: *mut Digest,
+        log_rows_per_hash: u32,
+        cols_count: u32,
+        log_per_coset_count: u32,
+        per_coset_values_stride_bf: u32,
+        per_coset_tree_stride_digests: u32,
+        count: u32,
+    )
+);
+
+/// `values` is exact `[coset][column][row]` storage without padding. Each tree
+/// slab has `leaves / 16` digests and is filled `[level 5 | level 6 | ...]`.
+pub fn build_partial_merkle_tree_multi_coset(
+    values: &DeviceSlice<BF>,
+    tree_backing: &mut DeviceSlice<Digest>,
+    log_rows_per_hash: u32,
     layers_count: u32,
     cosets_in_tile: usize,
-    per_coset_src_stride_digests: usize,
-    per_coset_dst_stride_digests: usize,
-    src_offset_in_coset: usize,
-    src_layer_count_per_coset: usize,
     stream: &CudaStream,
 ) -> CudaResult<()> {
-    if layers_count == 0 {
-        return Ok(());
-    }
-    assert_eq!(src_layer_count_per_coset % 2, 0);
-    let first_output_per_coset = src_layer_count_per_coset / 2;
-    launch_nodes_kernel_multi_coset_separate(
-        src_backing,
-        dst_backing,
-        cosets_in_tile,
-        per_coset_src_stride_digests,
-        per_coset_dst_stride_digests,
-        src_offset_in_coset,
-        /*dst_offset_in_coset=*/ 0,
-        first_output_per_coset,
+    const THREADS_PER_BLOCK: u32 = 256;
+    const LEAVES_PER_BLOCK: u32 = 512;
+    const REDUCTION_LAYERS: u32 = WARP_SIZE.trailing_zeros();
+
+    assert_ne!(layers_count, 0);
+    assert!(cosets_in_tile >= 1);
+    assert!(log_rows_per_hash < 32);
+    assert_eq!(tree_backing.len() % cosets_in_tile, 0);
+    let per_coset_tree_stride_digests = tree_backing.len() / cosets_in_tile;
+    assert!(per_coset_tree_stride_digests.is_power_of_two());
+    let per_coset_leaves_count = per_coset_tree_stride_digests << (REDUCTION_LAYERS - 1);
+    assert!(layers_count <= per_coset_tree_stride_digests.trailing_zeros());
+    let boundary_roots_per_coset = per_coset_leaves_count >> REDUCTION_LAYERS;
+    assert_eq!(values.len() % cosets_in_tile, 0);
+    let per_coset_values_stride_bf = values.len() / cosets_in_tile;
+    let rows_per_coset = per_coset_leaves_count
+        .checked_mul(1usize << log_rows_per_hash)
+        .expect("partial tree rows count overflow");
+    assert_eq!(per_coset_values_stride_bf % rows_per_coset, 0);
+    let cols_count = per_coset_values_stride_bf / rows_per_coset;
+
+    let total_leaves = checked_u32(
+        per_coset_leaves_count
+            .checked_mul(cosets_in_tile)
+            .expect("partial tree leaves count overflow"),
+    );
+    let mut config = CudaLaunchConfig::basic(
+        total_leaves.div_ceil(LEAVES_PER_BLOCK),
+        THREADS_PER_BLOCK,
         stream,
-    )?;
+    );
+    config.dynamic_smem_bytes = LEAVES_PER_BLOCK as usize * core::mem::size_of::<Digest>();
+    let args = PartialTreeMultiCosetArguments::new(
+        values.as_ptr(),
+        tree_backing.as_mut_ptr(),
+        log_rows_per_hash,
+        checked_u32(cols_count),
+        per_coset_leaves_count.trailing_zeros(),
+        checked_u32(per_coset_values_stride_bf),
+        checked_u32(per_coset_tree_stride_digests),
+        total_leaves,
+    );
+    PartialTreeMultiCosetFunction::default().launch(&config, &args)?;
     build_merkle_tree_nodes_multi_coset(
-        dst_backing,
+        tree_backing,
         layers_count - 1,
         cosets_in_tile,
-        per_coset_dst_stride_digests,
-        /*initial_src_offset_in_coset=*/ 0,
-        /*initial_src_layer_count_per_coset=*/ first_output_per_coset,
+        per_coset_tree_stride_digests,
+        0,
+        boundary_roots_per_coset,
         stream,
     )
 }

--- a/gpu/hash/src/blake2s/tests/merkle_tests.rs
+++ b/gpu/hash/src/blake2s/tests/merkle_tests.rs
@@ -7,6 +7,7 @@ use rand::Rng;
 use super::super::*;
 use gpu_core::primitives::device_structures::{DeviceMatrix, DeviceMatrixMut};
 use gpu_core::primitives::field::BF;
+use gpu_core::primitives::utils::LOG_WARP_SIZE;
 use gpu_ops::simple::set_to_zero;
 
 use super::{leaf_source_row, random_digest, verify_leaves, verify_nodes};
@@ -72,6 +73,79 @@ fn test_merkle_tree(log_n: usize) {
 #[test]
 fn merkle_tree() {
     test_merkle_tree(16);
+}
+
+fn test_partial_merkle_tree_multi_coset(
+    log_leaves_count: usize,
+    log_rows_per_hash: u32,
+    cosets_count: usize,
+    cols_count: usize,
+) {
+    let leaves_count = 1usize << log_leaves_count;
+    let full_tree_stride = leaves_count * 2;
+    let partial_tree_stride = full_tree_stride >> LOG_WARP_SIZE;
+    let values_stride = cols_count * (leaves_count << log_rows_per_hash);
+    let full_layers_count = (log_leaves_count + 1) as u32;
+    let partial_layers_count = full_layers_count - LOG_WARP_SIZE;
+    let initialized_partial_len = partial_tree_stride - 1;
+
+    let mut rng = rand::rng();
+    let mut values_host = vec![BF::ZERO; values_stride * cosets_count];
+    values_host.fill_with(|| BF::from_nonreduced_u32(rng.random()));
+    let mut full_tree_host = vec![Digest::default(); full_tree_stride * cosets_count];
+    let mut partial_tree_host = vec![Digest::default(); partial_tree_stride * cosets_count];
+
+    let stream = CudaStream::default();
+    let mut values_device = DeviceAllocation::alloc(values_host.len()).unwrap();
+    let mut full_tree_device = DeviceAllocation::alloc(full_tree_host.len()).unwrap();
+    let mut partial_tree_device = DeviceAllocation::alloc(partial_tree_host.len()).unwrap();
+    memory_copy_async(&mut values_device, &values_host, &stream).unwrap();
+    set_to_zero(&mut full_tree_device, &stream).unwrap();
+    set_to_zero(&mut partial_tree_device, &stream).unwrap();
+
+    build_merkle_tree_multi_coset(
+        &values_device,
+        &mut full_tree_device,
+        log_rows_per_hash,
+        full_layers_count,
+        cosets_count,
+        leaves_count,
+        values_stride,
+        full_tree_stride,
+        cols_count,
+        &stream,
+    )
+    .unwrap();
+    build_partial_merkle_tree_multi_coset(
+        &values_device,
+        &mut partial_tree_device,
+        log_rows_per_hash,
+        partial_layers_count,
+        cosets_count,
+        &stream,
+    )
+    .unwrap();
+
+    memory_copy_async(&mut full_tree_host, &full_tree_device, &stream).unwrap();
+    memory_copy_async(&mut partial_tree_host, &partial_tree_device, &stream).unwrap();
+    stream.synchronize().unwrap();
+
+    for coset in 0..cosets_count {
+        let full_start = coset * full_tree_stride + full_tree_stride - partial_tree_stride;
+        let partial_start = coset * partial_tree_stride;
+        assert_eq!(
+            &partial_tree_host[partial_start..partial_start + initialized_partial_len],
+            &full_tree_host[full_start..full_start + initialized_partial_len],
+        );
+    }
+}
+
+#[test]
+fn partial_merkle_tree_multi_coset_matches_full_tree() {
+    test_partial_merkle_tree_multi_coset(6, 0, 1, 3);
+    test_partial_merkle_tree_multi_coset(8, 2, 4, 7);
+    test_partial_merkle_tree_multi_coset(9, 1, 3, 0);
+    test_partial_merkle_tree_multi_coset(9, 1, 3, 2);
 }
 
 #[test]

--- a/gpu/trace/src/trace/holder/mod.rs
+++ b/gpu/trace/src/trace/holder/mod.rs
@@ -15,8 +15,8 @@ use gpu_core::primitives::device_structures::{
 use gpu_core::primitives::field::BF;
 use gpu_hash::blake2s::build_merkle_tree;
 use gpu_hash::blake2s::{
-    build_merkle_tree_multi_coset, build_merkle_tree_nodes_multi_coset_from_external_src,
-    gather_tree_caps_inline, Digest,
+    build_merkle_tree_multi_coset, build_partial_merkle_tree_multi_coset, gather_tree_caps_inline,
+    Digest,
 };
 use gpu_hash::blake2s::{
     gather_leaf_rows, gather_merkle_paths_device, gather_merkle_paths_from_rows,
@@ -496,21 +496,12 @@ impl TraceHolder<BF> {
             }
         };
 
-        // Multi-coset commit: every coset's Merkle tree is built layer-by-layer
-        // across all cosets in one launch per layer. For `Partial`/`None` modes we
-        // allocate one transient `tree_tops` slab covering all cosets;
-        // `lde_factor * tree_top_per_coset` is bounded by ~`2^(OMEGA_LOG_ORDER
-        // + 1) * sizeof(Digest)` ≈ 8 GB since `log_n + log_lde_factor <=
-        // OMEGA_LOG_ORDER` constrains the worst case across all schedules.
         let evals_total_len = lde_factor * evals_stride;
         // SAFETY: cosets backing remains alive for `&self`; evals range is
         // disjoint from the trees backing.
         let evals_backing: &DeviceSlice<BF> =
             unsafe { DeviceSlice::from_raw_parts(evals_ptr, evals_total_len) };
 
-        // Holds a transient tree_tops slab for Partial/None modes through the
-        // cap gather. Full mode commits directly into the consolidated trees
-        // backing and leaves this `None`.
         let mut transient_tree_tops: Option<DeviceAllocation<Digest>> = None;
 
         match &mut self.trees {
@@ -528,11 +519,8 @@ impl TraceHolder<BF> {
                 )?;
             }
             TreesHolder::Partial(backing) => {
-                let mut tree_tops =
-                    allocate_trees(lde_factor, log_domain_size, log_rows_per_leaf, context)?;
                 commit_trace_with_partial_tree_multi_coset(
                     evals_backing,
-                    &mut tree_tops,
                     backing,
                     log_domain_size,
                     log_lde_factor,
@@ -542,9 +530,6 @@ impl TraceHolder<BF> {
                     lde_factor,
                     stream,
                 )?;
-                // tree_tops is dropped after the cap gather completes; the
-                // bottom (in `backing`) is what queries read.
-                let _ = tree_tops;
             }
             TreesHolder::None => {
                 let mut tree_tops =
@@ -595,9 +580,6 @@ impl TraceHolder<BF> {
                 )?;
             }
             TreesHolder::None => {
-                // None mode now also uses one consolidated tree_tops slab
-                // (same layout as Full/Partial backing), so gather_tree_caps
-                // works directly across it.
                 let backing = transient_tree_tops
                     .as_ref()
                     .expect("None mode allocates transient_tree_tops above");
@@ -683,15 +665,12 @@ impl TraceHolder<BF> {
         let evals_total_len = instances_count * evals_stride;
         let evals_backing: &DeviceSlice<BF> =
             unsafe { DeviceSlice::from_raw_parts(evals_ptr, evals_total_len) };
-        let mut tree_tops =
-            allocate_trees(instances_count, log_domain_size, log_rows_per_leaf, context)?;
         let trees_backing = match &mut self.trees {
             TreesHolder::Partial(backing) => backing,
             _ => panic!("build_and_cache_partial_trees requires TreesHolder::Partial"),
         };
         commit_trace_with_partial_tree_multi_coset(
             evals_backing,
-            &mut tree_tops,
             trees_backing,
             log_domain_size,
             log_lde_factor,
@@ -701,8 +680,6 @@ impl TraceHolder<BF> {
             instances_count,
             stream,
         )?;
-        // tree_tops drops here — frees the transient full-tree allocation.
-        drop(tree_tops);
         Ok(())
     }
 
@@ -1041,16 +1018,9 @@ pub(crate) fn commit_trace_multi_coset(
     )
 }
 
-/// Takes one big
-/// `tree_tops_backing` slab sized for all cosets' tops, plus the existing
-/// shared `tree_bottoms_backing`. Builds top layers (leaves +
-/// PARTIAL_TREE_REDUCTION_LAYERS-1 layers of nodes) into every coset's top
-/// slab in one launch per layer, then runs the bottom layers across all
-/// cosets in one launch per layer.
 pub(crate) fn commit_trace_with_partial_tree_multi_coset(
     evals_backing: &DeviceSlice<BF>,
-    tree_tops_backing: &mut DeviceSlice<Digest>,
-    tree_bottoms_backing: &mut DeviceSlice<Digest>,
+    tree_backing: &mut DeviceSlice<Digest>,
     log_domain_size: u32,
     log_lde_factor: u32,
     log_rows_per_leaf: u32,
@@ -1066,55 +1036,20 @@ pub(crate) fn commit_trace_with_partial_tree_multi_coset(
             > log_rows_per_leaf + PARTIAL_TREE_REDUCTION_LAYERS + log_coset_tree_cap_size
     );
     let per_coset_evals_stride = columns_count << log_domain_size;
-    let per_coset_top_stride = 1usize << (log_domain_size + 1 - log_rows_per_leaf);
-    let per_coset_top_leaves_count = per_coset_top_stride >> 1;
-    let per_coset_bottom_stride = per_coset_top_stride >> PARTIAL_TREE_REDUCTION_LAYERS;
+    let per_coset_leaves_count = 1usize << (log_domain_size - log_rows_per_leaf);
+    let per_coset_tree_stride = (per_coset_leaves_count << 1) >> PARTIAL_TREE_REDUCTION_LAYERS;
     assert_eq!(evals_backing.len(), per_coset_evals_stride * cosets_in_tile);
-    assert_eq!(
-        tree_tops_backing.len(),
-        per_coset_top_stride * cosets_in_tile
-    );
-    assert_eq!(
-        tree_bottoms_backing.len(),
-        per_coset_bottom_stride * cosets_in_tile
-    );
-    // Top: leaves + (PARTIAL_TREE_REDUCTION_LAYERS - 1) node layers, all
-    // built inside each coset's tree_top slab.
-    build_merkle_tree_multi_coset(
-        evals_backing,
-        tree_tops_backing,
-        log_rows_per_leaf,
-        PARTIAL_TREE_REDUCTION_LAYERS,
-        cosets_in_tile,
-        per_coset_top_leaves_count,
-        per_coset_evals_stride,
-        per_coset_top_stride,
-        columns_count,
-        stream,
-    )?;
-    // Bottom: each coset's "top layer" within tree_tops has
-    // `per_coset_bottom_stride` digests sitting at offset
-    // `per_coset_top_stride - 2 * per_coset_bottom_stride` (mirroring
-    // `tree_top[tree_top_len - 2 * tree_bottom_len..][..tree_bottom_len]` in
-    // the single-coset path). The first bottom layer hashes pairs of those
-    // top-layer digests into tree_bottoms_backing[0..bottom_stride/2] across
-    // every coset; subsequent layers hash up in-place inside the bottoms
-    // slab. tree_bottoms is sized for OUTPUTS only, not for re-storing the
-    // input, so we never copy the top layer into the bottoms slab.
-    let top_layer_src_offset = per_coset_top_stride - 2 * per_coset_bottom_stride;
-    let bottom_layers_count = log_domain_size + 1
+    assert_eq!(tree_backing.len(), per_coset_tree_stride * cosets_in_tile);
+    let layers_count = log_domain_size + 1
         - log_rows_per_leaf
         - PARTIAL_TREE_REDUCTION_LAYERS
         - log_coset_tree_cap_size;
-    build_merkle_tree_nodes_multi_coset_from_external_src(
-        tree_tops_backing,
-        tree_bottoms_backing,
-        bottom_layers_count,
+    build_partial_merkle_tree_multi_coset(
+        evals_backing,
+        tree_backing,
+        log_rows_per_leaf,
+        layers_count,
         cosets_in_tile,
-        per_coset_top_stride,
-        per_coset_bottom_stride,
-        top_layer_src_offset,
-        per_coset_bottom_stride,
         stream,
     )
 }

--- a/gpu/trace/src/trace/holder/tests.rs
+++ b/gpu/trace/src/trace/holder/tests.rs
@@ -772,6 +772,33 @@ fn trace_holder_queries_match_across_tree_cache_modes() {
         .materialize_and_commit_from_hypercube_evals(&source_device, &context)
         .unwrap();
 
+    let cosets_count = 1usize << log_lde_factor;
+    let leaves_per_coset = domain_size >> log_rows_per_leaf;
+    let full_tree_stride = leaves_per_coset * 2;
+    let partial_tree_stride = full_tree_stride >> PARTIAL_TREE_REDUCTION_LAYERS;
+    let cap_per_coset = (1usize << log_tree_cap_size) / cosets_count;
+    let initialized_partial_len = partial_tree_stride - cap_per_coset;
+    let full_tree = full_holder.get_consolidated_tree().unwrap();
+    let partial_tree = partial_holder.get_consolidated_tree().unwrap();
+    let mut full_tree_host = vec![Digest::default(); full_tree.len()];
+    let mut partial_tree_host = vec![Digest::default(); partial_tree.len()];
+    memory_copy_async(&mut full_tree_host, full_tree, context.get_exec_stream()).unwrap();
+    memory_copy_async(
+        &mut partial_tree_host,
+        partial_tree,
+        context.get_exec_stream(),
+    )
+    .unwrap();
+    context.get_exec_stream().synchronize().unwrap();
+    for coset in 0..cosets_count {
+        let full_start = coset * full_tree_stride + full_tree_stride - partial_tree_stride;
+        let partial_start = coset * partial_tree_stride;
+        assert_eq!(
+            &partial_tree_host[partial_start..partial_start + initialized_partial_len],
+            &full_tree_host[full_start..full_start + initialized_partial_len],
+        );
+    }
+
     let query_indexes = vec![0u32, 1, 7, 13, 42];
     let mut indexes_device = context
         .alloc(query_indexes.len(), AllocationPlacement::BestFit)


### PR DESCRIPTION
## What ❔

Avoid materializing discarded Merkle-tree layers for generic `TraceHolder` partial commitments. A fused GPU kernel hashes leaves, reduces five levels in shared memory, and writes the persistent boundary roots directly.

The affected Blake2s work is 35.3% faster with 10 fewer launches; add/sub full-proof GPU time improves by 1.48%.

## Why ❔

Partial commitments only retain the upper tree, so building a transient full tree wastes GPU work and memory traffic.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
