### PR TITLE
perf(whir): specialize large coefficient leaf hashing

### DIFF
--- a/gpu/AGENTS.md
+++ b/gpu/AGENTS.md
@@ -134,7 +134,7 @@ root in `gkr_eval_ir`; `gpu_gkr_compiler` depends on it.
   for its own blake2s-dependent protocol kernels. See [`gkr/AGENTS.md`](gkr/AGENTS.md).
 - **`gpu_whir`** = WHIR folds (`fold/`) + PoW/query scheduling (`pow.rs`) +
   the recursive WHIR extension oracle and its side-stream LDE/Merkle commit
-  scheduler, with its own `gpu_whir_native` (24 kernels, no `__constant__`
+  scheduler, with its own `gpu_whir_native` (25 kernels, no `__constant__`
   symbols), namespace `airbender::whir`. Reads
   `gpu_gkr`'s exported headers (`accumulate_eq.cu`) and `gpu_hash`'s
   `hash.cuh` plus gpu_ntt's exported `whir_leaf_transform.cuh` (`leaves.cu`).

--- a/gpu/core/native_headers/common.cuh
+++ b/gpu/core/native_headers/common.cuh
@@ -38,6 +38,15 @@ using u64 = uint64_t;
 using i32 = int32_t;
 using i64 = int64_t;
 
+constexpr unsigned bitreverse_low_bits_constant(unsigned value, const unsigned num_bits) {
+  unsigned result = 0;
+  for (unsigned i = 0; i < num_bits; i++) {
+    result = (result << 1) | (value & 1);
+    value >>= 1;
+  }
+  return result;
+}
+
 // Bit-reverse of the low `num_bits` bits of `value` (the high `32 - num_bits`
 // bits are dropped). Single source of truth for the NTT/hash/WHIR bit-reversal
 // helpers. Guarded: `num_bits == 0` returns 0, avoiding the undefined `>> 32`

--- a/gpu/ntt/native/whir_leaf_transform.cuh
+++ b/gpu/ntt/native/whir_leaf_transform.cuh
@@ -122,4 +122,79 @@ DEVICE_FORCEINLINE void transform_whir_leaf_from_ntt(const Source &src, Destinat
   dst.set_at_slot(final_slot_in_leaf + 1, e4::mul(x_inv, e4::sub(final_a, final_b)));
 }
 
+template <unsigned LANE, unsigned STRIDE, unsigned COUNT> DEVICE_FORCEINLINE void square_whir_leaf_register_x_invs(bf (&x_invs)[COUNT]) {
+  static_assert(STRIDE <= COUNT);
+  x_invs[LANE] = bf::sqr(x_invs[LANE]);
+  if constexpr (LANE + 1 < STRIDE)
+    square_whir_leaf_register_x_invs<LANE + 1, STRIDE>(x_invs);
+}
+
+template <unsigned WORKER, unsigned STAGE, unsigned LOG_VALUES_PER_LEAF>
+DEVICE_FORCEINLINE void transform_whir_leaf_two_limb_register_workers(bf (&values)[2][1u << LOG_VALUES_PER_LEAF],
+                                                                      bf (&x_invs)[1u << (LOG_VALUES_PER_LEAF - 1)]) {
+  constexpr unsigned VALUES_COUNT = 1u << LOG_VALUES_PER_LEAF;
+  constexpr unsigned stride = 1u << (LOG_VALUES_PER_LEAF - 1 - STAGE);
+  constexpr unsigned region = WORKER / stride;
+  constexpr unsigned lane = WORKER & (stride - 1);
+  constexpr unsigned slot = 2 * stride * region + lane;
+#pragma unroll
+  for (unsigned limb = 0; limb < 2; limb++) {
+    const bf a = values[limb][slot];
+    const bf b = values[limb][slot + stride];
+    values[limb][slot] = bf::add(a, b);
+    values[limb][slot + stride] = bf::mul(x_invs[lane], bf::sub(a, b));
+  }
+  if constexpr (WORKER + 1 < VALUES_COUNT / 2)
+    transform_whir_leaf_two_limb_register_workers<WORKER + 1, STAGE, LOG_VALUES_PER_LEAF>(values, x_invs);
+}
+
+template <unsigned STAGE, unsigned LOG_VALUES_PER_LEAF>
+DEVICE_FORCEINLINE void transform_whir_leaf_two_limb_register_stage(bf (&values)[2][1u << LOG_VALUES_PER_LEAF], bf (&x_invs)[1u << (LOG_VALUES_PER_LEAF - 1)]) {
+  if constexpr (STAGE < LOG_VALUES_PER_LEAF) {
+    constexpr unsigned stride = 1u << (LOG_VALUES_PER_LEAF - 1 - STAGE);
+    square_whir_leaf_register_x_invs<0, stride>(x_invs);
+    transform_whir_leaf_two_limb_register_workers<0, STAGE, LOG_VALUES_PER_LEAF>(values, x_invs);
+    transform_whir_leaf_two_limb_register_stage<STAGE + 1, LOG_VALUES_PER_LEAF>(values, x_invs);
+  }
+}
+
+template <unsigned WORKER, unsigned LOG_VALUES_PER_LEAF, class Source0, class Source1, class InversePowerSource>
+DEVICE_FORCEINLINE void initialize_whir_leaf_two_limb_register_workers(const Source0 &src0, const Source1 &src1, const unsigned log_trace_len,
+                                                                       const unsigned log_lde_factor, const unsigned coset, const unsigned base_lane_in_coset,
+                                                                       bf (&values)[2][1u << LOG_VALUES_PER_LEAF],
+                                                                       bf (&x_invs)[1u << (LOG_VALUES_PER_LEAF - 1)], const bf two_inv_power,
+                                                                       const InversePowerSource &inverse_power_source) {
+  constexpr unsigned VALUES_COUNT = 1u << LOG_VALUES_PER_LEAF;
+  const unsigned leaves_per_coset = 1u << (log_trace_len - LOG_VALUES_PER_LEAF);
+  const unsigned src_row_a = leaves_per_coset * WORKER;
+  const unsigned src_row_b = src_row_a + leaves_per_coset * (VALUES_COUNT / 2);
+  const unsigned coset_offset = coset << (inverse_power_source.params.omega_log_order - log_trace_len - log_lde_factor);
+  const unsigned x_index = ((base_lane_in_coset + src_row_a) << (inverse_power_source.params.omega_log_order - log_trace_len)) + coset_offset;
+  const bf x_inv = inverse_power_source.get(x_index);
+  x_invs[WORKER] = x_inv;
+  const bf a0 = src0.get_at_row(src_row_a);
+  const bf b0 = src0.get_at_row(src_row_b);
+  const bf a1 = src1.get_at_row(src_row_a);
+  const bf b1 = src1.get_at_row(src_row_b);
+  values[0][WORKER] = bf::mul(two_inv_power, bf::add(a0, b0));
+  values[0][WORKER + VALUES_COUNT / 2] = bf::mul(bf::mul(x_inv, two_inv_power), bf::sub(a0, b0));
+  values[1][WORKER] = bf::mul(two_inv_power, bf::add(a1, b1));
+  values[1][WORKER + VALUES_COUNT / 2] = bf::mul(bf::mul(x_inv, two_inv_power), bf::sub(a1, b1));
+  if constexpr (WORKER + 1 < VALUES_COUNT / 2)
+    initialize_whir_leaf_two_limb_register_workers<WORKER + 1, LOG_VALUES_PER_LEAF>(src0, src1, log_trace_len, log_lde_factor, coset, base_lane_in_coset,
+                                                                                    values, x_invs, two_inv_power, inverse_power_source);
+}
+
+template <unsigned LOG_VALUES_PER_LEAF, class Source0, class Source1, class InversePowerSource>
+DEVICE_FORCEINLINE void transform_whir_leaf_two_limbs_from_ntt_registers(const Source0 &src0, const Source1 &src1, const unsigned log_trace_len,
+                                                                         const unsigned log_lde_factor, const unsigned coset, const unsigned base_lane_in_coset,
+                                                                         bf (&values)[2][1u << LOG_VALUES_PER_LEAF], const bf two_inv_power,
+                                                                         const InversePowerSource &inverse_power_source) {
+  static_assert(LOG_VALUES_PER_LEAF == 5);
+  bf x_invs[1u << (LOG_VALUES_PER_LEAF - 1)];
+  initialize_whir_leaf_two_limb_register_workers<0, LOG_VALUES_PER_LEAF>(src0, src1, log_trace_len, log_lde_factor, coset, base_lane_in_coset, values, x_invs,
+                                                                         two_inv_power, inverse_power_source);
+  transform_whir_leaf_two_limb_register_stage<1, LOG_VALUES_PER_LEAF>(values, x_invs);
+}
+
 } // namespace airbender::ntt

--- a/gpu/whir/AGENTS.md
+++ b/gpu/whir/AGENTS.md
@@ -58,7 +58,7 @@ rather than letting the duplicate drift by convention.
 - **Archive / `links` key**: `gpu_whir_native` (`build.rs`:
   `gpu_native_build::CudaArchive::new("gpu_whir_native", "GPU_WHIR").build()`
   — no `export_include`; nothing above this crate includes its headers).
-- **Kernel count**: 24 `__global__` kernels (verified by grep, across
+- **Kernel count**: 25 `__global__` kernels (verified by grep, across
   `whir/{accumulate_eq,columns,fold,leaves}.cu`). No `__constant__` symbols
   (all 8 cluster-wide ones live in `gpu_gkr`).
 - **Namespace**: `airbender::whir`.

--- a/gpu/whir/native/whir/leaves.cu
+++ b/gpu/whir/native/whir/leaves.cu
@@ -168,6 +168,115 @@ EXTERN __launch_bounds__(512, 2) __global__ void ab_gather_coefficient_leaves_an
                                               layers_count, partial_tree);
 }
 
+constexpr unsigned bitreverse_low_bits_constant(unsigned value, const unsigned bits) {
+  unsigned result = 0;
+  for (unsigned i = 0; i < bits; i++) {
+    result = (result << 1) | (value & 1);
+    value >>= 1;
+  }
+  return result;
+}
+
+template <unsigned BLOCK_INDEX, unsigned VALUE_IN_BLOCK = 0>
+DEVICE_FORCEINLINE void write_whir_leaf_two_limb_hash_block(const bf (&values)[2][32], u32 (&hash_block_smem)[16][32]) {
+  constexpr unsigned output_slot = 4 * BLOCK_INDEX + VALUE_IN_BLOCK;
+  constexpr unsigned transform_slot = bitreverse_low_bits_constant(output_slot, 5);
+  const unsigned word = 4 * VALUE_IN_BLOCK + 2 * threadIdx.y;
+  hash_block_smem[word][threadIdx.x] = bf::into_raw_u32(values[0][transform_slot]);
+  hash_block_smem[word + 1][threadIdx.x] = bf::into_raw_u32(values[1][transform_slot]);
+  if constexpr (VALUE_IN_BLOCK + 1 < 4)
+    write_whir_leaf_two_limb_hash_block<BLOCK_INDEX, VALUE_IN_BLOCK + 1>(values, hash_block_smem);
+}
+
+template <unsigned WORD = 0> DEVICE_FORCEINLINE void load_whir_leaf_hash_block(const u32 (&hash_block_smem)[16][32], u32 (&block)[16]) {
+  block[WORD] = hash_block_smem[WORD][threadIdx.x];
+  if constexpr (WORD + 1 < 16)
+    load_whir_leaf_hash_block<WORD + 1>(hash_block_smem, block);
+}
+
+DEVICE_FORCEINLINE void write_whir_leaf_two_limb_hash_block(const unsigned block_idx, const bf (&values)[2][32], u32 (&hash_block_smem)[16][32]) {
+  switch (block_idx) {
+  case 0:
+    write_whir_leaf_two_limb_hash_block<0>(values, hash_block_smem);
+    break;
+  case 1:
+    write_whir_leaf_two_limb_hash_block<1>(values, hash_block_smem);
+    break;
+  case 2:
+    write_whir_leaf_two_limb_hash_block<2>(values, hash_block_smem);
+    break;
+  case 3:
+    write_whir_leaf_two_limb_hash_block<3>(values, hash_block_smem);
+    break;
+  case 4:
+    write_whir_leaf_two_limb_hash_block<4>(values, hash_block_smem);
+    break;
+  case 5:
+    write_whir_leaf_two_limb_hash_block<5>(values, hash_block_smem);
+    break;
+  case 6:
+    write_whir_leaf_two_limb_hash_block<6>(values, hash_block_smem);
+    break;
+  case 7:
+    write_whir_leaf_two_limb_hash_block<7>(values, hash_block_smem);
+    break;
+  }
+}
+
+DEVICE_FORCEINLINE void transform_and_hash_whir_leaf_register_v32_two_limb(vectorized_e4_matrix_getter<ld_modifier::cs> ntt_output,
+                                                                           const ::airbender::ntt::whir_leaf_transform_params transform_params,
+                                                                           const unsigned log_trace_len, const unsigned log_lde_factor,
+                                                                           const unsigned natural_coset, const unsigned leaf_in_coset,
+                                                                           u32 (&hash_block_smem)[16][32], ::airbender::hash::digest &state) {
+  auto src0 = ntt_output.internal;
+  src0.add_col(2 * threadIdx.y);
+  auto src1 = src0;
+  src1.add_col(1);
+  bf values[2][32];
+  const ::airbender::ntt::params_inverse_power_source inverse_power_source{transform_params};
+  ::airbender::ntt::transform_whir_leaf_two_limbs_from_ntt_registers<5>(src0, src1, log_trace_len, log_lde_factor, natural_coset, leaf_in_coset, values,
+                                                                        transform_params.two_inv_power, inverse_power_source);
+
+  if (threadIdx.y == 0)
+    ::airbender::hash::initialize(state.words);
+  u32 t = 0;
+#pragma unroll 1
+  for (unsigned block_idx = 0; block_idx < 8; block_idx++) {
+    write_whir_leaf_two_limb_hash_block(block_idx, values, hash_block_smem);
+    __syncthreads();
+    if (threadIdx.y == 0) {
+      u32 block[16];
+      load_whir_leaf_hash_block(hash_block_smem, block);
+      if (block_idx + 1 == 8)
+        ::airbender::hash::compress<true>(state.words, t, block, 16);
+      else
+        ::airbender::hash::compress<false>(state.words, t, block, 16);
+    }
+    __syncthreads();
+  }
+}
+
+EXTERN __launch_bounds__(64) __global__ void ab_transform_and_hash_whir_leaves_from_ntt_multi_coset_to_staging_register_v32_kernel(
+    vectorized_e4_matrix_getter<ld_modifier::cs> ntt_output, u32 *staging, const ::airbender::ntt::whir_leaf_transform_params transform_params,
+    const unsigned log_trace_len, const unsigned log_lde_factor, const unsigned coset_index_base, const unsigned leaves_count) {
+  __shared__ u32 hash_block_smem[16][32];
+  const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const bool enabled = gid < leaves_count;
+  const unsigned safe_gid = enabled ? gid : leaves_count - 1;
+  const unsigned log_packed_leaf_count = log_trace_len - 5;
+  const unsigned packed_leaf_count = 1u << log_packed_leaf_count;
+  const unsigned coset_in_tile = safe_gid >> log_packed_leaf_count;
+  const unsigned leaf_in_coset = safe_gid & (packed_leaf_count - 1u);
+  const unsigned natural_coset = coset_index_base + coset_in_tile;
+  ntt_output.add_col(coset_in_tile);
+  ntt_output.add_row(leaf_in_coset);
+  ::airbender::hash::digest state;
+  transform_and_hash_whir_leaf_register_v32_two_limb(ntt_output, transform_params, log_trace_len, log_lde_factor, natural_coset, leaf_in_coset, hash_block_smem,
+                                                     state);
+  if (enabled && threadIdx.y == 0)
+    store_cs(reinterpret_cast<::airbender::hash::digest *>(staging) + gid, state);
+}
+
 // Source columns are tile-local; twiddles and tree placement use global cosets.
 EXTERN __launch_bounds__(512, 2) __global__
     void ab_transform_and_hash_whir_leaves_from_ntt_multi_coset_kernel(vectorized_e4_matrix_getter<ld_modifier::cs> ntt_output, u32 *results,

--- a/gpu/whir/native/whir/leaves.cu
+++ b/gpu/whir/native/whir/leaves.cu
@@ -168,15 +168,6 @@ EXTERN __launch_bounds__(512, 2) __global__ void ab_gather_coefficient_leaves_an
                                               layers_count, partial_tree);
 }
 
-constexpr unsigned bitreverse_low_bits_constant(unsigned value, const unsigned bits) {
-  unsigned result = 0;
-  for (unsigned i = 0; i < bits; i++) {
-    result = (result << 1) | (value & 1);
-    value >>= 1;
-  }
-  return result;
-}
-
 template <unsigned BLOCK_INDEX, unsigned VALUE_IN_BLOCK = 0>
 DEVICE_FORCEINLINE void write_whir_leaf_two_limb_hash_block(const bf (&values)[2][32], u32 (&hash_block_smem)[16][32]) {
   constexpr unsigned output_slot = 4 * BLOCK_INDEX + VALUE_IN_BLOCK;

--- a/gpu/whir/src/kernels/mod.rs
+++ b/gpu/whir/src/kernels/mod.rs
@@ -607,6 +607,35 @@ cuda_kernel_declaration!(
     )
 );
 
+cuda_kernel_signature_arguments_and_function!(
+    TransformAndHashWhirLeavesFromNttMultiCosetToStagingRegisterV32,
+    src: PtrAndStride<BF>,
+    staging: *mut u32,
+    transform_params: WhirLeafTransformParams,
+    log_trace_len: u32,
+    log_lde_factor: u32,
+    coset_index_base: u32,
+    leaves_count: u32,
+);
+
+cuda_kernel_declaration!(
+    ab_transform_and_hash_whir_leaves_from_ntt_multi_coset_to_staging_register_v32_kernel(
+        src: PtrAndStride<BF>,
+        staging: *mut u32,
+        transform_params: WhirLeafTransformParams,
+        log_trace_len: u32,
+        log_lde_factor: u32,
+        coset_index_base: u32,
+        leaves_count: u32,
+    )
+);
+
+const NATURAL_REGISTER_RESIDENT_V32_MIN_LEAVES_COUNT: usize = 1 << 16;
+
+fn use_register_resident_natural_v32(log_values_per_leaf: u32, leaves_count: usize) -> bool {
+    log_values_per_leaf == 5 && leaves_count >= NATURAL_REGISTER_RESIDENT_V32_MIN_LEAVES_COUNT
+}
+
 pub(crate) fn transform_and_hash_whir_leaves_from_ntt_multi_coset_to_staging(
     ntt_output: &DeviceSlice<BF>,
     staging: &mut DeviceSlice<Digest>,
@@ -631,6 +660,27 @@ pub(crate) fn transform_and_hash_whir_leaves_from_ntt_multi_coset_to_staging(
     assert_eq!(staging.len(), leaves_count);
     assert!(leaves_count <= u32::MAX as usize);
     assert!(ntt_output.len() >= trace_len * 4 * cosets_in_tile as usize);
+
+    if use_register_resident_natural_v32(log_values_per_leaf, leaves_count) {
+        let config = CudaLaunchConfig::basic(
+            (leaves_count as u32).div_ceil(WARP_SIZE),
+            (WARP_SIZE, 2u32),
+            stream,
+        );
+        let args = TransformAndHashWhirLeavesFromNttMultiCosetToStagingRegisterV32Arguments::new(
+            PtrAndStride::new(ntt_output.as_ptr(), trace_len),
+            staging.as_mut_ptr() as *mut u32,
+            transform_params,
+            log_trace_len,
+            log_lde_factor,
+            coset_index_base,
+            leaves_count as u32,
+        );
+        return TransformAndHashWhirLeavesFromNttMultiCosetToStagingRegisterV32Function(
+            ab_transform_and_hash_whir_leaves_from_ntt_multi_coset_to_staging_register_v32_kernel,
+        )
+        .launch(&config, &args);
+    }
 
     let values_per_leaf = 1usize << log_values_per_leaf;
     let block_dim_x = if values_per_leaf == 2 {

--- a/gpu/whir/src/kernels/tests.rs
+++ b/gpu/whir/src/kernels/tests.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+#[test]
+fn cpu_natural_register_resident_v32_respects_threshold_and_width() {
+    assert!(!use_register_resident_natural_v32(5, (1 << 16) - 1));
+    assert!(use_register_resident_natural_v32(5, 1 << 16));
+    assert!(!use_register_resident_natural_v32(4, 1 << 20));
+}
+
 use era_cudart::memory::{memory_copy_async, DeviceAllocation};
 use field::{Field, Rand};
 use gpu_core::primitives::device_structures::DeviceMatrix;

--- a/gpu/whir/src/lib.rs
+++ b/gpu/whir/src/lib.rs
@@ -1061,6 +1061,119 @@ pub(crate) mod tests {
         assert_coefficient_query_kernels_from_evaluation_backing_match_cpu(6, 32, 32, 1, true);
     }
 
+    fn bitreverse_low_bits_for_test(value: usize, bits: u32) -> usize {
+        value.reverse_bits() >> (usize::BITS - bits)
+    }
+
+    fn assert_coefficient_leaf_hash_natural_staging_matches_materialized_reference(
+        log_trace_len: u32,
+        lde_factor: usize,
+        coset_index_base: u32,
+        cosets_in_tile: u32,
+    ) {
+        const TREE_CAP_SIZE: usize = 16;
+        const VALUES_PER_LEAF: usize = 32;
+
+        let context = make_test_context(256, 64);
+        let trace_len = 1usize << log_trace_len;
+        let log_lde_factor = lde_factor.trailing_zeros();
+        let log_values_per_leaf = VALUES_PER_LEAF.trailing_zeros();
+        let packed_leaf_count = trace_len / VALUES_PER_LEAF;
+        let total_leaves = packed_leaf_count * lde_factor;
+        let tile_leaves = packed_leaf_count * cosets_in_tile as usize;
+        let monomial_coeffs = sample_monomial_coeffs(trace_len);
+        let evaluation = GpuWhirExtensionOracle::from_monomial_coeffs(
+            &monomial_coeffs,
+            lde_factor,
+            VALUES_PER_LEAF,
+            TREE_CAP_SIZE,
+            false,
+            &context,
+        )
+        .unwrap();
+        let evaluations = evaluation.trace_holder.get_consolidated_cosets();
+        let stream = context.get_exec_stream();
+        let mut materialized = context
+            .alloc::<BF>(evaluations.len(), AllocationPlacement::BestFit)
+            .unwrap();
+        memory_copy_async(&mut materialized, evaluations, stream).unwrap();
+        {
+            let mut materialized_matrix = DeviceMatrixMut::new(&mut materialized, trace_len);
+            gpu_ntt::ntt::transform_whir_leaves_from_ntt_in_place_multi_coset(
+                &mut materialized_matrix,
+                log_trace_len,
+                log_lde_factor,
+                log_values_per_leaf,
+                0,
+                lde_factor as u32,
+                stream,
+            )
+            .unwrap();
+        }
+
+        let tile_bf_offset = coset_index_base as usize * trace_len * EXT4_DEGREE;
+        let mut reference_digests = context
+            .alloc::<Digest>(total_leaves, AllocationPlacement::BestFit)
+            .unwrap();
+        gpu_hash::blake2s::hash_leaves_from_ntt_multi_coset(
+            &materialized[tile_bf_offset..],
+            &mut reference_digests,
+            log_values_per_leaf,
+            EXT4_DEGREE as u32,
+            log_lde_factor,
+            coset_index_base,
+            cosets_in_tile as usize,
+            packed_leaf_count,
+            trace_len as u32,
+            stream,
+        )
+        .unwrap();
+
+        let mut staging = context
+            .alloc::<Digest>(tile_leaves, AllocationPlacement::BestFit)
+            .unwrap();
+        kernels::transform_and_hash_whir_leaves_from_ntt_multi_coset_to_staging(
+            &evaluations[tile_bf_offset..],
+            &mut staging,
+            log_trace_len,
+            log_lde_factor,
+            log_values_per_leaf,
+            coset_index_base,
+            cosets_in_tile,
+            context
+                .ntt_device_context()
+                .whir_leaf_transform_params(log_values_per_leaf),
+            stream,
+        )
+        .unwrap();
+
+        let mut reference_host = vec![Digest::default(); total_leaves];
+        let mut staging_host = vec![Digest::default(); tile_leaves];
+        memory_copy_async(&mut reference_host, &reference_digests, stream).unwrap();
+        memory_copy_async(&mut staging_host, &staging, stream).unwrap();
+        stream.synchronize().unwrap();
+
+        for (gid, actual) in staging_host.iter().enumerate() {
+            let coset_in_tile = gid / packed_leaf_count;
+            let leaf_in_coset = gid % packed_leaf_count;
+            let natural_coset = coset_index_base as usize + coset_in_tile;
+            let bitrev_coset = bitreverse_low_bits_for_test(natural_coset, log_lde_factor);
+            let reference_idx = bitrev_coset * packed_leaf_count + leaf_in_coset;
+            assert_eq!(
+                actual, &reference_host[reference_idx],
+                "natural staging mismatch for coset_index_base={coset_index_base}, gid={gid}",
+            );
+        }
+    }
+
+    #[test]
+    fn coefficient_leaf_hash_natural_staging_matches_materialized_reference() {
+        assert_coefficient_leaf_hash_natural_staging_matches_materialized_reference(17, 32, 0, 16);
+        assert_coefficient_leaf_hash_natural_staging_matches_materialized_reference(
+            9, 8192, 17, 4097,
+        );
+    }
+
     #[test]
     fn fused_coefficient_leaf_hash_matches_materialized_reference() {
         let context = make_test_context(256, 32);

--- a/gpu/whir/src/lib.rs
+++ b/gpu/whir/src/lib.rs
@@ -1061,10 +1061,6 @@ pub(crate) mod tests {
         assert_coefficient_query_kernels_from_evaluation_backing_match_cpu(6, 32, 32, 1, true);
     }
 
-    fn bitreverse_low_bits_for_test(value: usize, bits: u32) -> usize {
-        value.reverse_bits() >> (usize::BITS - bits)
-    }
-
     fn assert_coefficient_leaf_hash_natural_staging_matches_materialized_reference(
         log_trace_len: u32,
         lde_factor: usize,
@@ -1157,7 +1153,7 @@ pub(crate) mod tests {
             let coset_in_tile = gid / packed_leaf_count;
             let leaf_in_coset = gid % packed_leaf_count;
             let natural_coset = coset_index_base as usize + coset_in_tile;
-            let bitrev_coset = bitreverse_low_bits_for_test(natural_coset, log_lde_factor);
+            let bitrev_coset = super::bitreverse_index(natural_coset, log_lde_factor);
             let reference_idx = bitrev_coset * packed_leaf_count + leaf_in_coset;
             assert_eq!(
                 actual, &reference_host[reference_idx],


### PR DESCRIPTION
## What ❔

Specialize large 32-value WHIR coefficient-leaf commitments with a register-resident transform and a 2 KiB shared Blake2s exchange buffer.

This improves the largest v32 kernel workload by 22.6%, the affected commitment aggregate by 5.3%, WHIR by 1.8%, and the full proof by 0.9%.

## Why ❔

The generic kernel stages the full E4 leaf in shared memory. The specialized geometry keeps transformed limbs in registers and is selected only from the measured 2^16-leaf crossover.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
