### PR TITLE
fix(cli): enable deterministic PoW on both backends

### DIFF
--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -18,7 +18,9 @@ name = "cli"
 path = "src/main.rs"
 
 [dependencies]
-prover = { workspace = true, features = ["prover"] }
+# `deterministic_pow` is pinned here, not exposed as a cli feature: CI builds
+# this crate with `--no-default-features`.
+prover = { workspace = true, features = ["prover", "deterministic_pow"] }
 setups = { workspace = true }
 common_constants = { workspace = true }
 serde = { workspace = true }
@@ -43,8 +45,12 @@ sha3 = { package = "sha3", version = "*" }
 log = "0.4"
 
 # GPU proving stack (behind the `gpu` feature).
-gpu_execution_prover = { workspace = true, optional = true, default-features = false }
-gpu_program_prover = { workspace = true, optional = true, default-features = false }
+gpu_execution_prover = { workspace = true, optional = true, default-features = false, features = [
+    "deterministic_pow",
+] }
+gpu_program_prover = { workspace = true, optional = true, default-features = false, features = [
+    "deterministic_pow",
+] }
 
 env_logger = "0.11"
 base64 = "0.21.7"


### PR DESCRIPTION
## What ❔

Enables `deterministic_pow` in `tools/cli` for both backends — `prover` for the host transcript, the two GPU prover crates for the device search kernel. Pinned on the dependency edges rather than behind a cli feature, since CI builds this crate with `--no-default-features`.

## Why ❔

Without it the parallel nonce search keeps whichever nonce it found first, so two `cli prove` runs over the same input emit different proof bytes and CPU/GPU output cannot be compared.

Verified on `basic_fibonacci --target recursion-unified`: two CPU runs and two GPU runs now agree byte-for-byte on the whole proof payload.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
