### PR TITLE
fix(execution_prover): bind real i&t address windows in unified mode

### DIFF
--- a/gpu/circuit_prover/src/proof/inputs.rs
+++ b/gpu/circuit_prover/src/proof/inputs.rs
@@ -1,6 +1,6 @@
 // Consolidated H2D bundle for prove() and commit_memory_from_transfers():
 // one shared Transfer for every pre-prove H2D piece (setup, decoder,
-// inits_and_teardowns, tracing_data, memory caps, canonical_top_bits,
+// inits_and_teardowns, tracing_data, memory caps, top_bits,
 // external_challenges), so prove() does a single ensure_transferred.
 
 use std::marker::PhantomData;
@@ -28,31 +28,31 @@ pub(crate) const EXTERNAL_CHALLENGES_E4_LEN: usize =
     NUM_PERMUTATION_ARGUMENT_LINEARIZATION_CHALLENGES + 1;
 
 // ---------------------------------------------------------------------------
-// CanonicalTopBitsTransfer
+// TopBitsTransfer
 // ---------------------------------------------------------------------------
 
-/// H2D wrapper for the canonical inits-and-teardowns top-bits transcript
+/// H2D wrapper for the inits-and-teardowns top-bits transcript
 /// prefix. The host source is `SchedulerHostAllocator`-backed and filled
 /// once on the scheduling thread at construction; the bundle's shared
 /// `Transfer` H2Ds it to device on `h2d_stream`.
 ///
 /// Only constructed when the compiled circuit has at least one teardown set
-/// (i.e. `canonical_top_bits.len() > 0`).
-pub(crate) struct CanonicalTopBitsTransfer<'a> {
+/// (i.e. `top_bits.len() > 0`).
+pub(crate) struct TopBitsTransfer<'a> {
     pub(crate) host: Arc<StaticPinnedBox<u32>>,
     pub(crate) device: DeviceAllocation<u32>,
     _marker: PhantomData<&'a ()>,
 }
 
-impl<'a> CanonicalTopBitsTransfer<'a> {
-    pub(crate) fn new(canonical_top_bits: &[u32], context: &ProverContext) -> CudaResult<Self> {
+impl<'a> TopBitsTransfer<'a> {
+    pub(crate) fn new(top_bits: &[u32], context: &ProverContext) -> CudaResult<Self> {
         assert!(
-            !canonical_top_bits.is_empty(),
-            "CanonicalTopBitsTransfer requires at least one top-bit entry",
+            !top_bits.is_empty(),
+            "TopBitsTransfer requires at least one top-bit entry",
         );
-        let len = canonical_top_bits.len();
+        let len = top_bits.len();
         let mut host = alloc_static_pinned_box_uninit::<u32>(len)?;
-        host.copy_from_slice(canonical_top_bits);
+        host.copy_from_slice(top_bits);
         let device = context.alloc::<u32>(len, AllocationPlacement::BestFit)?;
         Ok(Self {
             host: Arc::new(host),
@@ -133,14 +133,12 @@ pub struct GpuGKRProofTransfer<'a, A: GoodAllocator> {
     pub(crate) inits_and_teardowns: Option<InitsAndTeardownsTransfer<'a>>,
     pub(crate) tracing_data: Option<TracingDataTransfer<'a, A>>,
     pub(crate) memory: GpuGKRMemoryTransfer<'a>,
-    pub(crate) canonical_top_bits: Option<CanonicalTopBitsTransfer<'a>>,
+    pub(crate) top_bits: Option<TopBitsTransfer<'a>>,
     /// Host copy of the SAME per-circuit inits-and-teardowns top bits staged
-    /// in `canonical_top_bits` (empty when the circuit has no teardown sets).
-    /// For unified circuits these are the ACTUAL top bits: canonical
-    /// (`0..teardown_sets.len()`) for circuits carrying real i&t data, all
-    /// zeros for TRIVIAL (dummy) chunks — mirroring the CPU reference
-    /// (`prover_examples::unified`). Consumed at scheduling time by the
-    /// forward plan, backward blueprints, and terminal proof assembly.
+    /// in `top_bits` (empty when the circuit has no teardown sets): the global
+    /// address window each set holds, or all zeros for TRIVIAL (dummy) unified
+    /// chunks. Consumed at scheduling time by the forward plan, backward
+    /// blueprints, and terminal proof assembly.
     pub(crate) top_bits_host: Vec<u32>,
     pub(crate) external_challenges: ExternalChallengesTransfer<'a>,
 }
@@ -154,7 +152,7 @@ pub(crate) struct GpuGKRProofTransferKeepalive<'a, A: GoodAllocator> {
     _inits_and_teardowns: Option<InitsAndTeardownsTransfer<'a>>,
     _tracing_data: Option<TracingDataTransfer<'a, A>>,
     _memory: GpuGKRMemoryTransfer<'a>,
-    _canonical_top_bits: Option<CanonicalTopBitsTransfer<'a>>,
+    _top_bits: Option<TopBitsTransfer<'a>>,
     _external_challenges: ExternalChallengesTransfer<'a>,
     _callbacks: Callbacks<'a>,
 }
@@ -166,17 +164,14 @@ impl<'a, A: GoodAllocator + 'a> GpuGKRProofTransfer<'a, A> {
         inits_and_teardowns: Option<InitsAndTeardownsTransfer<'a>>,
         tracing_data: Option<TracingDataTransfer<'a, A>>,
         memory: GpuGKRMemoryTransfer<'a>,
-        canonical_top_bits_source: &[u32],
+        top_bits_source: &[u32],
         external_challenges_value: GKRExternalChallenges<BF, E4>,
         context: &ProverContext,
     ) -> CudaResult<Self> {
-        let canonical_top_bits = if canonical_top_bits_source.is_empty() {
+        let top_bits = if top_bits_source.is_empty() {
             None
         } else {
-            Some(CanonicalTopBitsTransfer::new(
-                canonical_top_bits_source,
-                context,
-            )?)
+            Some(TopBitsTransfer::new(top_bits_source, context)?)
         };
         let external_challenges =
             ExternalChallengesTransfer::new(external_challenges_value, context)?;
@@ -193,8 +188,8 @@ impl<'a, A: GoodAllocator + 'a> GpuGKRProofTransfer<'a, A> {
             inits_and_teardowns,
             tracing_data,
             memory,
-            canonical_top_bits,
-            top_bits_host: canonical_top_bits_source.to_vec(),
+            top_bits,
+            top_bits_host: top_bits_source.to_vec(),
             external_challenges,
         })
     }
@@ -215,8 +210,8 @@ impl<'a, A: GoodAllocator + 'a> GpuGKRProofTransfer<'a, A> {
             td.schedule_transfer(&mut self.transfer, context)?;
         }
         self.memory.schedule_transfer(&mut self.transfer, context)?;
-        if let Some(ctb) = self.canonical_top_bits.as_mut() {
-            ctb.schedule_transfer(&mut self.transfer, context)?;
+        if let Some(top_bits) = self.top_bits.as_mut() {
+            top_bits.schedule_transfer(&mut self.transfer, context)?;
         }
         self.external_challenges
             .schedule_transfer(&mut self.transfer, context)?;
@@ -231,7 +226,7 @@ impl<'a, A: GoodAllocator + 'a> GpuGKRProofTransfer<'a, A> {
             inits_and_teardowns,
             tracing_data,
             memory,
-            canonical_top_bits,
+            top_bits,
             top_bits_host: _,
             external_challenges,
         } = self;
@@ -241,7 +236,7 @@ impl<'a, A: GoodAllocator + 'a> GpuGKRProofTransfer<'a, A> {
             _inits_and_teardowns: inits_and_teardowns,
             _tracing_data: tracing_data,
             _memory: memory,
-            _canonical_top_bits: canonical_top_bits,
+            _top_bits: top_bits,
             _external_challenges: external_challenges,
             _callbacks: transfer.into_callbacks(),
         }

--- a/gpu/circuit_prover/src/proof/mod.rs
+++ b/gpu/circuit_prover/src/proof/mod.rs
@@ -19,7 +19,7 @@ use gpu_gkr::forward::{schedule_forward_pass, ForwardOutputSlabTarget};
 use gpu_gkr::GkrPrograms;
 use gpu_prover_context::ProverContext;
 
-pub use orchestration::{canonical_inits_and_teardowns_top_bits, GpuGKRProofJob};
+pub use orchestration::GpuGKRProofJob;
 use orchestration::{
     prepare_backward_handoff, prepare_stage1_and_forward_setup, schedule_backward_phase,
     schedule_terminal_proof_assembly, schedule_whir_phase, stage1_forward::BundleDeviceRefs,
@@ -84,7 +84,7 @@ fn prove_inner<'a, A: GoodAllocator + 'a>(
         inits_and_teardowns,
         tracing_data,
         memory,
-        canonical_top_bits,
+        top_bits,
         top_bits_host,
         external_challenges,
     } = inputs;
@@ -106,7 +106,7 @@ fn prove_inner<'a, A: GoodAllocator + 'a>(
 
     // Single fork/join from h2d_stream → exec_stream covering every pre-prove
     // H2D bundled by `inputs` (setup, decoder, inits_and_teardowns, tracing_data,
-    // memory caps, canonical_top_bits, external_challenges).
+    // memory caps, top_bits, external_challenges).
     transfer.ensure_transferred(context)?;
 
     let stream = context.get_exec_stream();
@@ -136,7 +136,7 @@ fn prove_inner<'a, A: GoodAllocator + 'a>(
             decoder: decoder.as_ref(),
             inits_and_teardowns: inits_and_teardowns.as_ref(),
             memory: &memory,
-            canonical_top_bits_device: canonical_top_bits.as_ref().map(|t| &t.device),
+            top_bits_device: top_bits.as_ref().map(|t| &t.device),
             external_challenges_device: &external_challenges.device,
         },
         tracing_data.as_ref(),
@@ -305,7 +305,7 @@ fn prove_inner<'a, A: GoodAllocator + 'a>(
         inits_and_teardowns,
         tracing_data,
         memory,
-        canonical_top_bits,
+        top_bits,
         top_bits_host,
         external_challenges,
     }

--- a/gpu/circuit_prover/src/proof/orchestration/backward.rs
+++ b/gpu/circuit_prover/src/proof/orchestration/backward.rs
@@ -147,8 +147,8 @@ pub(in crate::proof) fn prepare_backward_handoff(
 
 pub(in crate::proof) fn schedule_backward_phase(
     backward_state: GpuGKRDimensionReducingBackwardState,
-    // ACTUAL per-circuit i&t top bits: canonical for real i&t data, all
-    // zeros for trivial (dummy) unified chunks (CPU-reference parity).
+    // The global address window each of this circuit's i&t sets holds; all
+    // zeros for trivial (dummy) unified chunks.
     inits_and_teardowns_top_bits: Vec<u32>,
     gkr_programs: std::sync::Arc<gpu_gkr::GkrPrograms>,
     d_external_challenges_ptr: *const E4,

--- a/gpu/circuit_prover/src/proof/orchestration/mod.rs
+++ b/gpu/circuit_prover/src/proof/orchestration/mod.rs
@@ -6,8 +6,7 @@ use fft::GoodAllocator;
 
 use crate::proof::inputs::GpuGKRProofTransferKeepalive;
 use crate::upstream::{
-    DefaultTreeConstructor, DimensionReducingInputOutput, Field, GKRCircuitArtifact, GKRProof,
-    OutputType,
+    DefaultTreeConstructor, DimensionReducingInputOutput, Field, GKRProof, OutputType,
 };
 use gpu_core::primitives::callbacks::Callbacks;
 use gpu_core::primitives::context::HostAllocation;
@@ -39,7 +38,7 @@ pub(super) use whir::{schedule_whir_phase, WhirPhaseResult};
 pub(super) struct GpuGKRProofJobKeepalive<'a, A: GoodAllocator> {
     pub(super) _stage1: GpuGKRStage1Keepalive,
     /// Holds every per-piece transfer wrapper (setup, decoder, inits_and_teardowns,
-    /// tracing_data, memory caps, canonical_top_bits, external_challenges) plus the
+    /// tracing_data, memory caps, top_bits, external_challenges) plus the
     /// shared `Transfer`'s accumulated `Callbacks`.
     pub(super) _inputs: GpuGKRProofTransferKeepalive<'a, A>,
     pub(super) _forward_setup: GpuGKRForwardSetupHostKeepalive,
@@ -190,10 +189,4 @@ pub(crate) fn grand_product_accumulator_from_explicit_evaluations(
     }
 
     grand_product_accumulator_computed
-}
-
-pub fn canonical_inits_and_teardowns_top_bits(
-    compiled_circuit: &GKRCircuitArtifact<BF>,
-) -> Vec<u32> {
-    (0..compiled_circuit.memory_layout.teardown_sets.len() as u32).collect()
 }

--- a/gpu/circuit_prover/src/proof/orchestration/stage1_forward.rs
+++ b/gpu/circuit_prover/src/proof/orchestration/stage1_forward.rs
@@ -39,7 +39,7 @@ pub(in crate::proof) struct BundleDeviceRefs<'b, 'a> {
     pub decoder: Option<&'b DecoderTableTransfer<'a>>,
     pub inits_and_teardowns: Option<&'b InitsAndTeardownsTransfer<'a>>,
     pub memory: &'b GpuGKRMemoryTransfer<'a>,
-    pub canonical_top_bits_device: Option<&'b DeviceAllocation<u32>>,
+    pub top_bits_device: Option<&'b DeviceAllocation<u32>>,
     pub external_challenges_device: &'b DeviceAllocation<E4>,
 }
 
@@ -87,10 +87,7 @@ pub(in crate::proof) fn prepare_stage1_and_forward_setup<'a, A: GoodAllocator + 
             log_tree_cap_size: prover_config.cap_size.trailing_zeros(),
         });
 
-    let canonical_top_bits_len = bundle
-        .canonical_top_bits_device
-        .map(|d| d.len())
-        .unwrap_or(0);
+    let top_bits_len = bundle.top_bits_device.map(|d| d.len()).unwrap_or(0);
     let external_challenges_u32_len = EXTERNAL_CHALLENGES_E4_LEN * 4;
     debug_assert_eq!(
         bundle.memory.host.log_lde_factor, setup_geometry.log_lde_factor,
@@ -204,8 +201,8 @@ pub(in crate::proof) fn prepare_stage1_and_forward_setup<'a, A: GoodAllocator + 
     );
 
     let mut chunks: Vec<(*const u32, u32)> = Vec::with_capacity(5);
-    if let Some(d_canonical_top_bits) = bundle.canonical_top_bits_device {
-        chunks.push((d_canonical_top_bits.as_ptr(), canonical_top_bits_len as u32));
+    if let Some(d_top_bits) = bundle.top_bits_device {
+        chunks.push((d_top_bits.as_ptr(), top_bits_len as u32));
     }
     {
         let external_u32 = unsafe { bundle.external_challenges_device.transmute::<u32>() };

--- a/gpu/circuit_prover/src/proof/tests.rs
+++ b/gpu/circuit_prover/src/proof/tests.rs
@@ -37,14 +37,14 @@ fn draw_query_bits_after_verified_pow(seed: &mut Seed, num_bits_for_queries: usi
 }
 
 fn build_initial_transcript_input(
-    canonical_top_bits: &[u32],
+    top_bits: &[u32],
     external_challenges: &GKRExternalChallenges<BF, E4>,
     flattened_setup_tree_caps: &[u32],
     flattened_memory_tree_caps: &[u32],
     flattened_witness_tree_caps: &[u32],
 ) -> Vec<u32> {
     let mut transcript_input = Vec::new();
-    transcript_input.extend_from_slice(canonical_top_bits);
+    transcript_input.extend_from_slice(top_bits);
     external_challenges.flatten_into_buffer(&mut transcript_input);
     if !flattened_setup_tree_caps.is_empty() {
         transcript_input.extend_from_slice(flattened_setup_tree_caps);
@@ -136,34 +136,34 @@ fn initial_transcript_input_matches_cpu_order_with_and_without_setup_caps() {
         ]),
         _marker: std::marker::PhantomData,
     };
-    let canonical_top_bits = vec![0u32, 1, 2, 3];
+    let top_bits = vec![0u32, 1, 2, 3];
     let setup_caps = vec![11u32, 12, 13, 14];
     let memory_caps = vec![21u32, 22, 23, 24];
     let witness_caps = vec![31u32, 32, 33, 34];
 
     let with_setup = build_initial_transcript_input(
-        &canonical_top_bits,
+        &top_bits,
         &external_challenges,
         &setup_caps,
         &memory_caps,
         &witness_caps,
     );
     let without_setup = build_initial_transcript_input(
-        &canonical_top_bits,
+        &top_bits,
         &external_challenges,
         &[],
         &memory_caps,
         &witness_caps,
     );
 
-    let mut expected_with_setup = canonical_top_bits.clone();
+    let mut expected_with_setup = top_bits.clone();
     external_challenges.flatten_into_buffer(&mut expected_with_setup);
     expected_with_setup.extend_from_slice(&setup_caps);
     expected_with_setup.extend_from_slice(&memory_caps);
     expected_with_setup.extend_from_slice(&witness_caps);
     assert_eq!(with_setup, expected_with_setup);
 
-    let mut expected_without_setup = canonical_top_bits.clone();
+    let mut expected_without_setup = top_bits.clone();
     external_challenges.flatten_into_buffer(&mut expected_without_setup);
     expected_without_setup.extend_from_slice(&memory_caps);
     expected_without_setup.extend_from_slice(&witness_caps);
@@ -171,7 +171,7 @@ fn initial_transcript_input_matches_cpu_order_with_and_without_setup_caps() {
 
     let with_setup_seed =
         <Blake2sTranscript as Transcript<BF, E4>>::commit_initial_u32(&with_setup);
-    let mut expected_with_setup_seed = canonical_top_bits.clone();
+    let mut expected_with_setup_seed = top_bits.clone();
     external_challenges.flatten_into_buffer(&mut expected_with_setup_seed);
     expected_with_setup_seed.extend_from_slice(&setup_caps);
     expected_with_setup_seed.extend_from_slice(&memory_caps);
@@ -183,7 +183,7 @@ fn initial_transcript_input_matches_cpu_order_with_and_without_setup_caps() {
 
     let without_setup_seed =
         <Blake2sTranscript as Transcript<BF, E4>>::commit_initial_u32(&without_setup);
-    let mut expected_without_setup_seed = canonical_top_bits;
+    let mut expected_without_setup_seed = top_bits;
     external_challenges.flatten_into_buffer(&mut expected_without_setup_seed);
     expected_without_setup_seed.extend_from_slice(&memory_caps);
     expected_without_setup_seed.extend_from_slice(&witness_caps);

--- a/gpu/circuit_prover/src/tests/inits_and_teardowns.rs
+++ b/gpu/circuit_prover/src/tests/inits_and_teardowns.rs
@@ -96,8 +96,10 @@ pub(super) fn build_inits_and_teardowns_trace_host_for_test(
     page_indices: &[u32],
     values_packed: &[u32],
     timestamps_packed: &[common_constants::TimestampScalar],
+    top_bits: &[u32],
 ) -> InitsAndTeardownsTraceHost {
     InitsAndTeardownsTraceHost {
+        top_bits: top_bits.to_vec(),
         page_indices: ChunkedTraceHolder {
             chunks: vec![Arc::new(alloc_pinned_vec_from_slice_for_test(page_indices))],
         },
@@ -245,7 +247,7 @@ pub(super) fn prepare_inits_and_teardowns_proof_fixture(
         permutation_argument_additive_part,
         _marker: std::marker::PhantomData,
     };
-    let canonical_top_bits: Vec<u32> = (0..num_sets as u32).collect();
+    let top_bits: Vec<u32> = (0..num_sets as u32).collect();
 
     let prover_config = crate::config::prover_config(
         CircuitType::Unrolled(UnrolledCircuitType::InitsAndTeardowns),
@@ -294,7 +296,7 @@ pub(super) fn prepare_inits_and_teardowns_proof_fixture(
             &twiddles,
             &prover_config,
             CommitmentMode::SeparateMemoryAndWitness,
-            canonical_top_bits.clone(),
+            top_bits.clone(),
             trace_len,
             &worker,
         ))
@@ -349,6 +351,7 @@ pub(super) fn prepare_inits_and_teardowns_proof_fixture(
         &page_indices,
         &values_packed,
         &timestamps_packed,
+        &top_bits,
     );
     // Standalone i/t proves no per-cycle witness: empty non-memory tracing host,
     // and no decoder lookup (the default guard keeps the pinned alloc non-empty).

--- a/gpu/circuit_prover/src/tests/mod.rs
+++ b/gpu/circuit_prover/src/tests/mod.rs
@@ -290,11 +290,11 @@ impl BasicUnrolledFixture {
             .map(|host| InitsAndTeardownsTransfer::new(host, context))
             .transpose()?;
 
-        let canonical_top_bits = self
+        let top_bits = self
             .inits_and_teardowns_top_bits
             .clone()
             .unwrap_or_else(|| {
-                crate::proof::canonical_inits_and_teardowns_top_bits(&self.compiled_circuit)
+                (0..self.compiled_circuit.memory_layout.teardown_sets.len() as u32).collect()
             });
         BasicUnrolledTransfers::new(
             setup_transfer,
@@ -302,7 +302,7 @@ impl BasicUnrolledFixture {
             inits_and_teardowns_transfer,
             tracing_data_transfer,
             memory_transfer,
-            &canonical_top_bits,
+            &top_bits,
             self.external_challenges,
             context,
         )

--- a/gpu/circuit_prover/src/tests/unified_fixtures_helpers.rs
+++ b/gpu/circuit_prover/src/tests/unified_fixtures_helpers.rs
@@ -982,6 +982,7 @@ fn prepare_unified_fixture(
         &page_indices,
         &values_packed,
         &timestamps_packed,
+        &selected_set_top_bits,
     );
 
     let (expected_cpu_proof, delegation_grand_product_factors) = if compute_cpu_reference {

--- a/gpu/execution_prover/src/prover/pipeline.rs
+++ b/gpu/execution_prover/src/prover/pipeline.rs
@@ -412,6 +412,7 @@ fn assemble_result(
 ) -> ExecutionProverResult {
     let ResultAccumulator {
         trivial_unified_inits_and_teardowns_count,
+        unified_inits_and_teardowns_top_bits,
         simulation_result,
         circuit_families_memory_caps,
         inits_and_teardowns_memory_caps,
@@ -485,6 +486,7 @@ fn assemble_result(
             inits_and_teardowns_memory_caps,
             delegation_circuits_memory_caps,
             num_trivial_unified_circuits: trivial_unified_inits_and_teardowns_count,
+            unified_inits_and_teardowns_top_bits,
             binary_handle: BinaryHandle(binary_key),
         };
         ExecutionProverResult::CommitMemory(result)

--- a/gpu/execution_prover/src/prover/pipeline/results.rs
+++ b/gpu/execution_prover/src/prover/pipeline/results.rs
@@ -150,6 +150,9 @@ pub(super) struct ResultAccumulator {
         BTreeMap<usize, BTreeSet<(CircuitType, usize)>>,
     pub(super) unpaired_unified_inits_and_teardowns: BTreeMap<usize, InitsAndTeardownsData>,
     pub(super) unpaired_unified_tracing_data: BTreeMap<usize, TracingData<A>>,
+    /// Unified mode: the i&t address windows each real i&t-carrying instance was
+    /// assigned. Trivial (leading) instances are absent.
+    pub(super) unified_inits_and_teardowns_top_bits: BTreeMap<usize, Vec<u32>>,
     pub(super) simulation_result: Option<SimulationResult>,
     pub(super) circuit_families_memory_caps:
         BTreeMap<u8, BTreeMap<usize, Vec<MerkleTreeCapVarLength>>>,
@@ -191,6 +194,10 @@ impl ResultAccumulator {
                     let sequence_id = data.sequence_id;
                     if sequence_id < self.trivial_unified_inits_and_teardowns_count {
                         assert!(data.inits_and_teardowns.is_none());
+                    }
+                    if let Some(host) = data.inits_and_teardowns.as_ref() {
+                        self.unified_inits_and_teardowns_top_bits
+                            .insert(sequence_id, host.top_bits.clone());
                     }
                     if !request_context.proving
                         || cache.is_none()

--- a/gpu/execution_prover/src/prover/proof_artifacts.rs
+++ b/gpu/execution_prover/src/prover/proof_artifacts.rs
@@ -1,5 +1,4 @@
 use super::*;
-use gpu_circuit_prover::proof::canonical_inits_and_teardowns_top_bits;
 
 /// `(pow_challenge, external_challenges, proof_caps)`, as derived from a
 /// completed memory commitment and consumed by `prove_inner`.
@@ -23,6 +22,7 @@ impl ExecutionProver {
             inits_and_teardowns_memory_caps,
             delegation_circuits_memory_caps,
             num_trivial_unified_circuits,
+            unified_inits_and_teardowns_top_bits,
             binary_handle: _,
         } = memory_commitment;
         let execution_kind = self.binary_holders[&binary_key].execution_kind;
@@ -61,21 +61,20 @@ impl ExecutionProver {
                     .get(&unified_family_idx)
                     .map(|v| v.as_slice())
                     .unwrap_or(&[]);
-                // The GPU prove path derives i&t top bits canonically from the
-                // compiled circuit (`canonical_inits_and_teardowns_top_bits`);
-                // the FS seed must be built from the same top bits to stay
-                // self-consistent.
+                // The seed must absorb the same per-instance windows the proofs
+                // bind.
                 let compiled_circuit = self.binary_holders[&binary_key].precomputations
                     [&UnrolledCircuitType::Unified]
                     .gkr_programs
                     .compiled_circuit()
                     .as_ref();
-                let canonical_top_bits = canonical_inits_and_teardowns_top_bits(compiled_circuit);
+                let num_teardown_sets = compiled_circuit.memory_layout.teardown_sets.len();
                 fs_transform_unified(
                     final_register_values,
                     *final_pc,
                     *final_timestamp,
-                    &canonical_top_bits,
+                    num_teardown_sets,
+                    unified_inits_and_teardowns_top_bits,
                     *num_trivial_unified_circuits,
                     unified_memory_caps,
                     &delegation_circuits_memory_caps
@@ -290,12 +289,10 @@ fn fs_transform_unified(
     final_register_values: &[FinalRegisterValue; 32],
     final_pc: u32,
     final_timestamp: TimestampScalar,
-    canonical_top_bits: &[u32],
+    num_teardown_sets: usize,
+    top_bits_by_sequence_id: &BTreeMap<usize, Vec<u32>>,
     // Number of LEADING unified circuits (by sequence id) with trivial
-    // (dummy) inits-and-teardowns. Those must contribute all-zero top bits to
-    // the FS seed — the CPU reference uses `vec![0u32; num_teardown_sets]`
-    // for dummies — while the trailing real circuits use the canonical top
-    // bits (== the real ones in the supported regime).
+    // (dummy) inits-and-teardowns, which contribute all-zero top bits.
     num_trivial_unified_circuits: usize,
     unified_memory_caps: &[Vec<MerkleTreeCapVarLength>],
     delegation_circuits_memory_caps: &[(u32, Vec<Vec<MerkleTreeCapVarLength>>)],
@@ -311,9 +308,9 @@ fn fs_transform_unified(
                     .collect_vec(),
             };
             let top_bits = if sequence_id < num_trivial_unified_circuits {
-                vec![0u32; canonical_top_bits.len()]
+                vec![0u32; num_teardown_sets]
             } else {
-                canonical_top_bits.to_vec()
+                top_bits_by_sequence_id[&sequence_id].clone()
             };
             (top_bits, cap)
         })

--- a/gpu/execution_prover/src/prover/result.rs
+++ b/gpu/execution_prover/src/prover/result.rs
@@ -21,6 +21,9 @@ pub struct CommitMemoryResult {
     /// derivation, which must use all-zero top bits for the trivial circuits
     /// (CPU reference: `prover_examples::unified`).
     pub num_trivial_unified_circuits: usize,
+    /// Unified mode only: the i&t address windows each real i&t-carrying
+    /// instance was assigned. Trivial (leading) instances are absent.
+    pub unified_inits_and_teardowns_top_bits: BTreeMap<usize, Vec<u32>>,
     /// Set by [`ExecutionProver::commit_memory`] from the binary handle passed
     /// in. Read back in `prove`/`commit_memory_and_prove` to recover the binary
     /// associated with this commitment. Defaults to a placeholder for the inner

--- a/gpu/execution_prover/src/workers/cpu.rs
+++ b/gpu/execution_prover/src/workers/cpu.rs
@@ -92,26 +92,20 @@ pub(crate) fn run_simulator<
         assert!(!is_aborted);
         let results = results.unwrap();
         let instant = Instant::now();
+        let ram_words = memory_holder.memory.len();
         let inits_and_teardowns = collect_inits_and_teardowns(memory_holder, worker);
         let elapsed = instant.elapsed();
         let elapsed_ms = elapsed.as_secs_f64() * 1000.0;
         let count = inits_and_teardowns.iter().map(|v| v.len()).sum::<usize>();
         trace!("BATCH[{batch_id}] SIMULATOR collected INITS_AND_TEARDOWNS with {count} entries in {elapsed_ms:.3} ms");
         let mut instant = Instant::now();
-        let trace_len_log2 = CircuitType::Unrolled(UnrolledCircuitType::InitsAndTeardowns)
-            .get_domain_size()
-            .trailing_zeros() as usize;
-        let num_sets = crate::upstream::inits_and_teardowns::NUM_INIT_AND_TEARDOWN_SETS;
-        // The inits-and-teardowns circuit's trace (2^24 rows, see
-        // `inits_and_teardowns::TRACE_LEN_LOG2`) is always page-granular:
-        // it is a fixed upstream constant far above the page size
-        // (2^`PAGE_SIZE_LOG2` = 2^10 rows), so this never underflows.
-        assert!(
-            trace_len_log2 >= PAGE_SIZE_LOG2 as usize,
-            "inits-and-teardowns trace_len_log2 {trace_len_log2} below page size log2 {PAGE_SIZE_LOG2}"
-        );
-        let pages_per_set_log2 = trace_len_log2 - PAGE_SIZE_LOG2 as usize;
-        let pages_per_partition: usize = num_sets << pages_per_set_log2;
+        let carrier = if T::IS_SPLIT {
+            UnrolledCircuitType::InitsAndTeardowns
+        } else {
+            UnrolledCircuitType::Unified
+        };
+        let geometry = InitsAndTeardownsGeometry::new(carrier, ram_words);
+        let partitioning = InitsAndTeardownsPartitioning::new(inits_and_teardowns, geometry);
         let (circuit_type, sequence_id_offset) = if T::IS_SPLIT {
             (UnrolledCircuitType::InitsAndTeardowns, 0usize)
         } else {
@@ -122,22 +116,23 @@ pub(crate) fn run_simulator<
             // prefill markers, sequence_ids would skip and the replayer's
             // tracing results would not pair up.
             // Under the `2^N`-row convention each unified circuit covers
-            // `domain_size` cycles (one cycle per usable row).
+            // `domain_size` cycles (one cycle per usable row), which is also
+            // where the tracing producer slices its circuits
+            // (`cycles_per_circuit_for`), so both sides agree on the count.
             let per_circuit_count = UnrolledCircuitType::Unified.get_domain_size();
             let timestamp_diff = state.timestamp - INITIAL_TIMESTAMP;
             assert!(timestamp_diff.is_multiple_of(TIMESTAMP_STEP));
             let total_cycles = (timestamp_diff / TIMESTAMP_STEP) as usize;
-            // `count` (distinct RAM words dirtied) is not guaranteed to be
-            // <= `total_cycles`: a delegation dirties many fresh words per
-            // cycle (a Blake2s-with-compression call touches ~40 words while
-            // advancing only `num_rounds` timestamp cycles), so a
-            // delegation-heavy run over disjoint, never-reused buffers can
-            // invert the two. Saturate to avoid a release-mode underflow into an
-            // unbounded empty-circuit marker loop; when no spare cycles remain
-            // this yields zero padding circuits (the real I&T chunks below still
-            // emit). Behavior-identical whenever count <= total_cycles.
-            let empty_cycles = total_cycles.saturating_sub(count);
-            let empty_circuits = empty_cycles / per_circuit_count;
+            let total_circuits = total_cycles.div_ceil(per_circuit_count);
+            // The i&t-carrying instances are the TRAILING ones, so the markers
+            // take the leading sequence_ids.
+            let it_circuits = partitioning.instances_count();
+            assert!(
+                it_circuits <= total_circuits,
+                "inits-and-teardowns needs {it_circuits} unified instances but the execution \
+                 only spans {total_circuits} ({total_cycles} cycles)"
+            );
+            let empty_circuits = total_circuits - it_circuits;
             for sequence_id in 0..empty_circuits {
                 let data = InitsAndTeardownsData {
                     circuit_type: CircuitType::Unrolled(UnrolledCircuitType::Unified),
@@ -152,12 +147,8 @@ pub(crate) fn run_simulator<
             (UnrolledCircuitType::Unified, empty_circuits)
         };
         let circuit_type = CircuitType::Unrolled(circuit_type);
-        for (sequence_id, inits_and_teardowns_data) in get_inits_and_teardowns_chunks(
-            inits_and_teardowns,
-            pages_per_partition,
-            free_allocators,
-        )
-        .enumerate()
+        for (sequence_id, inits_and_teardowns_data) in
+            partitioning.into_chunks(free_allocators).enumerate()
         {
             let sequence_id = sequence_id + sequence_id_offset;
             let count = inits_and_teardowns_data.page_indices.len();
@@ -338,76 +329,183 @@ fn collect_inits_and_teardowns(
     chunks
 }
 
-/// Group sparse init-and-teardown records by page and produce one
-/// `InitsAndTeardownsTraceHost` per circuit-sized partition.
-///
-/// Each partition holds up to `pages_per_partition` touched pages. Touched
-/// pages are filled to `1 << PAGE_SIZE_LOG2` slots of `values_packed` and
-/// `timestamps_packed`, with untouched cells zero-padded (the GPU kernel
-/// relies on this contract). The three series are kept in lockstep at
-/// page granularity by allocating chunks aligned to the page boundary on the
-/// `values_packed` and `timestamps_packed` sides; `page_indices` carries one
-/// `u32` per page.
-///
-/// Pool allocators are pulled from `free_allocators` whenever the current
-/// chunk for a given series is full; the chunk's `Arc` is what eventually
-/// returns the allocator to the pool when the orchestrator drops the host
-/// after H2D has been scheduled.
-fn get_inits_and_teardowns_chunks(
-    values: Vec<Vec<InitAndTeardownRecord>>,
-    pages_per_partition: usize,
-    free_allocators: Receiver<A>,
-) -> impl Iterator<Item = InitsAndTeardownsTraceHost> {
-    assert!(pages_per_partition > 0);
-    let page_size = 1usize << PAGE_SIZE_LOG2;
-    // Aggregate sparse records into dense pages keyed by `page_idx`. The
-    // `BTreeMap` iteration order matches the test reference's ordering; the
-    // GPU kernel does not require sorted page indices but emitting them in a
-    // canonical order keeps debugging deterministic.
-    let mut pages: BTreeMap<u32, (Vec<u32>, Vec<TimestampScalar>)> = BTreeMap::new();
-    for chunk in values {
-        for record in chunk {
-            let word_idx = record.address >> 2;
-            let page_idx = word_idx >> PAGE_SIZE_LOG2;
-            let word_in_page = (word_idx & ((1u32 << PAGE_SIZE_LOG2) - 1)) as usize;
-            let entry = pages
-                .entry(page_idx)
-                .or_insert_with(|| (vec![0u32; page_size], vec![0u64; page_size]));
-            entry.0[word_in_page] = record.teardown_value;
-            entry.1[word_in_page] = record.teardown_timestamp;
+/// Address geometry of the circuit carrying the inits-and-teardowns data: each
+/// of its `num_sets` sets covers one *window* of `1 << trace_len_log2`
+/// consecutive RAM words, named in the proof by its global window index
+/// (`top_bits`).
+#[derive(Clone, Copy)]
+struct InitsAndTeardownsGeometry {
+    pages_per_set_log2: u32,
+    num_sets: usize,
+    windows_in_ram: u32,
+}
+
+impl InitsAndTeardownsGeometry {
+    fn new(carrier: UnrolledCircuitType, ram_words: usize) -> Self {
+        let trace_len_log2 = carrier.get_domain_size_log2();
+        assert!(
+            trace_len_log2 >= PAGE_SIZE_LOG2,
+            "inits-and-teardowns trace_len_log2 {trace_len_log2} below page size log2 {PAGE_SIZE_LOG2}"
+        );
+        Self {
+            pages_per_set_log2: trace_len_log2 - PAGE_SIZE_LOG2,
+            num_sets: carrier.get_num_inits_and_teardowns_sets(),
+            windows_in_ram: ram_words.div_ceil(1usize << trace_len_log2) as u32,
         }
     }
-    let total_pages = pages.len();
-    let partitions_count = total_pages.div_ceil(pages_per_partition).max(1);
-    // Drain pages from the BTreeMap partition by partition. The *first*
-    // partition absorbs the remainder and later partitions are full-sized;
-    // keeps sequence_id assignment stable.
-    let mut pages_iter = pages.into_iter();
-    (0..partitions_count).map(move |index| {
-        let take = if index == 0 {
-            total_pages - (partitions_count - 1) * pages_per_partition
+}
+
+/// Rebase a global page index onto the local geometry the kernel decodes: set
+/// index in the high bits, page within that set's window in the low ones (see
+/// `process_inits_and_teardowns_pages` in `memory_unrolled.cu`). `slots` is one
+/// instance's slice of the window schedule.
+#[inline]
+fn local_page_index(page_idx: u32, slots: &[(u32, usize)], pages_per_set_log2: u32) -> u32 {
+    let window = page_idx >> pages_per_set_log2;
+    let set_idx = slots
+        .iter()
+        .position(|(w, _)| *w == window)
+        .expect("page window must be scheduled in its own instance");
+    ((set_idx as u32) << pages_per_set_log2) | (page_idx & ((1u32 << pages_per_set_log2) - 1))
+}
+
+/// Sparse init-and-teardown records aggregated into dense pages, plus the
+/// window schedule that assigns those pages to circuit instances.
+struct InitsAndTeardownsPartitioning {
+    pages: BTreeMap<u32, (Vec<u32>, Vec<TimestampScalar>)>,
+    /// `(global window index, touched pages in that window)` per set slot,
+    /// ascending, `num_sets` slots per instance. The counts let `into_chunks`
+    /// pre-size its payload buffers exactly.
+    window_schedule: Vec<(u32, usize)>,
+    geometry: InitsAndTeardownsGeometry,
+}
+
+impl InitsAndTeardownsPartitioning {
+    fn new(values: Vec<Vec<InitAndTeardownRecord>>, geometry: InitsAndTeardownsGeometry) -> Self {
+        let InitsAndTeardownsGeometry {
+            pages_per_set_log2,
+            num_sets,
+            windows_in_ram,
+        } = geometry;
+        let page_size = 1usize << PAGE_SIZE_LOG2;
+        // Keyed by GLOBAL page index: that order is also window-major, which is
+        // what lets `into_chunks` group by window in one streaming pass without
+        // re-scanning or sorting the page payloads.
+        let mut pages: BTreeMap<u32, (Vec<u32>, Vec<TimestampScalar>)> = BTreeMap::new();
+        for chunk in values {
+            for record in chunk {
+                let word_idx = record.address >> 2;
+                let page_idx = word_idx >> PAGE_SIZE_LOG2;
+                let word_in_page = (word_idx & ((1u32 << PAGE_SIZE_LOG2) - 1)) as usize;
+                let entry = pages
+                    .entry(page_idx)
+                    .or_insert_with(|| (vec![0u32; page_size], vec![0u64; page_size]));
+                entry.0[word_in_page] = record.teardown_value;
+                entry.1[word_in_page] = record.teardown_timestamp;
+            }
+        }
+        let mut touched: Vec<(u32, usize)> = Vec::new();
+        for &page_idx in pages.keys() {
+            let window = page_idx >> pages_per_set_log2;
+            match touched.last_mut() {
+                Some((last, count)) if *last == window => *count += 1,
+                _ => touched.push((window, 1)),
+            }
+        }
+        let window_schedule = if num_sets as u32 >= windows_in_ram {
+            // The sets already span the whole address space (split mode), and
+            // `full_statement_verifier::unrolled_proof_statement` asserts
+            // `top_bits[i] == i`, so every window is present touched or not.
+            (0..num_sets as u32)
+                .map(|window| {
+                    let count = touched
+                        .binary_search_by_key(&window, |(w, _)| *w)
+                        .map_or(0, |i| touched[i].1);
+                    (window, count)
+                })
+                .collect()
         } else {
-            pages_per_partition
+            // Pad to whole instances, and to at least one since the unified
+            // verifier requires `num_it_circuits >= 1`. A padded set's rows are
+            // all zero, so its init and teardown contributions cancel and its
+            // window only has to keep the concatenated `top_bits` strictly
+            // increasing; the choice of which mirrors the CPU reference.
+            let instances = (touched.len().max(1)).div_ceil(num_sets);
+            let missing = instances * num_sets - touched.len();
+            if missing > 0 {
+                let below = min(missing, touched.first().map_or(0, |(w, _)| *w) as usize);
+                let mut padded = Vec::with_capacity(touched.len() + missing);
+                padded.extend((0..below as u32).map(|w| (w, 0)));
+                padded.append(&mut touched);
+                padded.extend((0..(missing - below) as u32).map(|i| (windows_in_ram + i, 0)));
+                touched = padded;
+            }
+            touched
         };
-        let mut page_indices_flat: Vec<u32> = Vec::with_capacity(take);
-        let mut values_flat: Vec<u32> = Vec::with_capacity(take * page_size);
-        let mut timestamps_flat: Vec<TimestampScalar> = Vec::with_capacity(take * page_size);
-        for _ in 0..take {
-            let (idx, (vals, ts)) = pages_iter.next().unwrap();
-            page_indices_flat.push(idx);
-            values_flat.extend_from_slice(&vals);
-            timestamps_flat.extend_from_slice(&ts);
+        Self {
+            pages,
+            window_schedule,
+            geometry,
         }
-        let page_indices = chunk_into_pinned::<u32>(&page_indices_flat, &free_allocators, 1);
-        let values_packed = chunk_into_pinned::<u32>(&values_flat, &free_allocators, page_size);
-        let timestamps_packed =
-            chunk_into_pinned::<TimestampScalar>(&timestamps_flat, &free_allocators, page_size);
-        InitsAndTeardownsTraceHost {
-            page_indices,
-            values_packed,
-            timestamps_packed,
-        }
-    })
+    }
+
+    fn instances_count(&self) -> usize {
+        self.window_schedule.len() / self.geometry.num_sets
+    }
+
+    /// One `InitsAndTeardownsTraceHost` per instance, in ascending window order.
+    /// Touched pages are filled to `1 << PAGE_SIZE_LOG2` slots of
+    /// `values_packed` / `timestamps_packed` with untouched cells zero-padded
+    /// (the GPU kernel relies on this), which is why the chunks handed to
+    /// `chunk_into_pinned` are page-aligned.
+    ///
+    /// Pool allocators are pulled from `free_allocators` whenever the current
+    /// chunk for a given series is full; the chunk's `Arc` is what eventually
+    /// returns the allocator to the pool when the orchestrator drops the host
+    /// after H2D has been scheduled.
+    fn into_chunks(
+        self,
+        free_allocators: Receiver<A>,
+    ) -> impl Iterator<Item = InitsAndTeardownsTraceHost> {
+        let Self {
+            pages,
+            window_schedule,
+            geometry:
+                InitsAndTeardownsGeometry {
+                    pages_per_set_log2,
+                    num_sets,
+                    ..
+                },
+        } = self;
+        let page_size = 1usize << PAGE_SIZE_LOG2;
+        let instances_count = window_schedule.len() / num_sets;
+        let mut pages_iter = pages.into_iter();
+        (0..instances_count).map(move |instance_idx| {
+            let slots = &window_schedule[instance_idx * num_sets..][..num_sets];
+            let take: usize = slots.iter().map(|(_, count)| *count).sum();
+            let mut page_indices_flat: Vec<u32> = Vec::with_capacity(take);
+            let mut values_flat: Vec<u32> = Vec::with_capacity(take * page_size);
+            let mut timestamps_flat: Vec<TimestampScalar> = Vec::with_capacity(take * page_size);
+            // Page and schedule order agree, so this instance's pages are
+            // exactly the next `take` at the front of the iterator.
+            for _ in 0..take {
+                let (page_idx, (vals, ts)) = pages_iter.next().unwrap();
+                page_indices_flat.push(local_page_index(page_idx, slots, pages_per_set_log2));
+                values_flat.extend_from_slice(&vals);
+                timestamps_flat.extend_from_slice(&ts);
+            }
+            let page_indices = chunk_into_pinned::<u32>(&page_indices_flat, &free_allocators, 1);
+            let values_packed = chunk_into_pinned::<u32>(&values_flat, &free_allocators, page_size);
+            let timestamps_packed =
+                chunk_into_pinned::<TimestampScalar>(&timestamps_flat, &free_allocators, page_size);
+            InitsAndTeardownsTraceHost {
+                page_indices,
+                values_packed,
+                timestamps_packed,
+                top_bits: slots.iter().map(|(w, _)| *w).collect(),
+            }
+        })
+    }
 }
 
 /// Pack a flat slice of `T` into pinned-allocator chunks of size at most
@@ -458,4 +556,125 @@ fn chunk_into_pinned<T: Copy + 'static>(
         written += take;
     }
     ChunkedTraceHolder { chunks }
+}
+
+#[cfg(test)]
+mod cpu_partitioning_tests {
+    use super::*;
+
+    const UNIFIED_RAM_WORDS: usize = (1usize << 30) / 4;
+
+    fn unified_geometry() -> InitsAndTeardownsGeometry {
+        InitsAndTeardownsGeometry::new(UnrolledCircuitType::Unified, UNIFIED_RAM_WORDS)
+    }
+
+    /// One record in `window`, at `page_in_window`, word 0 of that page.
+    fn record_in(
+        geometry: &InitsAndTeardownsGeometry,
+        window: u32,
+        page_in_window: u32,
+    ) -> InitAndTeardownRecord {
+        let page_idx = (window << geometry.pages_per_set_log2) | page_in_window;
+        InitAndTeardownRecord {
+            address: (page_idx << PAGE_SIZE_LOG2) << 2,
+            teardown_value: 7,
+            teardown_timestamp: 11,
+        }
+    }
+
+    fn partition(
+        geometry: InitsAndTeardownsGeometry,
+        records: Vec<InitAndTeardownRecord>,
+    ) -> InitsAndTeardownsPartitioning {
+        InitsAndTeardownsPartitioning::new(vec![records], geometry)
+    }
+
+    fn windows_of(p: &InitsAndTeardownsPartitioning) -> Vec<u32> {
+        p.window_schedule.iter().map(|(w, _)| *w).collect()
+    }
+
+    #[test]
+    fn cpu_unified_geometry_comes_from_the_unified_circuit() {
+        let geometry = unified_geometry();
+        // The dedicated i&t circuit's 16 sets x 2^24 words must not leak in.
+        assert_eq!(geometry.num_sets, 2);
+        assert_eq!(geometry.pages_per_set_log2, 23 - PAGE_SIZE_LOG2);
+        assert_eq!(geometry.windows_in_ram, 32);
+    }
+
+    #[test]
+    fn cpu_unified_carries_touched_windows_and_rebases_pages() {
+        let geometry = unified_geometry();
+        let p = partition(
+            geometry,
+            vec![record_in(&geometry, 0, 3), record_in(&geometry, 2, 5)],
+        );
+        assert_eq!(windows_of(&p), vec![0, 2]);
+        assert_eq!(p.instances_count(), 1);
+
+        let slots = p.window_schedule.clone();
+        let pages_per_set = 1u32 << geometry.pages_per_set_log2;
+        assert_eq!(local_page_index(3, &slots, geometry.pages_per_set_log2), 3);
+        assert_eq!(
+            local_page_index(
+                (2 << geometry.pages_per_set_log2) | 5,
+                &slots,
+                geometry.pages_per_set_log2
+            ),
+            pages_per_set | 5
+        );
+    }
+
+    #[test]
+    fn cpu_unified_pads_and_groups_into_whole_instances() {
+        let geometry = unified_geometry();
+        let beyond = geometry.windows_in_ram;
+
+        // Window 0 free -> pad below it; window 0 taken -> pad past RAM.
+        assert_eq!(
+            windows_of(&partition(geometry, vec![record_in(&geometry, 3, 0)])),
+            vec![0, 3]
+        );
+        assert_eq!(
+            windows_of(&partition(geometry, vec![record_in(&geometry, 0, 0)])),
+            vec![0, beyond]
+        );
+        // No dirtied word still needs one instance.
+        assert_eq!(
+            windows_of(&partition(geometry, vec![])),
+            vec![beyond, beyond + 1]
+        );
+
+        let many = partition(
+            geometry,
+            vec![
+                record_in(&geometry, 5, 0),
+                record_in(&geometry, 1, 0),
+                record_in(&geometry, 9, 0),
+                record_in(&geometry, 4, 0),
+            ],
+        );
+        assert_eq!(windows_of(&many), vec![1, 4, 5, 9]);
+        assert_eq!(many.instances_count(), 2);
+    }
+
+    #[test]
+    fn cpu_split_keeps_canonical_windows_and_page_indices() {
+        let geometry = InitsAndTeardownsGeometry::new(
+            UnrolledCircuitType::InitsAndTeardowns,
+            UNIFIED_RAM_WORDS,
+        );
+        let p = partition(
+            geometry,
+            vec![record_in(&geometry, 0, 1), record_in(&geometry, 7, 2)],
+        );
+        assert_eq!(windows_of(&p), (0..16).collect::<Vec<_>>());
+        assert_eq!(p.instances_count(), 1);
+        // Set index == window, so the rebase is the identity.
+        let global = (7 << geometry.pages_per_set_log2) | 2;
+        assert_eq!(
+            local_page_index(global, &p.window_schedule, geometry.pages_per_set_log2),
+            global
+        );
+    }
 }

--- a/gpu/execution_prover/src/workers/gpu.rs
+++ b/gpu/execution_prover/src/workers/gpu.rs
@@ -7,7 +7,7 @@ use crate::A;
 use crossbeam_channel::{Receiver, Sender};
 use era_cudart::device::{get_device_properties, set_device};
 use era_cudart::result::CudaResult;
-use gpu_circuit_prover::proof::{canonical_inits_and_teardowns_top_bits, prove, GpuGKRProofJob};
+use gpu_circuit_prover::proof::{prove, GpuGKRProofJob};
 use gpu_core::primitives::field::{BF, E4};
 use gpu_gkr::setup::GpuGKRSetupTransfer;
 use gpu_prover_context::{ProverContext, ProverContextConfig};
@@ -237,14 +237,12 @@ fn schedule_phase_one<'a>(
         None
     };
 
-    // A unified circuit whose request carries no inits-and-teardowns data is a
-    // TRIVIAL (dummy) i&t chunk: only the trailing circuits of a unified
-    // execution hold real i&t data. Remember that before the host buffer is
-    // consumed below — it selects the all-zero top bits for the proof path.
-    let is_trivial_unified_inits_and_teardowns = matches!(
-        circuit_type,
-        CircuitType::Unrolled(gpu_trace::witness::circuit_type::UnrolledCircuitType::Unified)
-    ) && inits_and_teardowns_host.is_none();
+    // Captured before the host buffer is consumed below. `None` covers both
+    // circuits that carry no i&t at all and the TRIVIAL (dummy) leading unified
+    // chunks — only a unified execution's trailing circuits hold real i&t data.
+    let carried_top_bits = inits_and_teardowns_host
+        .as_ref()
+        .map(|host| host.top_bits.clone());
 
     let inits_and_teardowns_transfer = if let Some(host) = inits_and_teardowns_host {
         Some(InitsAndTeardownsTransfer::new(host, context)?)
@@ -296,15 +294,15 @@ fn schedule_phase_one<'a>(
             .gkr_programs
             .compiled_circuit()
             .as_ref();
-        // ACTUAL top bits for this circuit: canonical (== the real top bits in
-        // the supported regime) for circuits with real i&t data; all zeros for
-        // trivial unified chunks, mirroring the CPU reference
-        // (`prover_examples::unified` uses `vec![0u32; num_teardown_sets]`).
-        let top_bits = if is_trivial_unified_inits_and_teardowns {
-            vec![0u32; compiled_circuit.memory_layout.teardown_sets.len()]
-        } else {
-            canonical_inits_and_teardowns_top_bits(compiled_circuit)
-        };
+        // Without i&t data the windows are all zero, which is what the unified
+        // verifier requires of its leading instances.
+        let num_teardown_sets = compiled_circuit.memory_layout.teardown_sets.len();
+        let top_bits = carried_top_bits.unwrap_or_else(|| vec![0u32; num_teardown_sets]);
+        assert_eq!(
+            top_bits.len(),
+            num_teardown_sets,
+            "inits-and-teardowns top bits must cover every teardown set of {circuit_type:?}"
+        );
         let mut bundle = gpu_circuit_prover::proof::inputs::GpuGKRProofTransfer::<'_, A>::new(
             setup_transfer,
             decoder_transfer,

--- a/gpu/trace/src/witness/circuit_type.rs
+++ b/gpu/trace/src/witness/circuit_type.rs
@@ -42,6 +42,10 @@ const LOAD_STORE_WORD_DOMAIN_SIZE_LOG2: u32 =
 const LOAD_STORE_SUBWORD_DOMAIN_SIZE_LOG2: u32 =
     <LoadStoreSubwordOnlyCircuit as RiscVCycleCircuit<BabyBearField, true>>::DOMAIN_SIZE_LOG2;
 const INITS_AND_TEARDOWNS_DOMAIN_SIZE_LOG2: u32 = inits_and_teardowns::TRACE_LEN_LOG2;
+const INITS_AND_TEARDOWNS_NUM_SETS: usize = inits_and_teardowns::NUM_INIT_AND_TEARDOWN_SETS;
+// One inline i&t "pair" allocates two sets (`allocate_inline_inits_and_teardowns_sets`).
+const UNIFIED_REDUCED_MACHINE_NUM_INIT_AND_TEARDOWN_SETS: usize =
+    2 * <UnifiedReducedMachineCircuit as RiscVCycleCircuit<BabyBearField, true>>::NUM_INIT_AND_TEARDOWN_PAIRS;
 const MUL_DIV_UNSIGNED_DOMAIN_SIZE_LOG2: u32 =
     <UnsignedMulDivCircuit as RiscVCycleCircuit<BabyBearField, false>>::DOMAIN_SIZE_LOG2;
 
@@ -197,6 +201,17 @@ impl UnrolledCircuitType {
             Self::Memory(circuit_type) => circuit_type.get_family_idx(),
             Self::NonMemory(circuit_type) => circuit_type.get_family_idx(),
             Self::Unified => REDUCED_MACHINE_CIRCUIT_FAMILY_IDX,
+        }
+    }
+
+    /// Length of this circuit's `memory_layout.teardown_sets`. Each set covers
+    /// one `get_domain_size()`-word address window.
+    #[inline(always)]
+    pub const fn get_num_inits_and_teardowns_sets(&self) -> usize {
+        match self {
+            Self::InitsAndTeardowns => INITS_AND_TEARDOWNS_NUM_SETS,
+            Self::Memory(_) | Self::NonMemory(_) => 0,
+            Self::Unified => UNIFIED_REDUCED_MACHINE_NUM_INIT_AND_TEARDOWN_SETS,
         }
     }
 }

--- a/gpu/trace/src/witness/trace_unrolled.rs
+++ b/gpu/trace/src/witness/trace_unrolled.rs
@@ -174,11 +174,18 @@ impl From<&InitsAndTeardownsTraceDevice> for InitsAndTeardownsTraceRaw {
 /// page-aligned (length is a multiple of `1 << PAGE_SIZE_LOG2`); chunks of
 /// `page_indices` carry one entry per page. Per-field chunk lengths sum to
 /// the same total page count.
+///
+/// `page_indices` are **local** to this instance: the high `log2(num_sets)` bits
+/// select the set, the low bits the page within that set's window. `top_bits`
+/// maps each set back to the global window it holds — set `i` covers global
+/// words `[top_bits[i] << trace_len_log2, (top_bits[i] + 1) << trace_len_log2)`.
 #[derive(Clone)]
 pub struct InitsAndTeardownsTraceHost {
     pub page_indices: ChunkedTraceHolder<u32, ConcurrentStaticHostAllocator>,
     pub values_packed: ChunkedTraceHolder<u32, ConcurrentStaticHostAllocator>,
     pub timestamps_packed: ChunkedTraceHolder<TimestampScalar, ConcurrentStaticHostAllocator>,
+    /// One global window index per set, ascending.
+    pub top_bits: Vec<u32>,
 }
 
 impl InitsAndTeardownsTraceHost {
@@ -187,6 +194,7 @@ impl InitsAndTeardownsTraceHost {
             page_indices,
             values_packed,
             timestamps_packed,
+            top_bits: _,
         } = self;
         let mut allocators = page_indices.into_allocators();
         allocators.extend(values_packed.into_allocators());


### PR DESCRIPTION
## What ❔

Unified-mode GPU proving now binds the **real** inits-and-teardowns address windows (`top_bits`) per circuit instance, instead of the canonical `0..num_sets` placeholder, and ships page indices in the local set geometry the i&t kernel actually decodes.

## Why ❔

`top_bits` bind the GKR i&t address window and are absorbed into the Fiat-Shamir transcript. Canonical values are only correct when one instance's sets span the whole address space — true for the dedicated i&t circuit (16 sets x 2^24 words == 1 GiB), false for the unified circuit (2 sets, 32 windows over the same RAM), which additionally inherited the dedicated circuit's geometry and over-packed pages 16x. The result was a unified proof whose memory permutation argument did not close, blocking the GPU recursion ladder at the bridge.

See the commit message for the mechanism, the padding rule, and why the grouping costs no extra pass.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
