### PR TITLE
perf(gpu_gkr): merge forward dim-reducing towers into a single kernel

### DIFF
--- a/gpu/gkr/native/gkr/forward/dim_reducing_tower.cu
+++ b/gpu/gkr/native/gkr/forward/dim_reducing_tower.cu
@@ -2,14 +2,9 @@
 
 namespace airbender::gkr::forward {
 
-EXTERN __global__ __launch_bounds__(GKR_DIM_REDUCING_FORWARD_TOWER_BLOCK, 4) void ab_gkr_dim_reducing_forward_tower_pairwise_e4_kernel(
-    const __grid_constant__ gkr_dim_reducing_forward_tower_pairwise_batch<e4> batch) {
-  gkr_dim_reducing_forward_tower_pairwise(batch);
-}
-
-EXTERN __global__ __launch_bounds__(GKR_DIM_REDUCING_FORWARD_TOWER_BLOCK, 4) void ab_gkr_dim_reducing_forward_tower_lookup_e4_kernel(
-    const __grid_constant__ gkr_dim_reducing_forward_tower_lookup_batch<e4> batch) {
-  gkr_dim_reducing_forward_tower_lookup(batch);
+EXTERN __global__ __launch_bounds__(GKR_DIM_REDUCING_FORWARD_TOWER_BLOCK, 4) void ab_gkr_dim_reducing_forward_tower_e4_kernel(
+    const __grid_constant__ gkr_dim_reducing_forward_tower_batch<e4> batch) {
+  gkr_dim_reducing_forward_tower(batch);
 }
 
 } // namespace airbender::gkr::forward

--- a/gpu/gkr/native/gkr/forward/fwd_vm.cuh
+++ b/gpu/gkr/native/gkr/forward/fwd_vm.cuh
@@ -24,6 +24,12 @@ constexpr u32 FWD_VM_REDUCTION_PAIR_CAP = 5;
 constexpr u32 FWD_VM_REDUCTION_PAIR_PAIRWISE2 = 0;
 constexpr u32 FWD_VM_REDUCTION_PAIR_LOOKUP = 1;
 
+// The Rust side encodes both the VM's fused-reduction prefix and the dim-reducing tower
+// batch with the single vocabulary in vm/desc.rs; pin the two native copies.
+static_assert(FWD_VM_REDUCTION_PAIR_CAP == GKR_DIM_REDUCING_FORWARD_TOWER_PAIR_CAP, "reduction-pair cap drift");
+static_assert(FWD_VM_REDUCTION_PAIR_PAIRWISE2 == GKR_DIM_REDUCING_FORWARD_TOWER_PAIRWISE2, "reduction-pair kind drift");
+static_assert(FWD_VM_REDUCTION_PAIR_LOOKUP == GKR_DIM_REDUCING_FORWARD_TOWER_LOOKUP, "reduction-pair kind drift");
+
 static_assert(FWD_VM_SOURCE_WINDOW_COUNT == 1u << FWD_VM_SOURCE_WINDOW_BITS, "source-window field width drift");
 static_assert(FWD_VM_DST_SLOT_COUNT == 1u << FWD_VM_DST_SLOT_BITS, "destination-slot field width drift");
 

--- a/gpu/gkr/native/gkr/support/descriptors.cuh
+++ b/gpu/gkr/native/gkr/support/descriptors.cuh
@@ -170,25 +170,30 @@ static_assert(__builtin_offsetof(gkr_dim_reducing_continuation_batch_compact<e4>
               "continuation descriptor offsets drift");
 static_assert(sizeof(gkr_dim_reducing_continuation_batch_compact<e4>) + 2 * sizeof(u32) <= 32764, "continuation kernel parameters exceed CUDA limit");
 
-// Tower batches: one per slot (no cross-slot batching). Each tower kernel consumes a single slot's
-// contiguous input row range (B = GKR_DIM_REDUCING_FORWARD_TOWER_BLOCK elements per block) and
-// drives it down `round_count` halving levels through shared memory, writing each intermediate
-// level to DRAM for the backward pass.
-template <typename E> struct gkr_dim_reducing_forward_tower_pairwise_batch {
-  const E *input;
-  E *round_outputs[GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS];
-  u32 input_len;
-  u32 round_count;
+// Merged tower batch (blockIdx.y selects the pair). A pair's two streams are either two
+// independent product towers (PAIRWISE2) or one lookup tower's num/den (LOOKUP).
+static constexpr unsigned GKR_DIM_REDUCING_FORWARD_TOWER_PAIR_CAP = 5;
+static constexpr unsigned GKR_DIM_REDUCING_FORWARD_TOWER_PAIRWISE2 = 0;
+static constexpr unsigned GKR_DIM_REDUCING_FORWARD_TOWER_LOOKUP = 1;
+
+template <typename E> struct gkr_dim_reducing_forward_tower_pair {
+  const E *input[2];
+  E *round_outputs[GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS][2];
+  u32 kind;
+  u32 reserved;
 };
 
-template <typename E> struct gkr_dim_reducing_forward_tower_lookup_batch {
-  const E *input_num;
-  const E *input_den;
-  E *round_outputs_num[GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS];
-  E *round_outputs_den[GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS];
+template <typename E> struct gkr_dim_reducing_forward_tower_batch {
+  gkr_dim_reducing_forward_tower_pair<E> pairs[GKR_DIM_REDUCING_FORWARD_TOWER_PAIR_CAP];
+  u32 pair_count;
   u32 input_len;
   u32 round_count;
+  u32 reserved;
 };
+
+static_assert(sizeof(gkr_dim_reducing_forward_tower_pair<e4>) == 152, "tower pair ABI size drift");
+static_assert(sizeof(gkr_dim_reducing_forward_tower_batch<e4>) == 776, "tower batch ABI size drift");
+static_assert(alignof(gkr_dim_reducing_forward_tower_batch<e4>) == 8, "tower batch ABI alignment drift");
 
 struct gkr_forward_setup_generic_lookup_descriptor {
   const bf *input;

--- a/gpu/gkr/native/gkr/support/lookup_helpers.cuh
+++ b/gpu/gkr/native/gkr/support/lookup_helpers.cuh
@@ -97,19 +97,23 @@ template <typename E> DEVICE_FORCEINLINE void gkr_eval_lookup_pair(const E a, co
   den = E::mul(b, d);
 }
 
-// Pairwise-product tower: each block consumes B = blockDim.x contiguous input rows (or fewer, in
-// the single-block tail) and fuses up to log2(B) halving rounds in shared memory. Every round's
-// output is also written to DRAM for backward consumption.
-template <typename E> DEVICE_FORCEINLINE void gkr_dim_reducing_forward_tower_pairwise(const gkr_dim_reducing_forward_tower_pairwise_batch<E> &batch) {
-  extern __shared__ E smem_pairwise[];
+// Each block consumes B = blockDim.x contiguous input rows of pair blockIdx.y and fuses up to
+// log2(B) halving rounds in shared memory. Every round's output is also written to DRAM for
+// backward consumption.
+template <typename E> DEVICE_FORCEINLINE void gkr_dim_reducing_forward_tower(const gkr_dim_reducing_forward_tower_batch<E> &batch) {
+  extern __shared__ E smem_tower[];
+  E *smem_a = smem_tower;
+  E *smem_b = smem_tower + blockDim.x;
 
+  const gkr_dim_reducing_forward_tower_pair<E> &pair = batch.pairs[blockIdx.y];
   const unsigned tid = threadIdx.x;
   const unsigned bid = blockIdx.x;
   const unsigned base = bid * blockDim.x;
 
-  // Round-0 load from DRAM to shmem. Threads outside the valid tail range idle.
-  if (base + tid < batch.input_len)
-    smem_pairwise[tid] = load<E, ld_modifier::cs>(batch.input, base + tid);
+  if (base + tid < batch.input_len) {
+    smem_a[tid] = load<E, ld_modifier::cs>(pair.input[0], base + tid);
+    smem_b[tid] = load<E, ld_modifier::cs>(pair.input[1], base + tid);
+  }
   __syncthreads();
 
   // For body launches, cur_len == blockDim.x == B. For the single-block tail where
@@ -117,59 +121,25 @@ template <typename E> DEVICE_FORCEINLINE void gkr_dim_reducing_forward_tower_pai
   unsigned cur_len = blockDim.x < batch.input_len ? blockDim.x : batch.input_len;
   for (unsigned r = 0; r < batch.round_count; ++r) {
     cur_len >>= 1;
-    E out;
+    E out_a;
+    E out_b;
     const bool active = tid < cur_len;
     if (active) {
-      const E lhs = smem_pairwise[2 * tid];
-      const E rhs = smem_pairwise[2 * tid + 1];
-      gkr_eval_product(lhs, rhs, out);
-      // Coalesced DRAM write — block b's slice of this level is [b*cur_len, (b+1)*cur_len).
-      store<E, st_modifier::cs>(batch.round_outputs[r], out, bid * cur_len + tid);
+      if (pair.kind == GKR_DIM_REDUCING_FORWARD_TOWER_PAIRWISE2) {
+        gkr_eval_product(smem_a[2 * tid], smem_a[2 * tid + 1], out_a);
+        gkr_eval_product(smem_b[2 * tid], smem_b[2 * tid + 1], out_b);
+      } else {
+        gkr_eval_lookup_pair(smem_a[2 * tid], smem_b[2 * tid], smem_a[2 * tid + 1], smem_b[2 * tid + 1], out_a, out_b);
+      }
+      store<E, st_modifier::cs>(pair.round_outputs[r][0], out_a, bid * cur_len + tid);
+      store<E, st_modifier::cs>(pair.round_outputs[r][1], out_b, bid * cur_len + tid);
     }
     __syncthreads(); // Read phase complete; safe to overwrite shmem.
-    if (active)
-      smem_pairwise[tid] = out;
+    if (active) {
+      smem_a[tid] = out_a;
+      smem_b[tid] = out_b;
+    }
     __syncthreads(); // Next round may read a wider slice; ensure all writes visible.
-  }
-}
-
-// Lookup-pair tower: same shape as pairwise but with num/den shmem buffers side by side.
-template <typename E> DEVICE_FORCEINLINE void gkr_dim_reducing_forward_tower_lookup(const gkr_dim_reducing_forward_tower_lookup_batch<E> &batch) {
-  extern __shared__ E smem_lookup[];
-  E *smem_num = smem_lookup;
-  E *smem_den = smem_lookup + blockDim.x;
-
-  const unsigned tid = threadIdx.x;
-  const unsigned bid = blockIdx.x;
-  const unsigned base = bid * blockDim.x;
-
-  if (base + tid < batch.input_len) {
-    smem_num[tid] = load<E, ld_modifier::cs>(batch.input_num, base + tid);
-    smem_den[tid] = load<E, ld_modifier::cs>(batch.input_den, base + tid);
-  }
-  __syncthreads();
-
-  unsigned cur_len = blockDim.x < batch.input_len ? blockDim.x : batch.input_len;
-  for (unsigned r = 0; r < batch.round_count; ++r) {
-    cur_len >>= 1;
-    E out_num;
-    E out_den;
-    const bool active = tid < cur_len;
-    if (active) {
-      const E a = smem_num[2 * tid];
-      const E b = smem_den[2 * tid];
-      const E c = smem_num[2 * tid + 1];
-      const E d = smem_den[2 * tid + 1];
-      gkr_eval_lookup_pair(a, b, c, d, out_num, out_den);
-      store<E, st_modifier::cs>(batch.round_outputs_num[r], out_num, bid * cur_len + tid);
-      store<E, st_modifier::cs>(batch.round_outputs_den[r], out_den, bid * cur_len + tid);
-    }
-    __syncthreads();
-    if (active) {
-      smem_num[tid] = out_num;
-      smem_den[tid] = out_den;
-    }
-    __syncthreads();
   }
 }
 

--- a/gpu/gkr/src/forward/dimension_reducing.rs
+++ b/gpu/gkr/src/forward/dimension_reducing.rs
@@ -1,3 +1,4 @@
+use super::vm::desc::{REDUCTION_PAIR_CAP, REDUCTION_PAIR_LOOKUP, REDUCTION_PAIR_PAIRWISE2};
 use super::*;
 
 #[derive(Clone, Copy)]
@@ -111,7 +112,6 @@ where
 pub(super) fn schedule_prepared_dimension_reduction_forward<E>(
     prepared: &PreparedDimensionReductionForward<E>,
     start_round: u32,
-    tracing_ranges: &mut Vec<Range>,
     context: &ProverContext,
 ) -> CudaResult<()>
 where
@@ -125,129 +125,115 @@ where
     let stream = context.get_exec_stream();
     let slot_count = prepared.slot_initial_inputs.len();
     assert_eq!(prepared.slot_output_types.len(), slot_count);
+
+    // A pairwise OutputType contributes its two slots as one pair's (a, b)
+    // streams; a lookup slot contributes its (num, den).
+    let mut pair_slots: Vec<(u32, [usize; 2])> = Vec::new();
     let mut slot_idx = 0usize;
     while slot_idx < slot_count {
-        let range_type = prepared.slot_output_types[slot_idx];
-        let range_end = prepared.slot_output_types[slot_idx..]
-            .iter()
-            .position(|kind| *kind != range_type)
-            .map(|offset| slot_idx + offset)
-            .unwrap_or(slot_count);
-        let range = Range::new(format!(
-            "gkr.forward.dimension_reduction.tower.{range_type:?}"
-        ))?;
-        range.start(stream)?;
-
-        for slot in slot_idx..range_end {
-            let mut current_input = if start_round == 0 {
-                prepared.slot_initial_inputs[slot]
-            } else {
-                output_as_input(prepared.per_round_slot_outputs[start_round as usize - 1][slot])
-            };
-            let mut current_input_log_2 = prepared.initial_trace_log_2 - start_round;
-            let mut round = start_round;
-            while round < prepared.total_rounds {
-                let chunk_rounds =
-                    (prepared.total_rounds - round).min(GKR_DIM_REDUCING_FORWARD_TOWER_LOG_BLOCK);
-                dispatch_tower_slot_launch(
-                    current_input,
-                    slot,
-                    round,
-                    chunk_rounds,
-                    1u32 << current_input_log_2,
-                    &prepared.per_round_slot_outputs,
-                    stream,
-                )?;
-                round += chunk_rounds;
-                current_input_log_2 -= chunk_rounds;
-                if round < prepared.total_rounds {
-                    current_input =
-                        output_as_input(prepared.per_round_slot_outputs[round as usize - 1][slot]);
-                }
+        match prepared.slot_initial_inputs[slot_idx] {
+            LoweredSlotInitialInput::PairwiseProduct { .. } => {
+                let partner = slot_idx + 1;
+                assert!(
+                    partner < slot_count
+                        && prepared.slot_output_types[partner]
+                            == prepared.slot_output_types[slot_idx]
+                        && matches!(
+                            prepared.slot_initial_inputs[partner],
+                            LoweredSlotInitialInput::PairwiseProduct { .. }
+                        ),
+                    "pairwise reduction type must own exactly two adjacent slots"
+                );
+                pair_slots.push((REDUCTION_PAIR_PAIRWISE2, [slot_idx, partner]));
+                slot_idx += 2;
+            }
+            LoweredSlotInitialInput::LookupPair { .. } => {
+                pair_slots.push((REDUCTION_PAIR_LOOKUP, [slot_idx, slot_idx]));
+                slot_idx += 1;
             }
         }
+    }
+    assert!(pair_slots.len() <= REDUCTION_PAIR_CAP);
 
-        range.end(stream)?;
-        tracing_ranges.push(range);
-        slot_idx = range_end;
+    let mut round = start_round;
+    let mut input_log_2 = prepared.initial_trace_log_2 - start_round;
+    while round < prepared.total_rounds {
+        let chunk_rounds =
+            (prepared.total_rounds - round).min(GKR_DIM_REDUCING_FORWARD_TOWER_LOG_BLOCK);
+        let mut batch = GpuGKRDimensionReducingForwardTowerBatch::<E> {
+            pair_count: pair_slots.len() as u32,
+            input_len: 1u32 << input_log_2,
+            round_count: chunk_rounds,
+            ..Default::default()
+        };
+        for (pair, &(kind, slots)) in batch.pairs.iter_mut().zip(&pair_slots) {
+            pair.kind = kind;
+            pair.input = pair_input_streams(prepared, round, kind, slots);
+            for local_r in 0..chunk_rounds as usize {
+                pair.round_outputs[local_r] =
+                    pair_output_streams(prepared, round as usize + local_r, kind, slots);
+            }
+        }
+        launch_dimension_reducing_forward_tower(batch, stream)?;
+        round += chunk_rounds;
+        input_log_2 -= chunk_rounds;
     }
     Ok(())
 }
 
-fn output_as_input<E>(output: LoweredSlotOutput<E>) -> LoweredSlotInitialInput<E> {
-    match output {
-        LoweredSlotOutput::PairwiseProduct { output } => {
-            LoweredSlotInitialInput::PairwiseProduct { input: output }
+fn pair_input_streams<E>(
+    prepared: &PreparedDimensionReductionForward<E>,
+    round: u32,
+    kind: u32,
+    slots: [usize; 2],
+) -> [*const E; 2] {
+    if round == 0 {
+        match kind {
+            REDUCTION_PAIR_PAIRWISE2 => slots.map(|slot| {
+                let LoweredSlotInitialInput::PairwiseProduct { input } =
+                    prepared.slot_initial_inputs[slot]
+                else {
+                    panic!("tower slot {slot} changed kind");
+                };
+                input
+            }),
+            _ => {
+                let LoweredSlotInitialInput::LookupPair { num, den } =
+                    prepared.slot_initial_inputs[slots[0]]
+                else {
+                    panic!("tower slot {} changed kind", slots[0]);
+                };
+                [num, den]
+            }
         }
-        LoweredSlotOutput::LookupPair {
-            output_num,
-            output_den,
-        } => LoweredSlotInitialInput::LookupPair {
-            num: output_num,
-            den: output_den,
-        },
+    } else {
+        pair_output_streams(prepared, round as usize - 1, kind, slots).map(|ptr| ptr as *const E)
     }
 }
 
-fn dispatch_tower_slot_launch<E>(
-    slot_input: LoweredSlotInitialInput<E>,
-    slot_idx: usize,
-    chunk_start_round: u32,
-    chunk_rounds: u32,
-    chunk_input_len: u32,
-    per_round_slot_outputs: &[Vec<LoweredSlotOutput<E>>],
-    stream: &era_cudart::stream::CudaStream,
-) -> CudaResult<()>
-where
-    E: crate::ForwardKernels,
-{
-    match slot_input {
-        LoweredSlotInitialInput::PairwiseProduct { input } => {
-            let mut batch = GpuGKRDimensionReducingForwardTowerPairwiseBatch::<E> {
-                input,
-                input_len: chunk_input_len,
-                round_count: chunk_rounds,
-                ..Default::default()
+fn pair_output_streams<E>(
+    prepared: &PreparedDimensionReductionForward<E>,
+    round: usize,
+    kind: u32,
+    slots: [usize; 2],
+) -> [*mut E; 2] {
+    let round_outputs = &prepared.per_round_slot_outputs[round];
+    match kind {
+        REDUCTION_PAIR_PAIRWISE2 => slots.map(|slot| {
+            let LoweredSlotOutput::PairwiseProduct { output } = round_outputs[slot] else {
+                panic!("tower slot {slot} changed kind at round {round}");
             };
-            for local_r in 0..chunk_rounds as usize {
-                let round_idx = chunk_start_round as usize + local_r;
-                match per_round_slot_outputs[round_idx][slot_idx] {
-                    LoweredSlotOutput::PairwiseProduct { output } => {
-                        batch.round_outputs[local_r] = output;
-                    }
-                    LoweredSlotOutput::LookupPair { .. } => panic!(
-                        "tower slot {} changed kind between round 0 and round {}",
-                        slot_idx, round_idx
-                    ),
-                }
-            }
-            launch_dimension_reducing_forward_tower_pairwise(&batch, stream)
-        }
-        LoweredSlotInitialInput::LookupPair { num, den } => {
-            let mut batch = GpuGKRDimensionReducingForwardTowerLookupBatch::<E> {
-                input_num: num,
-                input_den: den,
-                input_len: chunk_input_len,
-                round_count: chunk_rounds,
-                ..Default::default()
+            output
+        }),
+        _ => {
+            let LoweredSlotOutput::LookupPair {
+                output_num,
+                output_den,
+            } = round_outputs[slots[0]]
+            else {
+                panic!("tower slot {} changed kind at round {round}", slots[0]);
             };
-            for local_r in 0..chunk_rounds as usize {
-                let round_idx = chunk_start_round as usize + local_r;
-                match per_round_slot_outputs[round_idx][slot_idx] {
-                    LoweredSlotOutput::LookupPair {
-                        output_num,
-                        output_den,
-                    } => {
-                        batch.round_outputs_num[local_r] = output_num;
-                        batch.round_outputs_den[local_r] = output_den;
-                    }
-                    LoweredSlotOutput::PairwiseProduct { .. } => panic!(
-                        "tower slot {} changed kind between round 0 and round {}",
-                        slot_idx, round_idx
-                    ),
-                }
-            }
-            launch_dimension_reducing_forward_tower_lookup(&batch, stream)
+            [output_num, output_den]
         }
     }
 }

--- a/gpu/gkr/src/forward/kernels/mod.rs
+++ b/gpu/gkr/src/forward/kernels/mod.rs
@@ -1,4 +1,4 @@
-use std::ptr::null;
+use std::ptr::{null, null_mut};
 
 use era_cudart::execution::{CudaLaunchConfig, KernelFunction};
 use era_cudart::result::CudaResult;
@@ -6,148 +6,105 @@ use era_cudart::stream::CudaStream;
 use era_cudart::{cuda_kernel_declaration, cuda_kernel_signature_arguments_and_function};
 use gpu_core::primitives::field::E4;
 
+use super::vm::desc::REDUCTION_PAIR_CAP;
+
 pub(crate) const GKR_DIM_REDUCING_FORWARD_TOWER_LOG_BLOCK: u32 = 8;
 pub(crate) const GKR_DIM_REDUCING_FORWARD_TOWER_BLOCK: u32 =
     1 << GKR_DIM_REDUCING_FORWARD_TOWER_LOG_BLOCK;
 pub(crate) const GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS: usize =
     GKR_DIM_REDUCING_FORWARD_TOWER_LOG_BLOCK as usize;
 
+/// `kind` is `vm::desc::REDUCTION_PAIR_*`: PAIRWISE2 folds two independent
+/// product towers, LOOKUP folds one lookup tower's (num, den).
 #[repr(C)]
-pub(crate) struct GpuGKRDimensionReducingForwardTowerPairwiseBatch<E> {
-    pub(crate) input: *const E,
-    pub(crate) round_outputs: [*mut E; GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS],
-    pub(crate) input_len: u32,
-    pub(crate) round_count: u32,
+pub(crate) struct GpuGKRDimensionReducingForwardTowerPair<E> {
+    pub(crate) input: [*const E; 2],
+    pub(crate) round_outputs: [[*mut E; 2]; GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS],
+    pub(crate) kind: u32,
+    pub(crate) reserved: u32,
 }
 
-impl<E> Copy for GpuGKRDimensionReducingForwardTowerPairwiseBatch<E> {}
+impl<E> Copy for GpuGKRDimensionReducingForwardTowerPair<E> {}
 
-impl<E> Clone for GpuGKRDimensionReducingForwardTowerPairwiseBatch<E> {
+impl<E> Clone for GpuGKRDimensionReducingForwardTowerPair<E> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<E> Default for GpuGKRDimensionReducingForwardTowerPairwiseBatch<E> {
+impl<E> Default for GpuGKRDimensionReducingForwardTowerPair<E> {
     fn default() -> Self {
         Self {
-            input: null(),
-            round_outputs: [null::<E>().cast_mut(); GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS],
-            input_len: 0,
-            round_count: 0,
+            input: [null(); 2],
+            round_outputs: [[null_mut(); 2]; GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS],
+            kind: 0,
+            reserved: 0,
         }
     }
 }
-
-unsafe impl<E> Send for GpuGKRDimensionReducingForwardTowerPairwiseBatch<E> {}
-unsafe impl<E> Sync for GpuGKRDimensionReducingForwardTowerPairwiseBatch<E> {}
 
 #[repr(C)]
-pub(crate) struct GpuGKRDimensionReducingForwardTowerLookupBatch<E> {
-    pub(crate) input_num: *const E,
-    pub(crate) input_den: *const E,
-    pub(crate) round_outputs_num: [*mut E; GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS],
-    pub(crate) round_outputs_den: [*mut E; GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS],
+pub(crate) struct GpuGKRDimensionReducingForwardTowerBatch<E> {
+    pub(crate) pairs: [GpuGKRDimensionReducingForwardTowerPair<E>; REDUCTION_PAIR_CAP],
+    pub(crate) pair_count: u32,
     pub(crate) input_len: u32,
     pub(crate) round_count: u32,
+    pub(crate) reserved: u32,
 }
 
-impl<E> Copy for GpuGKRDimensionReducingForwardTowerLookupBatch<E> {}
-
-impl<E> Clone for GpuGKRDimensionReducingForwardTowerLookupBatch<E> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<E> Default for GpuGKRDimensionReducingForwardTowerLookupBatch<E> {
+impl<E> Default for GpuGKRDimensionReducingForwardTowerBatch<E> {
     fn default() -> Self {
         Self {
-            input_num: null(),
-            input_den: null(),
-            round_outputs_num: [null::<E>().cast_mut(); GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS],
-            round_outputs_den: [null::<E>().cast_mut(); GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS],
+            pairs: [GpuGKRDimensionReducingForwardTowerPair::default(); REDUCTION_PAIR_CAP],
+            pair_count: 0,
             input_len: 0,
             round_count: 0,
+            reserved: 0,
         }
     }
 }
 
-unsafe impl<E> Send for GpuGKRDimensionReducingForwardTowerLookupBatch<E> {}
-unsafe impl<E> Sync for GpuGKRDimensionReducingForwardTowerLookupBatch<E> {}
+/// ABI size guards, paired with the CUDA `static_assert`s in `descriptors.cuh`.
+const _: () = {
+    assert!(core::mem::size_of::<GpuGKRDimensionReducingForwardTowerPair<E4>>() == 152);
+    assert!(core::mem::size_of::<GpuGKRDimensionReducingForwardTowerBatch<E4>>() == 776);
+    assert!(core::mem::align_of::<GpuGKRDimensionReducingForwardTowerBatch<E4>>() == 8);
+};
 
 cuda_kernel_signature_arguments_and_function!(
-    pub(crate) GpuGKRDimensionReducingForwardTowerPairwise<T>,
-    batch: GpuGKRDimensionReducingForwardTowerPairwiseBatch<T>,
-);
-
-cuda_kernel_signature_arguments_and_function!(
-    pub(crate) GpuGKRDimensionReducingForwardTowerLookup<T>,
-    batch: GpuGKRDimensionReducingForwardTowerLookupBatch<T>,
+    pub(crate) GpuGKRDimensionReducingForwardTower<T>,
+    batch: GpuGKRDimensionReducingForwardTowerBatch<T>,
 );
 
 cuda_kernel_declaration!(pub(crate)
-    ab_gkr_dim_reducing_forward_tower_pairwise_e4_kernel(
-        batch: GpuGKRDimensionReducingForwardTowerPairwiseBatch<E4>,
+    ab_gkr_dim_reducing_forward_tower_e4_kernel(
+        batch: GpuGKRDimensionReducingForwardTowerBatch<E4>,
     )
 );
 
-cuda_kernel_declaration!(pub(crate)
-    ab_gkr_dim_reducing_forward_tower_lookup_e4_kernel(
-        batch: GpuGKRDimensionReducingForwardTowerLookupBatch<E4>,
-    )
-);
-
-pub(crate) fn launch_dimension_reducing_forward_tower_pairwise<E: crate::ForwardKernels>(
-    batch: &GpuGKRDimensionReducingForwardTowerPairwiseBatch<E>,
+pub(crate) fn launch_dimension_reducing_forward_tower<E: crate::ForwardKernels>(
+    batch: GpuGKRDimensionReducingForwardTowerBatch<E>,
     stream: &CudaStream,
 ) -> CudaResult<()> {
     let block_size = GKR_DIM_REDUCING_FORWARD_TOWER_BLOCK;
     let input_len = batch.input_len;
-    assert!(input_len > 0, "tower pairwise batch has empty input");
+    assert!(input_len > 0, "tower batch has empty input");
     let config = CudaLaunchConfig::builder()
-        .grid_dim(input_len.div_ceil(block_size).max(1))
-        .block_dim(block_size)
-        .dynamic_smem_bytes(block_size as usize * std::mem::size_of::<E>())
-        .stream(stream)
-        .build();
-    let args = GpuGKRDimensionReducingForwardTowerPairwiseArguments::new(*batch);
-    GpuGKRDimensionReducingForwardTowerPairwiseFunction(
-        E::DIMENSION_REDUCING_FORWARD_TOWER_PAIRWISE,
-    )
-    .launch(&config, &args)
-}
-
-pub(crate) fn launch_dimension_reducing_forward_tower_lookup<E: crate::ForwardKernels>(
-    batch: &GpuGKRDimensionReducingForwardTowerLookupBatch<E>,
-    stream: &CudaStream,
-) -> CudaResult<()> {
-    let block_size = GKR_DIM_REDUCING_FORWARD_TOWER_BLOCK;
-    let input_len = batch.input_len;
-    assert!(input_len > 0, "tower lookup batch has empty input");
-    let config = CudaLaunchConfig::builder()
-        .grid_dim(input_len.div_ceil(block_size).max(1))
+        .grid_dim((input_len.div_ceil(block_size).max(1), batch.pair_count))
         .block_dim(block_size)
         .dynamic_smem_bytes(2 * block_size as usize * std::mem::size_of::<E>())
         .stream(stream)
         .build();
-    let args = GpuGKRDimensionReducingForwardTowerLookupArguments::new(*batch);
-    GpuGKRDimensionReducingForwardTowerLookupFunction(E::DIMENSION_REDUCING_FORWARD_TOWER_LOOKUP)
+    let args = GpuGKRDimensionReducingForwardTowerArguments::new(batch);
+    GpuGKRDimensionReducingForwardTowerFunction(E::DIMENSION_REDUCING_FORWARD_TOWER)
         .launch(&config, &args)
 }
 
 pub(crate) trait ForwardKernels: Copy + Sized {
-    const DIMENSION_REDUCING_FORWARD_TOWER_PAIRWISE:
-        GpuGKRDimensionReducingForwardTowerPairwiseSignature<Self>;
-    const DIMENSION_REDUCING_FORWARD_TOWER_LOOKUP:
-        GpuGKRDimensionReducingForwardTowerLookupSignature<Self>;
+    const DIMENSION_REDUCING_FORWARD_TOWER: GpuGKRDimensionReducingForwardTowerSignature<Self>;
 }
 
 impl ForwardKernels for E4 {
-    const DIMENSION_REDUCING_FORWARD_TOWER_PAIRWISE:
-        GpuGKRDimensionReducingForwardTowerPairwiseSignature<Self> =
-        ab_gkr_dim_reducing_forward_tower_pairwise_e4_kernel;
-    const DIMENSION_REDUCING_FORWARD_TOWER_LOOKUP:
-        GpuGKRDimensionReducingForwardTowerLookupSignature<Self> =
-        ab_gkr_dim_reducing_forward_tower_lookup_e4_kernel;
+    const DIMENSION_REDUCING_FORWARD_TOWER: GpuGKRDimensionReducingForwardTowerSignature<Self> =
+        ab_gkr_dim_reducing_forward_tower_e4_kernel;
 }

--- a/gpu/gkr/src/forward/mod.rs
+++ b/gpu/gkr/src/forward/mod.rs
@@ -214,7 +214,6 @@ pub fn schedule_forward_pass(
     schedule_prepared_dimension_reduction_forward(
         &prepared_reductions,
         vm::desc::FUSED_REDUCTION_ROUNDS as u32,
-        &mut tracing_ranges,
         context,
     )?;
     dimension_reduction_range.end(stream)?;

--- a/gpu/gkr/src/forward/tests/mod.rs
+++ b/gpu/gkr/src/forward/tests/mod.rs
@@ -120,9 +120,7 @@ fn dimension_reducing_forward_tower_matches_reference() {
         &context,
     )
     .unwrap();
-    let mut tracing_ranges = Vec::new();
-    schedule_prepared_dimension_reduction_forward(&prepared, 0, &mut tracing_ranges, &context)
-        .unwrap();
+    schedule_prepared_dimension_reduction_forward(&prepared, 0, &context).unwrap();
 
     let stream = context.get_exec_stream();
     for (round_idx, outputs) in prepared.per_round_slot_outputs.iter().enumerate().skip(7) {
@@ -146,8 +144,7 @@ fn dimension_reducing_forward_tower_matches_reference() {
             }
         }
     }
-    schedule_prepared_dimension_reduction_forward(&prepared, 7, &mut tracing_ranges, &context)
-        .unwrap();
+    schedule_prepared_dimension_reduction_forward(&prepared, 7, &context).unwrap();
     context.get_exec_stream().synchronize().unwrap();
     let final_layer_idx = prepared.final_layer_idx;
     let dim_reducing_inputs = prepared.dimension_reduction_description;


### PR DESCRIPTION
## What ❔

Merge the forward GKR dimension-reducing tower kernels (per-slot pairwise/lookup) into one batched kernel; `blockIdx.y` selects the pair, so the post-VM remainder is one launch per ≤8-round chunk — 2 launches in production, down from 10–14.

## Why ❔

Finishes off the forward pass: fewer, concurrent launches (add_sub 2^24 tower window 61.7 µs → 25.9 µs) and simpler scheduling; the pair kind vocabulary and cap are shared with the forward VM's fused-reduction prefix and pinned by static_asserts on both sides of the ABI.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
