### PR TITLE
perf(gpu_gkr): reconstruct base-layer-claims eq inline and drop CUB from the phase

### DIFF
--- a/gpu/gkr/native/gkr/backward/dim_reducing.cu
+++ b/gpu/gkr/native/gkr/backward/dim_reducing.cu
@@ -51,7 +51,18 @@ EXTERN __global__ void ab_gkr_dim_reducing_build_eq_values_from_group_tables_e4_
 EXTERN __global__ void ab_gkr_dim_reducing_trace_holder_block_partials_e4_kernel(const bf *raw_values, const e4 *eq_values, e4 *block_partials,
                                                                                  const unsigned trace_len, const unsigned column_start,
                                                                                  const unsigned chunk_cols, const unsigned blocks_count) {
-  gkr_trace_holder_block_partials(raw_values, eq_values, block_partials, trace_len, column_start, chunk_cols, blocks_count);
+  gkr_trace_holder_block_partials(raw_values, gkr_trace_holder_eq_dense<e4>{eq_values}, block_partials, trace_len, column_start, chunk_cols, blocks_count);
+}
+
+EXTERN __global__ void ab_gkr_dim_reducing_trace_holder_block_partials_eq_inline_e4_kernel(const bf *raw_values, const e4 *eq_low, const gkr_eq_sizes sizes,
+                                                                                           e4 *block_partials, const unsigned trace_len,
+                                                                                           const unsigned column_start, const unsigned chunk_cols,
+                                                                                           const unsigned blocks_count) {
+  gkr_trace_holder_block_partials(raw_values, gkr_eq_inline_reader<e4>{eq_low, sizes}, block_partials, trace_len, column_start, chunk_cols, blocks_count);
+}
+
+EXTERN __global__ void ab_gkr_dim_reducing_trace_holder_column_sums_e4_kernel(const e4 *block_partials, e4 *column_sums, const unsigned blocks_count) {
+  gkr_trace_holder_column_sums(block_partials, column_sums, blocks_count);
 }
 
 EXTERN __global__ void ab_gkr_dim_reducing_round0_batched_compact_e4_kernel(const __grid_constant__ gkr_dim_reducing_round0_batch_compact<e4> batch,

--- a/gpu/gkr/native/gkr/support/eq_inline.cuh
+++ b/gpu/gkr/native/gkr/support/eq_inline.cuh
@@ -25,10 +25,29 @@ template <typename E> DEVICE_FORCEINLINE E gkr_compute_eq_inline(const E *__rest
   return acc;
 }
 
+// `row` must be 4-aligned. With `sizes.low >= 2` the pack shares its high-slab
+// indices, so the high product is computed once; the warp-uniform fallback
+// covers packs that would straddle the low table.
 template <typename E> struct gkr_eq_inline_reader {
   const E *eq_low;
   gkr_eq_sizes sizes;
-  DEVICE_FORCEINLINE E operator()(const unsigned row) const { return gkr_compute_eq_inline(eq_low, sizes, row); }
+  DEVICE_FORCEINLINE void load4(const unsigned row, E (&eq)[4]) const {
+    if (sizes.low >= 2) {
+      const unsigned shift1 = sizes.low;
+      const unsigned shift0 = sizes.low + sizes.high[1];
+      const unsigned hi0 = (row >> shift0) & ((1u << sizes.high[0]) - 1u);
+      const unsigned hi1 = (row >> shift1) & ((1u << sizes.high[1]) - 1u);
+      const unsigned lo = row & ((1u << sizes.low) - 1u);
+      const E hi = E::mul(load<E, ld_modifier::ca>(&ab_gkr_eq_high[0][0], hi0), load<E, ld_modifier::ca>(&ab_gkr_eq_high[1][0], hi1));
+#pragma unroll
+      for (unsigned i = 0; i < 4; ++i)
+        eq[i] = E::mul(hi, load<E, ld_modifier::cs>(eq_low, lo + i));
+    } else {
+#pragma unroll
+      for (unsigned i = 0; i < 4; ++i)
+        eq[i] = gkr_compute_eq_inline(eq_low, sizes, row + i);
+    }
+  }
 };
 
 // `gkr_compute_eq_inline` variant that reads high slabs from caller-supplied

--- a/gpu/gkr/native/gkr/support/eq_inline.cuh
+++ b/gpu/gkr/native/gkr/support/eq_inline.cuh
@@ -25,6 +25,12 @@ template <typename E> DEVICE_FORCEINLINE E gkr_compute_eq_inline(const E *__rest
   return acc;
 }
 
+template <typename E> struct gkr_eq_inline_reader {
+  const E *eq_low;
+  gkr_eq_sizes sizes;
+  DEVICE_FORCEINLINE E operator()(const unsigned row) const { return gkr_compute_eq_inline(eq_low, sizes, row); }
+};
+
 // `gkr_compute_eq_inline` variant that reads high slabs from caller-supplied
 // global pointers rather than the single `ab_gkr_eq_high` constant. Used by
 // WHIR's batched accumulator where every query needs its own factored-eq state.

--- a/gpu/gkr/native/gkr/support/kernel_helpers.cuh
+++ b/gpu/gkr/native/gkr/support/kernel_helpers.cuh
@@ -206,7 +206,11 @@ struct __align__(16) gkr_trace_holder_bf4 {
 
 template <typename E> struct gkr_trace_holder_eq_dense {
   const E *eq_values;
-  DEVICE_FORCEINLINE E operator()(const unsigned row) const { return load<E, ld_modifier::cs>(eq_values, row); }
+  DEVICE_FORCEINLINE void load4(const unsigned row, E (&eq)[4]) const {
+#pragma unroll
+    for (unsigned i = 0; i < 4; ++i)
+      eq[i] = load<E, ld_modifier::cs>(eq_values, row + i);
+  }
 };
 
 template <typename E, typename EqFn>
@@ -230,10 +234,8 @@ DEVICE_FORCEINLINE void gkr_trace_holder_block_partials(const bf *raw_values, co
 
   for (unsigned packed_row = packed_gid; packed_row < packed_trace_len; packed_row += packed_stride) {
     const unsigned row = packed_row << 2;
-    const E eq0 = eq_fn(row);
-    const E eq1 = eq_fn(row + 1);
-    const E eq2 = eq_fn(row + 2);
-    const E eq3 = eq_fn(row + 3);
+    E eq[4];
+    eq_fn.load4(row, eq);
 #pragma unroll
     for (unsigned local_col = 0; local_col < GKR_TRACE_HOLDER_PARTIALS_COLUMNS_PER_CHUNK; ++local_col) {
       if (local_col >= chunk_cols)
@@ -241,10 +243,10 @@ DEVICE_FORCEINLINE void gkr_trace_holder_block_partials(const bf *raw_values, co
       const unsigned column = column_start + local_col;
       const size_t row_offset = static_cast<size_t>(column) * trace_len + row;
       const auto values = load<gkr_trace_holder_bf4, ld_modifier::cs>(reinterpret_cast<const gkr_trace_holder_bf4 *>(raw_values), row_offset >> 2);
-      E partial = E::mul(values.values[0], eq0);
-      partial = E::fma(eq1, values.values[1], partial);
-      partial = E::fma(eq2, values.values[2], partial);
-      partial = E::fma(eq3, values.values[3], partial);
+      E partial = E::mul(values.values[0], eq[0]);
+      partial = E::fma(eq[1], values.values[1], partial);
+      partial = E::fma(eq[2], values.values[2], partial);
+      partial = E::fma(eq[3], values.values[3], partial);
       accumulators[local_col] = E::add(accumulators[local_col], partial);
     }
   }

--- a/gpu/gkr/native/gkr/support/kernel_helpers.cuh
+++ b/gpu/gkr/native/gkr/support/kernel_helpers.cuh
@@ -204,8 +204,13 @@ struct __align__(16) gkr_trace_holder_bf4 {
   bf values[4];
 };
 
-template <typename E>
-DEVICE_FORCEINLINE void gkr_trace_holder_block_partials(const bf *raw_values, const E *eq_values, E *block_partials, const unsigned trace_len,
+template <typename E> struct gkr_trace_holder_eq_dense {
+  const E *eq_values;
+  DEVICE_FORCEINLINE E operator()(const unsigned row) const { return load<E, ld_modifier::cs>(eq_values, row); }
+};
+
+template <typename E, typename EqFn>
+DEVICE_FORCEINLINE void gkr_trace_holder_block_partials(const bf *raw_values, const EqFn eq_fn, E *block_partials, const unsigned trace_len,
                                                         const unsigned column_start, const unsigned chunk_cols, const unsigned blocks_count) {
   static_assert(GKR_TRACE_HOLDER_PARTIALS_THREADS_PER_BLOCK % GKR_TRACE_HOLDER_PARTIALS_WARP_SIZE == 0);
   static_assert(sizeof(gkr_trace_holder_bf4) == 4 * sizeof(bf));
@@ -225,10 +230,10 @@ DEVICE_FORCEINLINE void gkr_trace_holder_block_partials(const bf *raw_values, co
 
   for (unsigned packed_row = packed_gid; packed_row < packed_trace_len; packed_row += packed_stride) {
     const unsigned row = packed_row << 2;
-    const E eq0 = load<E, ld_modifier::cs>(eq_values, row);
-    const E eq1 = load<E, ld_modifier::cs>(eq_values, row + 1);
-    const E eq2 = load<E, ld_modifier::cs>(eq_values, row + 2);
-    const E eq3 = load<E, ld_modifier::cs>(eq_values, row + 3);
+    const E eq0 = eq_fn(row);
+    const E eq1 = eq_fn(row + 1);
+    const E eq2 = eq_fn(row + 2);
+    const E eq3 = eq_fn(row + 3);
 #pragma unroll
     for (unsigned local_col = 0; local_col < GKR_TRACE_HOLDER_PARTIALS_COLUMNS_PER_CHUNK; ++local_col) {
       if (local_col >= chunk_cols)
@@ -269,6 +274,18 @@ DEVICE_FORCEINLINE void gkr_trace_holder_block_partials(const bf *raw_values, co
       store<E, st_modifier::cs>(block_partials, block_sum, partial_offset);
     }
   }
+}
+
+// Launch contract: blockDim = one warp, blockIdx.x = column.
+template <typename E> DEVICE_FORCEINLINE void gkr_trace_holder_column_sums(const E *block_partials, E *column_sums, const unsigned blocks_count) {
+  const unsigned lane_id = threadIdx.x;
+  const size_t column_base = static_cast<size_t>(blockIdx.x) * blocks_count;
+  E acc = E::ZERO();
+  for (unsigned i = lane_id; i < blocks_count; i += GKR_TRACE_HOLDER_PARTIALS_WARP_SIZE)
+    acc = E::add(acc, load<E, ld_modifier::cs>(block_partials, column_base + i));
+  acc = gkr_trace_holder_partials_warp_reduce_sum(acc);
+  if (lane_id == 0)
+    store<E, st_modifier::cs>(column_sums, acc, blockIdx.x);
 }
 
 } // namespace airbender::gkr

--- a/gpu/gkr/src/backward/kernels/launchers.rs
+++ b/gpu/gkr/src/backward/kernels/launchers.rs
@@ -134,6 +134,25 @@ cuda_kernel_signature_arguments_and_function!(
 );
 
 cuda_kernel_signature_arguments_and_function!(
+    pub(crate) GpuDimensionReducingTraceHolderBlockPartialsEqInline<T>,
+    raw_values: *const BF,
+    eq_low: *const T,
+    sizes: GkrEqSizes,
+    block_partials: *mut T,
+    trace_len: u32,
+    column_start: u32,
+    chunk_cols: u32,
+    blocks_count: u32,
+);
+
+cuda_kernel_signature_arguments_and_function!(
+    pub(crate) GpuDimensionReducingTraceHolderColumnSums<T>,
+    block_partials: *const T,
+    column_sums: *mut T,
+    blocks_count: u32,
+);
+
+cuda_kernel_signature_arguments_and_function!(
     pub(crate) GpuDimensionReducingRound0BatchedCompact<T>,
     batch: GpuGKRDimensionReducingRound0BatchCompact<T>,
     acc_size: u32,
@@ -185,6 +204,25 @@ cuda_kernel_declaration!(pub(crate)
         trace_len: u32,
         column_start: u32,
         chunk_cols: u32,
+        blocks_count: u32,
+    )
+);
+cuda_kernel_declaration!(pub(crate)
+    ab_gkr_dim_reducing_trace_holder_block_partials_eq_inline_e4_kernel(
+        raw_values: *const BF,
+        eq_low: *const E4,
+        sizes: GkrEqSizes,
+        block_partials: *mut E4,
+        trace_len: u32,
+        column_start: u32,
+        chunk_cols: u32,
+        blocks_count: u32,
+    )
+);
+cuda_kernel_declaration!(pub(crate)
+    ab_gkr_dim_reducing_trace_holder_column_sums_e4_kernel(
+        block_partials: *const E4,
+        column_sums: *mut E4,
         blocks_count: u32,
     )
 );
@@ -393,6 +431,61 @@ pub(crate) fn launch_trace_holder_block_partials(
 
     GpuDimensionReducingTraceHolderBlockPartialsFunction(
         ab_gkr_dim_reducing_trace_holder_block_partials_e4_kernel,
+    )
+    .launch(&config, &args)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn launch_trace_holder_block_partials_eq_inline(
+    raw_values: *const BF,
+    eq_low: *const E4,
+    sizes: GkrEqSizes,
+    block_partials: *mut E4,
+    trace_len: usize,
+    column_start: usize,
+    chunk_cols: usize,
+    blocks_count: usize,
+    context: &ProverContext,
+) -> CudaResult<()> {
+    assert!(trace_len <= u32::MAX as usize);
+    assert!(column_start <= u32::MAX as usize);
+    assert!(chunk_cols <= u32::MAX as usize);
+    assert!(blocks_count <= u32::MAX as usize);
+    let config = gkr_trace_holder_partials_launch_config(blocks_count as u32, context);
+    let args = GpuDimensionReducingTraceHolderBlockPartialsEqInlineArguments::new(
+        raw_values,
+        eq_low,
+        sizes,
+        block_partials,
+        trace_len as u32,
+        column_start as u32,
+        chunk_cols as u32,
+        blocks_count as u32,
+    );
+    GpuDimensionReducingTraceHolderBlockPartialsEqInlineFunction(
+        ab_gkr_dim_reducing_trace_holder_block_partials_eq_inline_e4_kernel,
+    )
+    .launch(&config, &args)
+}
+
+pub(crate) fn launch_trace_holder_column_sums(
+    block_partials: *const E4,
+    column_sums: *mut E4,
+    columns_count: usize,
+    blocks_count: usize,
+    context: &ProverContext,
+) -> CudaResult<()> {
+    assert!(columns_count <= u32::MAX as usize);
+    assert!(blocks_count <= u32::MAX as usize);
+    let config =
+        CudaLaunchConfig::basic(columns_count as u32, WARP_SIZE, context.get_exec_stream());
+    let args = GpuDimensionReducingTraceHolderColumnSumsArguments::new(
+        block_partials,
+        column_sums,
+        blocks_count as u32,
+    );
+    GpuDimensionReducingTraceHolderColumnSumsFunction(
+        ab_gkr_dim_reducing_trace_holder_column_sums_e4_kernel,
     )
     .launch(&config, &args)
 }

--- a/gpu/gkr/src/base_layer_claims/mod.rs
+++ b/gpu/gkr/src/base_layer_claims/mod.rs
@@ -4,20 +4,16 @@ use era_cudart::result::CudaResult;
 use era_cudart::slice::DeviceSlice;
 
 use super::backward::{
-    eq_group_tables_len, launch_build_eq_values_from_point, launch_trace_holder_block_partials,
-    GKR_TRACE_HOLDER_PARTIALS_COLUMNS_PER_CHUNK,
+    get_eq_high_constant_device_ptr, launch_build_eq_high_and_low_groups_from_point,
+    launch_trace_holder_block_partials_eq_inline, launch_trace_holder_column_sums, make_eq_sizes,
+    GkrEqSizes, GKR_EQ_GROUP_TABLE_LEN, GKR_TRACE_HOLDER_PARTIALS_COLUMNS_PER_CHUNK,
 };
 use crate::proof_layout::{ProofLayout, WhirBaseLayerKind};
 use crate::upstream::{GKRAddress, GKRLayerDescription, VirtualSetupPoly};
 use gpu_core::allocator::tracker::AllocationPlacement;
 use gpu_core::primitives::context::{DeviceAllocation, UnsafeAccessor};
-use gpu_core::primitives::device_structures::DeviceMatrix;
 use gpu_core::primitives::device_tracing::Range;
 use gpu_core::primitives::field::{BF, E4};
-use gpu_cub::cub::device_reduce::{
-    batch_reduce, get_batch_reduce_temp_storage_bytes, ReduceOperation,
-};
-use gpu_cub::cub::CUB_TEMP_STORAGE_EXTRA_ALIGNMENT_LOG2;
 use gpu_prover_context::ProverContext;
 use gpu_trace::trace::holder::TraceHolder;
 
@@ -209,19 +205,18 @@ impl GpuGKRBaseLayerClaimsScheduledExecution {
 fn schedule_reduce_trace_holder_claims(
     label: &str,
     trace_holder: &TraceHolder<BF>,
-    eq_values: &DeviceSlice<E4>,
-    // B3: `batch_reduce` writes straight into the slab's `whir.{kind}.evals`
-    // range (raw `(ptr, len)` resolved by the caller via
-    // `proof_layout.whir_base_evals_device_mut`). Eliminates the standalone
-    // `claims_device` allocation and the post-D2H slab H2D-back loop.
+    eq_low: &DeviceSlice<E4>,
+    eq_sizes: GkrEqSizes,
+    // The column-sums kernel writes straight into the slab's
+    // `whir.{kind}.evals` range (raw `(ptr, len)` resolved by the caller via
+    // `proof_layout.whir_base_evals_device_mut`).
     slab_claims_dst: (*mut E4, usize),
     tracing_ranges: &mut Vec<Range>,
     context: &ProverContext,
 ) -> CudaResult<()> {
     let trace_len = 1usize << trace_holder.log_domain_size;
-    assert_eq!(eq_values.len(), trace_len);
+    assert_eq!(eq_low.len(), GKR_EQ_GROUP_TABLE_LEN);
     assert!(trace_len <= u32::MAX as usize);
-    assert!(trace_len <= i32::MAX as usize);
     assert_eq!(
         trace_len % 4,
         0,
@@ -229,28 +224,18 @@ fn schedule_reduce_trace_holder_claims(
     );
     let columns_count = trace_holder.columns_count;
     assert!(columns_count <= u32::MAX as usize);
-    assert!(columns_count <= i32::MAX as usize);
     if columns_count == 0 {
         return Ok(());
     }
 
-    let blocks_count = context.get_device_properties().sm_count;
+    // 2 blocks/SM (the register-file cap): 1 block/SM leaves the inline-eq
+    // latency uncovered.
+    let blocks_count = 2 * context.get_device_properties().sm_count;
     assert!(blocks_count > 0, "device must expose at least one SM");
     assert!(blocks_count <= u32::MAX as usize);
-    assert!(blocks_count <= i32::MAX as usize);
 
     let mut block_partials =
         context.alloc(columns_count * blocks_count, AllocationPlacement::BestFit)?;
-    let reduction_temp_bytes = get_batch_reduce_temp_storage_bytes::<E4>(
-        ReduceOperation::Sum,
-        columns_count as i32,
-        blocks_count as i32,
-    )?;
-    let mut reduction_temp = context
-        .alloc_with_extra_alignment::<u8, CUB_TEMP_STORAGE_EXTRA_ALIGNMENT_LOG2>(
-            reduction_temp_bytes,
-            AllocationPlacement::BestFit,
-        )?;
     let stream = context.get_exec_stream();
     let reduction_range = Range::new(format!("gkr.base_layer_claims.reduce.{label}"))?;
     reduction_range.start(stream)?;
@@ -258,9 +243,10 @@ fn schedule_reduce_trace_holder_claims(
     for column_start in (0..columns_count).step_by(GKR_TRACE_HOLDER_PARTIALS_COLUMNS_PER_CHUNK) {
         let chunk_cols =
             (columns_count - column_start).min(GKR_TRACE_HOLDER_PARTIALS_COLUMNS_PER_CHUNK);
-        launch_trace_holder_block_partials(
+        launch_trace_holder_block_partials_eq_inline(
             raw_values.as_ptr(),
-            eq_values.as_ptr(),
+            eq_low.as_ptr(),
+            eq_sizes,
             block_partials.as_mut_ptr(),
             trace_len,
             column_start,
@@ -269,25 +255,20 @@ fn schedule_reduce_trace_holder_claims(
             context,
         )?;
     }
-    let block_partials_matrix = DeviceMatrix::new(&block_partials, blocks_count);
 
-    // `batch_reduce` writes its output through the slab's `whir.{kind}.evals`
-    // range (B3). The slab is held alive by `_proof_slab` keepalive across
+    // The slab destination is held alive by the `_proof_slab` keepalive across
     // all base-layer reductions and the subsequent terminal D2H.
     let (slab_ptr, slab_len) = slab_claims_dst;
     assert_eq!(
         slab_len, columns_count,
         "slab whir.{label}.evals length must match trace_holder.columns_count",
     );
-    // SAFETY: the slab destination memory outlives both the `batch_reduce`
-    // kernel and the subsequent terminal D2H; `columns_count` is in-bounds.
-    let claims_dst_slice = unsafe { DeviceSlice::from_raw_parts_mut(slab_ptr, columns_count) };
-    batch_reduce(
-        ReduceOperation::Sum,
-        &mut reduction_temp,
-        &block_partials_matrix,
-        claims_dst_slice,
-        stream,
+    launch_trace_holder_column_sums(
+        block_partials.as_ptr(),
+        slab_ptr,
+        columns_count,
+        blocks_count,
+        context,
     )?;
     reduction_range.end(stream)?;
     tracing_ranges.push(reduction_range);
@@ -341,26 +322,24 @@ pub fn schedule_prepare_base_layer_claims_with_sources(
     let schedule_range = Range::new("gkr.base_layer_claims.schedule")?;
     schedule_range.start(stream)?;
 
-    let mut eq_group_tables = context.alloc(
-        eq_group_tables_len(claim_point_len).max(1),
-        AllocationPlacement::BestFit,
-    )?;
-    let mut eq_values = context.alloc(trace_len, AllocationPlacement::BestFit)?;
-    launch_build_eq_values_from_point(
+    // Overwriting the shared `ab_gkr_eq_high` `__constant__` slabs is safe:
+    // backward's last read of them precedes this schedule.
+    let mut eq_low = context.alloc(GKR_EQ_GROUP_TABLE_LEN, AllocationPlacement::BestFit)?;
+    launch_build_eq_high_and_low_groups_from_point(
         claim_point_device.as_ptr(),
         0,
         claim_point_len,
-        eq_group_tables.as_mut_ptr(),
-        eq_values.as_mut_ptr(),
-        trace_len,
+        get_eq_high_constant_device_ptr(),
+        eq_low.as_mut_ptr(),
         context,
     )?;
+    let eq_sizes = make_eq_sizes(claim_point_len);
 
-    // Route `batch_reduce`'s output of each base-layer column reduction
-    // straight into the slab's `whir.{kind}.evals` range. Production does not
-    // mirror those dense vectors here; cached relation extras are gathered
-    // from the slab on device below, and final proof parsing reads the same
-    // slab ranges after the terminal D2H.
+    // Route each column reduction's output straight into the slab's
+    // `whir.{kind}.evals` range. Production does not mirror those dense
+    // vectors here; cached relation extras are gathered from the slab on
+    // device below, and final proof parsing reads the same slab ranges after
+    // the terminal D2H.
     let slab_claims_dst = |kind: WhirBaseLayerKind| -> (*mut E4, usize) {
         let (ptr, len) = unsafe {
             proof_layout.whir_base_evals_device_mut(proof_slab.as_ptr() as *mut u8, kind)
@@ -370,7 +349,8 @@ pub fn schedule_prepare_base_layer_claims_with_sources(
     schedule_reduce_trace_holder_claims(
         "memory",
         memory_trace_holder,
-        &eq_values,
+        &eq_low,
+        eq_sizes,
         slab_claims_dst(WhirBaseLayerKind::Memory),
         &mut tracing_ranges,
         context,
@@ -378,7 +358,8 @@ pub fn schedule_prepare_base_layer_claims_with_sources(
     schedule_reduce_trace_holder_claims(
         "witness",
         witness_trace_holder,
-        &eq_values,
+        &eq_low,
+        eq_sizes,
         slab_claims_dst(WhirBaseLayerKind::Witness),
         &mut tracing_ranges,
         context,
@@ -386,7 +367,8 @@ pub fn schedule_prepare_base_layer_claims_with_sources(
     schedule_reduce_trace_holder_claims(
         "setup",
         setup_trace_holder,
-        &eq_values,
+        &eq_low,
+        eq_sizes,
         slab_claims_dst(WhirBaseLayerKind::Setup),
         &mut tracing_ranges,
         context,


### PR DESCRIPTION
## What ❔

- Base-layer claims reconstruct eq from the factored 3-slot tables (high product hoisted per 4-row pack) instead of streaming a dense 268 MB eq vector on every column chunk; the dense kernel stays for backward extras.
- The phase's CUB `batch_reduce` is replaced by an owned one-warp-per-column sums kernel.
- 2 blocks/SM (1 block/SM was latency-bound).

## Why ❔

Removes ~4 GB of redundant eq reads per proof: phase 5.34 → 2.63 ms on add_sub 2^24, partials at the column-read floor (89% DRAM). add_sub sec100 and unified proof parity byte-identical.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.