### PR TITLE
perf(gpu_ntt): fused LDE boundary, terminal-pass eviction, 256-thread middles

### DIFF
--- a/gpu/ntt/native/evals_to_monomials_three_pass.cu
+++ b/gpu/ntt/native/evals_to_monomials_three_pass.cu
@@ -3,13 +3,16 @@
 
 namespace airbender::ntt {
 
-EXTERN __launch_bounds__(512, 2) __global__
+// Two tile roles per thread at 256 threads / 3 blocks-per-SM (see the forward
+// noninitial body for the shape rationale).
+EXTERN __launch_bounds__(256, 3) __global__
     void ab_evals_to_monomials_nonfinal_8_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out, const int log_n,
                                                         const int start_stage, const int num_cols_per_coset, const int log_cosets_in_tile) {
   using namespace pass_config::three_pass_phase_a;
+  constexpr int ROLES = 2;
+  constexpr int ROLE_TILE_STRIDE = THREAD_TILES_PER_BLOCK / ROLES;
 
   const int lane_in_tile = threadIdx.x & 31;
-  const int tile_id = threadIdx.x >> LOG_DATA_TILE_SIZE;
 
   const int exchg_region_size = 1 << (log_n - start_stage);
   const int tile_gmem_stride = exchg_region_size >> LOG_DATA_TILES_PER_BLOCK;
@@ -38,72 +41,79 @@ EXTERN __launch_bounds__(512, 2) __global__
 
   __shared__ bf smem_block[8192];
 
-  bf vals[VALS_PER_THREAD];
+#pragma unroll
+  for (int role = 0; role < ROLES; role++) {
+    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    const int thread_il_gmem_start = lane_in_tile + tile_id * tile_gmem_stride;
+    const int thread_il_smem_start = lane_in_tile + tile_id * TILE_SIZE;
 
-  // "ct" = consecutive tile layout
-  // "il" = interleaved tile layout
-  const int thread_il_gmem_start = lane_in_tile + tile_id * tile_gmem_stride;
-  const int thread_ct_gmem_start = lane_in_tile + tile_id * interleaved_gmem_stride;
-  const int thread_il_smem_start = lane_in_tile + tile_id * TILE_SIZE;
-  const int thread_ct_smem_start = lane_in_tile + tile_id * TILE_SIZE * THREAD_TILES_PER_BLOCK;
+    bf vals[VALS_PER_THREAD];
 
 #pragma unroll
-  for (int i{0}, addr{thread_il_gmem_start}; i < VALS_PER_THREAD; i++, addr += interleaved_gmem_stride)
-    vals[i] = gmem_in.get_at_row(addr);
+    for (int i{0}, addr{thread_il_gmem_start}; i < VALS_PER_THREAD; i++, addr += interleaved_gmem_stride)
+      vals[i] = gmem_in.get_at_row(addr);
 
-  int block_exchg_region_offset = alternating_block_idx_y;
-  if (start_stage == 0) {
-    reg_exchg_inv<8, 16, 1>(vals, block_exchg_region_offset);
-    block_exchg_region_offset <<= 1;
-    reg_exchg_inv<4, 8, 2>(vals, block_exchg_region_offset);
-    block_exchg_region_offset <<= 1;
-    reg_exchg_inv<2, 4, 4>(vals, block_exchg_region_offset);
-    block_exchg_region_offset <<= 1;
-    reg_exchg_inv<1, 2, 8>(vals, block_exchg_region_offset);
-    block_exchg_region_offset <<= 1;
-  } else {
-    reg_exchg_cmem_twiddles_inv<8, 16, 1>(vals, block_exchg_region_offset);
-    block_exchg_region_offset <<= 1;
-    reg_exchg_cmem_twiddles_inv<4, 8, 2>(vals, block_exchg_region_offset);
-    block_exchg_region_offset <<= 1;
-    reg_exchg_cmem_twiddles_inv<2, 4, 4>(vals, block_exchg_region_offset);
-    block_exchg_region_offset <<= 1;
-    reg_exchg_cmem_twiddles_inv<1, 2, 8>(vals, block_exchg_region_offset);
-    block_exchg_region_offset <<= 1;
+    int block_exchg_region_offset = alternating_block_idx_y;
+    if (start_stage == 0) {
+      reg_exchg_inv<8, 16, 1>(vals, block_exchg_region_offset);
+      block_exchg_region_offset <<= 1;
+      reg_exchg_inv<4, 8, 2>(vals, block_exchg_region_offset);
+      block_exchg_region_offset <<= 1;
+      reg_exchg_inv<2, 4, 4>(vals, block_exchg_region_offset);
+      block_exchg_region_offset <<= 1;
+      reg_exchg_inv<1, 2, 8>(vals, block_exchg_region_offset);
+    } else {
+      reg_exchg_cmem_twiddles_inv<8, 16, 1>(vals, block_exchg_region_offset);
+      block_exchg_region_offset <<= 1;
+      reg_exchg_cmem_twiddles_inv<4, 8, 2>(vals, block_exchg_region_offset);
+      block_exchg_region_offset <<= 1;
+      reg_exchg_cmem_twiddles_inv<2, 4, 4>(vals, block_exchg_region_offset);
+      block_exchg_region_offset <<= 1;
+      reg_exchg_cmem_twiddles_inv<1, 2, 8>(vals, block_exchg_region_offset);
+    }
+
+#pragma unroll
+    for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
+      smem_block[addr] = vals[i]; // write interleaved smem tiles
   }
-
-#pragma unroll
-  for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
-    smem_block[addr] = vals[i]; // write interleaved smem tiles
 
   __syncthreads();
 
 #pragma unroll
-  for (int i{0}, addr{thread_ct_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE)
-    vals[i] = smem_block[addr]; // read consecutive smem tiles
+  for (int role = 0; role < ROLES; role++) {
+    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    const int thread_ct_gmem_start = lane_in_tile + tile_id * interleaved_gmem_stride;
+    const int thread_ct_smem_start = lane_in_tile + tile_id * TILE_SIZE * THREAD_TILES_PER_BLOCK;
 
-  int tile_exchg_region_offset = block_exchg_region_offset + tile_id;
-  if (start_stage == 0) {
-    reg_exchg_inv<8, 16, 1>(vals, tile_exchg_region_offset);
-    tile_exchg_region_offset <<= 1;
-    reg_exchg_inv<4, 8, 2>(vals, tile_exchg_region_offset);
-    tile_exchg_region_offset <<= 1;
-    reg_exchg_inv<2, 4, 4>(vals, tile_exchg_region_offset);
-    tile_exchg_region_offset <<= 1;
-    reg_exchg_inv<1, 2, 8>(vals, tile_exchg_region_offset);
-  } else {
-    reg_exchg_cmem_twiddles_inv<8, 16, 1>(vals, tile_exchg_region_offset);
-    tile_exchg_region_offset <<= 1;
-    reg_exchg_cmem_twiddles_inv<4, 8, 2>(vals, tile_exchg_region_offset);
-    tile_exchg_region_offset <<= 1;
-    reg_exchg_cmem_twiddles_inv<2, 4, 4>(vals, tile_exchg_region_offset);
-    tile_exchg_region_offset <<= 1;
-    reg_exchg_cmem_twiddles_inv<1, 2, 8>(vals, tile_exchg_region_offset);
-  }
+    bf vals[VALS_PER_THREAD];
 
 #pragma unroll
-  for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
-    gmem_out.set_at_row(row, vals[i]); // write consecutive gmem tiles
+    for (int i{0}, addr{thread_ct_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE)
+      vals[i] = smem_block[addr]; // read consecutive smem tiles
+
+    int tile_exchg_region_offset = (alternating_block_idx_y << 4) + tile_id;
+    if (start_stage == 0) {
+      reg_exchg_inv<8, 16, 1>(vals, tile_exchg_region_offset);
+      tile_exchg_region_offset <<= 1;
+      reg_exchg_inv<4, 8, 2>(vals, tile_exchg_region_offset);
+      tile_exchg_region_offset <<= 1;
+      reg_exchg_inv<2, 4, 4>(vals, tile_exchg_region_offset);
+      tile_exchg_region_offset <<= 1;
+      reg_exchg_inv<1, 2, 8>(vals, tile_exchg_region_offset);
+    } else {
+      reg_exchg_cmem_twiddles_inv<8, 16, 1>(vals, tile_exchg_region_offset);
+      tile_exchg_region_offset <<= 1;
+      reg_exchg_cmem_twiddles_inv<4, 8, 2>(vals, tile_exchg_region_offset);
+      tile_exchg_region_offset <<= 1;
+      reg_exchg_cmem_twiddles_inv<2, 4, 4>(vals, tile_exchg_region_offset);
+      tile_exchg_region_offset <<= 1;
+      reg_exchg_cmem_twiddles_inv<1, 2, 8>(vals, tile_exchg_region_offset);
+    }
+
+#pragma unroll
+    for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
+      gmem_out.set_at_row(row, vals[i]); // write consecutive gmem tiles
+  }
 }
 
 template <int STAGES>

--- a/gpu/ntt/native/hypercube_evals_to_monomials_three_pass.cu
+++ b/gpu/ntt/native/hypercube_evals_to_monomials_three_pass.cu
@@ -3,13 +3,16 @@
 
 namespace airbender::ntt {
 
-EXTERN __launch_bounds__(512, 2) __global__
+// Two tile roles per thread at 256 threads / 3 blocks-per-SM (see the forward
+// noninitial body for the shape rationale).
+EXTERN __launch_bounds__(256, 3) __global__
     void ab_hypercube_evals_to_monomials_nonfinal_8_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
                                                                   const int log_n, const int start_stage) {
   using namespace pass_config::three_pass_phase_a;
+  constexpr int ROLES = 2;
+  constexpr int ROLE_TILE_STRIDE = THREAD_TILES_PER_BLOCK / ROLES;
 
   const int lane_in_tile = threadIdx.x & 31;
-  const int tile_id = threadIdx.x >> LOG_DATA_TILE_SIZE;
 
   const int exchg_region_size = 1 << (log_n - start_stage);
   const int tile_gmem_stride = exchg_region_size >> LOG_DATA_TILES_PER_BLOCK;
@@ -24,43 +27,212 @@ EXTERN __launch_bounds__(512, 2) __global__
 
   __shared__ bf smem_block[8192];
 
-  bf vals[VALS_PER_THREAD];
+#pragma unroll
+  for (int role = 0; role < ROLES; role++) {
+    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    const int thread_il_gmem_start = lane_in_tile + tile_id * tile_gmem_stride;
+    const int thread_il_smem_start = lane_in_tile + tile_id * TILE_SIZE;
 
-  // "ct" = consecutive tile layout
-  // "il" = interleaved tile layout
-  const int thread_il_gmem_start = lane_in_tile + tile_id * tile_gmem_stride;
-  const int thread_ct_gmem_start = lane_in_tile + tile_id * interleaved_gmem_stride;
-  const int thread_il_smem_start = lane_in_tile + tile_id * TILE_SIZE;
-  const int thread_ct_smem_start = lane_in_tile + tile_id * TILE_SIZE * THREAD_TILES_PER_BLOCK;
+    bf vals[VALS_PER_THREAD];
 
 #pragma unroll
-  for (int i{0}, addr{thread_il_gmem_start}; i < VALS_PER_THREAD; i++, addr += interleaved_gmem_stride)
-    vals[i] = gmem_in.get_at_row(addr);
+    for (int i{0}, addr{thread_il_gmem_start}; i < VALS_PER_THREAD; i++, addr += interleaved_gmem_stride)
+      vals[i] = gmem_in.get_at_row(addr);
 
-  reg_exchg_hypercube_inv<8, 16, 1>(vals);
-  reg_exchg_hypercube_inv<4, 8, 2>(vals);
-  reg_exchg_hypercube_inv<2, 4, 4>(vals);
-  reg_exchg_hypercube_inv<1, 2, 8>(vals);
+    reg_exchg_hypercube_inv<8, 16, 1>(vals);
+    reg_exchg_hypercube_inv<4, 8, 2>(vals);
+    reg_exchg_hypercube_inv<2, 4, 4>(vals);
+    reg_exchg_hypercube_inv<1, 2, 8>(vals);
 
 #pragma unroll
-  for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
-    smem_block[addr] = vals[i]; // write interleaved smem tiles
+    for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
+      smem_block[addr] = vals[i]; // write interleaved smem tiles
+  }
 
   __syncthreads();
 
 #pragma unroll
-  for (int i{0}, addr{thread_ct_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE)
-    vals[i] = smem_block[addr]; // read consecutive smem tiles
+  for (int role = 0; role < ROLES; role++) {
+    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    const int thread_ct_gmem_start = lane_in_tile + tile_id * interleaved_gmem_stride;
+    const int thread_ct_smem_start = lane_in_tile + tile_id * TILE_SIZE * THREAD_TILES_PER_BLOCK;
 
-  reg_exchg_hypercube_inv<8, 16, 1>(vals);
-  reg_exchg_hypercube_inv<4, 8, 2>(vals);
-  reg_exchg_hypercube_inv<2, 4, 4>(vals);
-  reg_exchg_hypercube_inv<1, 2, 8>(vals);
+    bf vals[VALS_PER_THREAD];
 
 #pragma unroll
-  for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
-    gmem_out.set_at_row(row, vals[i]); // write consecutive gmem tiles
+    for (int i{0}, addr{thread_ct_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE)
+      vals[i] = smem_block[addr]; // read consecutive smem tiles
+
+    reg_exchg_hypercube_inv<8, 16, 1>(vals);
+    reg_exchg_hypercube_inv<4, 8, 2>(vals);
+    reg_exchg_hypercube_inv<2, 4, 4>(vals);
+    reg_exchg_hypercube_inv<1, 2, 8>(vals);
+
+#pragma unroll
+    for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
+      gmem_out.set_at_row(row, vals[i]); // write consecutive gmem tiles
+  }
 }
+
+// Fused LDE boundary for a column's FIRST coset (transposed layout only):
+// iNTT final stages + in-place monomial writeback + coset scale +
+// forward-initial stages. In-place contract: each block rewrites exactly the
+// scratch window it read; only later launches read the writeback, so
+// same-stream order suffices. The coarse-twiddle staging must wait for the
+// hypercube warp transpose (they share smem's upper half).
+template <int STAGES>
+DEVICE_FORCEINLINE void lde_fused_boundary_writeback_up_to_8_stages(bf_matrix_getter_setter<ld_modifier::cg, st_modifier::cg> gmem_scratch,
+                                                                    bf_matrix_setter<st_modifier::cg> gmem_out, const int log_n, const int coset_index_base,
+                                                                    const int coset_factor_shift, const int num_cols_per_coset, const int log_cosets_in_tile) {
+  using namespace pass_config::three_pass_phase_b;
+  constexpr int REGIONS_PER_WARP = 1 << (10 - STAGES);
+
+  const unsigned log_blocks_per_ntt = static_cast<unsigned>(log_n) - 13u;
+  const FlatBlockIndex fi = decompose_flat_1d(log_blocks_per_ntt, static_cast<unsigned>(log_cosets_in_tile));
+  gmem_scratch.add_col(fi.col);
+  gmem_out.add_col(static_cast<int>(fi.coset) * num_cols_per_coset + static_cast<int>(fi.col));
+  const int coset_factor_power = (coset_index_base + static_cast<int>(fi.coset)) << coset_factor_shift;
+
+  const int lane_id = threadIdx.x & 31;
+  const int warp_id = threadIdx.x >> 5;
+  const int pipeline_memcpy_start = 4 * threadIdx.x;
+  const int pipeline_memcpy_stride = 4 * blockDim.x;
+  const int gmem_block_offset = static_cast<int>(fi.intra_x) * VALS_PER_BLOCK;
+  gmem_scratch.add_row(gmem_block_offset + warp_id * VALS_PER_WARP);
+  gmem_out.add_row(gmem_block_offset + warp_id * VALS_PER_WARP);
+
+  __shared__ bf smem_block[8192]; // warp transposes; [4096..8192) doubles as coarse twiddles
+  bf *smem_warp = smem_block + warp_id * VALS_PER_WARP;
+  bf *smem_twiddles = smem_block + (VALS_PER_BLOCK >> 1);
+
+  bf vals[VALS_PER_THREAD];
+
+#pragma unroll
+  for (int i{0}, row{lane_id}; i < VALS_PER_THREAD; i++, row += WARP_SIZE)
+    vals[i] = gmem_scratch.get_at_row(row);
+
+  // Hypercube iNTT final STAGES stages (mirrors the standalone final kernel).
+  if (STAGES >= 5) {
+#pragma unroll
+    for (int i{0}; i < REGIONS_PER_WARP; i++) {
+      if (STAGES == 8) {
+        bf *vals_this_region = vals + 8 * i;
+        reg_exchg_hypercube_inv<4, 8, 1>(vals_this_region);
+        reg_exchg_hypercube_inv<2, 4, 2>(vals_this_region);
+        reg_exchg_hypercube_inv<1, 2, 4>(vals_this_region);
+      }
+      if (STAGES == 7) {
+        bf *vals_this_region = vals + 4 * i;
+        reg_exchg_hypercube_inv<2, 4, 1>(vals_this_region);
+        reg_exchg_hypercube_inv<1, 2, 2>(vals_this_region);
+      }
+      if (STAGES == 6) {
+        bf *vals_this_region = vals + 2 * i;
+        reg_exchg_hypercube_inv<1, 2, 1>(vals_this_region);
+      }
+    }
+  }
+
+  warp_transpose_swizzled<VALS_PER_THREAD>(smem_warp, vals, lane_id);
+
+  reg_exchg_hypercube_inv<16, 32, 1>(vals);
+  reg_exchg_hypercube_inv<8, 16, 2>(vals);
+  reg_exchg_hypercube_inv<4, 8, 4>(vals);
+  reg_exchg_hypercube_inv<2, 4, 8>(vals);
+  reg_exchg_hypercube_inv<1, 2, 16>(vals);
+
+  // Warps 4-7's transposes must retire before the twiddle staging overwrites
+  // smem's upper half.
+  __syncthreads();
+
+#pragma unroll
+  for (int i{0}, addr{pipeline_memcpy_start}; i < 4; i++, addr += pipeline_memcpy_stride)
+    __pipeline_memcpy_async(smem_twiddles + addr, ab_fwd_gmem_twiddles_coarse + addr, 4 * sizeof(bf));
+  __pipeline_commit();
+
+  // Materialize the monomials (pre-scale); overlaps the twiddle copy.
+#pragma unroll
+  for (int i{0}, row{lane_id}; i < VALS_PER_THREAD; i++, row += WARP_SIZE)
+    gmem_scratch.set_at_row(row, vals[i]);
+
+  // Coset scale on the logical monomial rows, also overlapping the copy.
+  if (coset_factor_power > 0) {
+#pragma unroll
+    for (int i{0}, global_row{lane_id + gmem_block_offset + warp_id * VALS_PER_WARP}; i < VALS_PER_THREAD; i++, global_row += WARP_SIZE) {
+      const int effective_row = transposed_row_to_effective_row(global_row);
+      const bf coset_offset = get_power_from_layers(::ab_ntt_forward_powers, bitrev(effective_row, log_n) * coset_factor_power);
+      vals[i] = bf::mul(vals[i], coset_offset);
+    }
+  }
+
+  __pipeline_wait_prior(0);
+  __syncthreads();
+
+  // Forward NTT initial STAGES stages, transposed path (mirrors
+  // monomials_to_evals_three_pass.cu's initial body).
+  int thread_exchg_region_offset = (threadIdx.x + static_cast<int>(fi.intra_x) * blockDim.x) << 4;
+  constexpr bf *cmem_twiddles = ab_fwd_cmem_twiddles_finest_11;
+  reg_exchg_cmem_smem_twiddles_fwd<EightStages, 1, 2, 16, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
+  thread_exchg_region_offset >>= 1;
+  reg_exchg_cmem_smem_twiddles_fwd<EightStages, 2, 4, 8, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
+  thread_exchg_region_offset >>= 1;
+  reg_exchg_cmem_smem_twiddles_fwd<EightStages, 4, 8, 4, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
+  thread_exchg_region_offset >>= 1;
+  reg_exchg_cmem_smem_twiddles_fwd<EightStages, 8, 16, 2, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
+  thread_exchg_region_offset >>= 1;
+  reg_exchg_cmem_smem_twiddles_fwd<EightStages, 16, 32, 1, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
+
+  __syncthreads();
+
+  warp_transpose_swizzled<VALS_PER_THREAD>(smem_warp, vals, lane_id);
+
+  if (STAGES >= 5) {
+    int warp_exchg_region_offset = (static_cast<int>(fi.intra_x) * WARPS_PER_BLOCK + warp_id) << 4;
+#pragma unroll
+    for (int i{0}; i < REGIONS_PER_WARP; i++) {
+      if (STAGES == 8) {
+        int exchg_region_offset = warp_exchg_region_offset + i * 4;
+        bf *vals_this_region = vals + 8 * i;
+        reg_exchg_cmem_twiddles_fwd<1, 2, 4>(vals_this_region, exchg_region_offset);
+        exchg_region_offset >>= 1;
+        reg_exchg_cmem_twiddles_fwd<2, 4, 2>(vals_this_region, exchg_region_offset);
+        exchg_region_offset >>= 1;
+        reg_exchg_cmem_twiddles_fwd<4, 8, 1>(vals_this_region, exchg_region_offset);
+      }
+      if (STAGES == 7) {
+        int exchg_region_offset = warp_exchg_region_offset + i * 2;
+        bf *vals_this_region = vals + 4 * i;
+        reg_exchg_cmem_twiddles_fwd<1, 2, 2>(vals_this_region, exchg_region_offset);
+        exchg_region_offset >>= 1;
+        reg_exchg_cmem_twiddles_fwd<2, 4, 1>(vals_this_region, exchg_region_offset);
+      }
+      if (STAGES == 6) {
+        int exchg_region_offset = warp_exchg_region_offset + i;
+        bf *vals_this_region = vals + 2 * i;
+        reg_exchg_cmem_twiddles_fwd<1, 2, 1>(vals_this_region, exchg_region_offset);
+      }
+    }
+  }
+
+#pragma unroll
+  for (int i{0}, row{lane_id}; i < VALS_PER_THREAD; i++, row += WARP_SIZE)
+    gmem_out.set_at_row(row, vals[i]);
+}
+
+#define DEFINE_LDE_FUSED_WRITEBACK_KERNEL(STAGES)                                                                                                              \
+  EXTERN __launch_bounds__(256, 3) __global__ void ab_lde_fused_boundary_writeback_##STAGES##_stages_kernel(                                                   \
+      bf_matrix_getter_setter<ld_modifier::cg, st_modifier::cg> gmem_scratch, bf_matrix_setter<st_modifier::cg> gmem_out, const int log_n,                     \
+      const int coset_index_base, const int coset_factor_shift, const int num_cols_per_coset, const int log_cosets_in_tile) {                                  \
+    lde_fused_boundary_writeback_up_to_8_stages<STAGES>(gmem_scratch, gmem_out, log_n, coset_index_base, coset_factor_shift, num_cols_per_coset,               \
+                                                        log_cosets_in_tile);                                                                                   \
+  }
+
+DEFINE_LDE_FUSED_WRITEBACK_KERNEL(5)
+DEFINE_LDE_FUSED_WRITEBACK_KERNEL(6)
+DEFINE_LDE_FUSED_WRITEBACK_KERNEL(7)
+DEFINE_LDE_FUSED_WRITEBACK_KERNEL(8)
+
+#undef DEFINE_LDE_FUSED_WRITEBACK_KERNEL
 
 template <int STAGES>
 DEVICE_FORCEINLINE void hypercube_evals_to_monomials_final_up_to_8_stages(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,

--- a/gpu/ntt/native/monomials_to_evals_three_pass.cu
+++ b/gpu/ntt/native/monomials_to_evals_three_pass.cu
@@ -3,13 +3,19 @@
 
 namespace airbender::ntt {
 
-EXTERN __launch_bounds__(512, 2) __global__
-    void ab_monomials_to_evals_noninitial_8_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
-                                                          const int log_n, const int start_stage, const int num_cols_per_coset, const int log_cosets_in_tile) {
+// Two tile roles per thread at 256 threads / 3 blocks-per-SM: same grid, same
+// 16-logical-tile decomposition and byte-identical address permutation as the
+// previous 512-thread shape; a role's vals die into smem at the barrier, so
+// live register pressure stays at the single-role level. 3 blocks/SM wins by
+// giving each SM more independent __syncthreads domains.
+template <ld_modifier LD, st_modifier ST>
+DEVICE_FORCEINLINE void monomials_to_evals_noninitial_8_stages_body(bf_matrix_getter<LD> gmem_in, bf_matrix_setter<ST> gmem_out, const int log_n,
+                                                                    const int start_stage, const int num_cols_per_coset, const int log_cosets_in_tile) {
   using namespace pass_config::three_pass_phase_a;
+  constexpr int ROLES = 2;
+  constexpr int ROLE_TILE_STRIDE = THREAD_TILES_PER_BLOCK / ROLES;
 
   const int lane_in_tile = threadIdx.x & 31;
-  const int tile_id = threadIdx.x >> LOG_DATA_TILE_SIZE;
 
   const int exchg_region_size = 1 << (start_stage + 8);
   const int tile_gmem_stride = exchg_region_size >> LOG_DATA_TILES_PER_BLOCK;
@@ -25,7 +31,11 @@ EXTERN __launch_bounds__(512, 2) __global__
   const unsigned log_blocks_x = static_cast<unsigned>(start_stage - 5);
   const unsigned log_blocks_y = static_cast<unsigned>(log_n - start_stage - 8);
   const FlatBlockIndex fi = decompose_flat_2d(log_blocks_x, log_blocks_y, static_cast<unsigned>(log_cosets_in_tile));
-  apply_flat_col_offset(fi, num_cols_per_coset, gmem_in, gmem_out);
+  // apply_flat_col_offset is pinned to cg accessors; inline it for the
+  // modifier-templated body.
+  const int col_offset = static_cast<int>(fi.coset) * num_cols_per_coset + static_cast<int>(fi.col);
+  gmem_in.add_col(col_offset);
+  gmem_out.add_col(col_offset);
   const unsigned blocks_per_exchg_region = 1u << log_blocks_x;
   const unsigned num_exchg_regions = 1u << log_blocks_y;
 
@@ -40,67 +50,93 @@ EXTERN __launch_bounds__(512, 2) __global__
 
   __shared__ bf smem_block[8192];
 
-  bf vals[VALS_PER_THREAD];
+#pragma unroll
+  for (int role = 0; role < ROLES; role++) {
+    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    const int thread_ct_gmem_start = lane_in_tile + tile_id * interleaved_gmem_stride;
+    const int thread_ct_smem_start = lane_in_tile + tile_id * TILE_SIZE * THREAD_TILES_PER_BLOCK;
 
-  // "ct" = consecutive tile layout
-  // "il" = interleaved tile layout
-  const int thread_il_gmem_start = lane_in_tile + tile_id * tile_gmem_stride;
-  const int thread_ct_gmem_start = lane_in_tile + tile_id * interleaved_gmem_stride;
-  const int thread_il_smem_start = lane_in_tile + tile_id * TILE_SIZE;
-  const int thread_ct_smem_start = lane_in_tile + tile_id * TILE_SIZE * THREAD_TILES_PER_BLOCK;
+    bf vals[VALS_PER_THREAD];
 
 #pragma unroll
-  for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
-    vals[i] = gmem_in.get_at_row(row); // read consecutive gmem tiles
+    for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
+      vals[i] = gmem_in.get_at_row(row); // read consecutive gmem tiles
 
-  int tile_exchg_region_offset = (alternating_block_idx_y * THREAD_TILES_PER_BLOCK + tile_id) << 3;
-  if (start_stage == log_n - 8) {
-    reg_exchg_fwd<1, 2, 8>(vals, tile_exchg_region_offset);
-    tile_exchg_region_offset >>= 1;
-    reg_exchg_fwd<2, 4, 4>(vals, tile_exchg_region_offset);
-    tile_exchg_region_offset >>= 1;
-    reg_exchg_fwd<4, 8, 2>(vals, tile_exchg_region_offset);
-    tile_exchg_region_offset >>= 1;
-    reg_exchg_fwd<8, 16, 1>(vals, tile_exchg_region_offset);
-  } else {
-    reg_exchg_cmem_twiddles_fwd<1, 2, 8>(vals, tile_exchg_region_offset);
-    tile_exchg_region_offset >>= 1;
-    reg_exchg_cmem_twiddles_fwd<2, 4, 4>(vals, tile_exchg_region_offset);
-    tile_exchg_region_offset >>= 1;
-    reg_exchg_cmem_twiddles_fwd<4, 8, 2>(vals, tile_exchg_region_offset);
-    tile_exchg_region_offset >>= 1;
-    reg_exchg_cmem_twiddles_fwd<8, 16, 1>(vals, tile_exchg_region_offset);
+    int tile_exchg_region_offset = (alternating_block_idx_y * THREAD_TILES_PER_BLOCK + tile_id) << 3;
+    if (start_stage == log_n - 8) {
+      reg_exchg_fwd<1, 2, 8>(vals, tile_exchg_region_offset);
+      tile_exchg_region_offset >>= 1;
+      reg_exchg_fwd<2, 4, 4>(vals, tile_exchg_region_offset);
+      tile_exchg_region_offset >>= 1;
+      reg_exchg_fwd<4, 8, 2>(vals, tile_exchg_region_offset);
+      tile_exchg_region_offset >>= 1;
+      reg_exchg_fwd<8, 16, 1>(vals, tile_exchg_region_offset);
+    } else {
+      reg_exchg_cmem_twiddles_fwd<1, 2, 8>(vals, tile_exchg_region_offset);
+      tile_exchg_region_offset >>= 1;
+      reg_exchg_cmem_twiddles_fwd<2, 4, 4>(vals, tile_exchg_region_offset);
+      tile_exchg_region_offset >>= 1;
+      reg_exchg_cmem_twiddles_fwd<4, 8, 2>(vals, tile_exchg_region_offset);
+      tile_exchg_region_offset >>= 1;
+      reg_exchg_cmem_twiddles_fwd<8, 16, 1>(vals, tile_exchg_region_offset);
+    }
+
+#pragma unroll
+    for (int i{0}, addr{thread_ct_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE)
+      smem_block[addr] = vals[i]; // write consecutive smem tiles
   }
-
-#pragma unroll
-  for (int i{0}, addr{thread_ct_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE)
-    smem_block[addr] = vals[i]; // write consecutive smem tiles
 
   __syncthreads();
 
 #pragma unroll
-  for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
-    vals[i] = smem_block[addr]; // read interleaved smem tiles
+  for (int role = 0; role < ROLES; role++) {
+    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    const int thread_il_gmem_start = lane_in_tile + tile_id * tile_gmem_stride;
+    const int thread_il_smem_start = lane_in_tile + tile_id * TILE_SIZE;
 
-  if (start_stage == log_n - 8) {
-    reg_exchg_fwd<1, 2, 8>(vals);
-    reg_exchg_fwd<2, 4, 4>(vals);
-    reg_exchg_fwd<4, 8, 2>(vals);
-    reg_exchg_final_fwd<8>(vals);
-  } else {
-    int block_exchg_region_offset = alternating_block_idx_y << 3;
-    reg_exchg_cmem_twiddles_fwd<1, 2, 8>(vals, block_exchg_region_offset);
-    block_exchg_region_offset >>= 1;
-    reg_exchg_cmem_twiddles_fwd<2, 4, 4>(vals, block_exchg_region_offset);
-    block_exchg_region_offset >>= 1;
-    reg_exchg_cmem_twiddles_fwd<4, 8, 2>(vals, block_exchg_region_offset);
-    block_exchg_region_offset >>= 1;
-    reg_exchg_cmem_twiddles_fwd<8, 16, 1>(vals, block_exchg_region_offset);
-  }
+    bf vals[VALS_PER_THREAD];
 
 #pragma unroll
-  for (int i{0}, addr{thread_il_gmem_start}; i < VALS_PER_THREAD; i++, addr += interleaved_gmem_stride)
-    gmem_out.set_at_row(addr, vals[i]);
+    for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
+      vals[i] = smem_block[addr]; // read interleaved smem tiles
+
+    if (start_stage == log_n - 8) {
+      reg_exchg_fwd<1, 2, 8>(vals);
+      reg_exchg_fwd<2, 4, 4>(vals);
+      reg_exchg_fwd<4, 8, 2>(vals);
+      reg_exchg_final_fwd<8>(vals);
+    } else {
+      int block_exchg_region_offset = alternating_block_idx_y << 3;
+      reg_exchg_cmem_twiddles_fwd<1, 2, 8>(vals, block_exchg_region_offset);
+      block_exchg_region_offset >>= 1;
+      reg_exchg_cmem_twiddles_fwd<2, 4, 4>(vals, block_exchg_region_offset);
+      block_exchg_region_offset >>= 1;
+      reg_exchg_cmem_twiddles_fwd<4, 8, 2>(vals, block_exchg_region_offset);
+      block_exchg_region_offset >>= 1;
+      reg_exchg_cmem_twiddles_fwd<8, 16, 1>(vals, block_exchg_region_offset);
+    }
+
+#pragma unroll
+    for (int i{0}, addr{thread_il_gmem_start}; i < VALS_PER_THREAD; i++, addr += interleaved_gmem_stride)
+      gmem_out.set_at_row(addr, vals[i]);
+  }
+}
+
+EXTERN __launch_bounds__(256, 3) __global__
+    void ab_monomials_to_evals_noninitial_8_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
+                                                          const int log_n, const int start_stage, const int num_cols_per_coset, const int log_cosets_in_tile) {
+  monomials_to_evals_noninitial_8_stages_body(gmem_in, gmem_out, log_n, start_stage, num_cols_per_coset, log_cosets_in_tile);
+}
+
+// Evict variant for the LAST noninitial pass: its input lines are dead after
+// this read and its output is not re-read within the LDE phase (next consumer
+// is the Merkle leaf hash), so evict-first keeps these dead lines from
+// evicting the monomials that later cosets' initials still need.
+EXTERN __launch_bounds__(256, 3) __global__
+    void ab_monomials_to_evals_noninitial_8_stages_evict_kernel(bf_matrix_getter<ld_modifier::cs> gmem_in, bf_matrix_setter<st_modifier::cs> gmem_out,
+                                                                const int log_n, const int start_stage, const int num_cols_per_coset,
+                                                                const int log_cosets_in_tile) {
+  monomials_to_evals_noninitial_8_stages_body(gmem_in, gmem_out, log_n, start_stage, num_cols_per_coset, log_cosets_in_tile);
 }
 
 template <int STAGES>

--- a/gpu/ntt/src/ntt/forward.rs
+++ b/gpu/ntt/src/ntt/forward.rs
@@ -9,6 +9,7 @@ use super::kernels::*;
 use super::shared;
 use gpu_core::primitives::device_structures::{
     DeviceMatrixChunk, DeviceMatrixChunkImpl, DeviceMatrixChunkMut, DeviceMatrixChunkMutImpl,
+    MutPtrAndStride, PtrAndStride,
 };
 use gpu_core::primitives::field::BaseField;
 use gpu_core::primitives::utils::GetChunksCount;
@@ -16,6 +17,53 @@ use gpu_core::primitives::utils::GetChunksCount;
 use std::mem::size_of;
 
 type BF = BaseField;
+
+/// The two forward noninitial passes for one (column-chunk, coset-tile). The
+/// LAST pass uses the evict variant: its inputs are dead after the read and
+/// its output is not re-read within the LDE phase.
+fn launch_noninitial_pair(
+    output_matrix_const: PtrAndStride<BF>,
+    output_matrix_mut: MutPtrAndStride<BF>,
+    log_n: usize,
+    ntts_in_launch: usize,
+    num_cols_per_coset: usize,
+    log_cosets_in_tile: i32,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    let n = 1usize << log_n;
+    let bf_vals_per_block = 1usize << 13; // 8192
+    let mut start_stage = log_n - 16;
+    for _ in 0..2 {
+        let num_block_exchg_regions = n >> (start_stage + 8);
+        let block_exchg_region_size = 1 << (start_stage + 8);
+        let blocks_per_exchg_region = block_exchg_region_size / bf_vals_per_block;
+        debug_assert_eq!(
+            blocks_per_exchg_region * num_block_exchg_regions,
+            n / bf_vals_per_block
+        );
+        let grid_dim: Dim3 = (blocks_per_exchg_region as u32
+            * num_block_exchg_regions as u32
+            * ntts_in_launch as u32)
+            .into();
+        let config = CudaLaunchConfig::basic(grid_dim, 256, stream);
+        let args = StridedTilesStagesArguments::new(
+            output_matrix_const,
+            output_matrix_mut,
+            log_n as i32,
+            start_stage as i32,
+            shared::checked_i32(num_cols_per_coset, "num_cols_per_coset"),
+            log_cosets_in_tile,
+        );
+        let noninitial = if start_stage == log_n - 8 {
+            ab_monomials_to_evals_noninitial_8_stages_evict_kernel
+        } else {
+            ab_monomials_to_evals_noninitial_8_stages_kernel
+        };
+        StridedTilesStagesFunction(noninitial).launch(&config, &args)?;
+        start_stage += 8;
+    }
+    Ok(())
+}
 
 pub(crate) fn monomials_to_evals_3_pass(
     inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
@@ -123,40 +171,87 @@ pub(crate) fn monomials_to_evals_3_pass(
                 log_cosets_in_tile,
             );
             initial_function.launch(&config, &args_initial)?;
-            // Two noninitial_8 passes with start_stage = log_n - 16, log_n - 8.
-            let threads = 512;
-            let mut start_stage = log_n - 16;
-            for _ in 0..2 {
-                let num_block_exchg_regions = n >> (start_stage + 8);
-                let block_exchg_region_size = 1 << (start_stage + 8);
-                let blocks_per_exchg_region = block_exchg_region_size / bf_vals_per_block;
-                debug_assert_eq!(
-                    blocks_per_exchg_region * num_block_exchg_regions,
-                    n / bf_vals_per_block
-                );
-                let grid_dim: Dim3 = (blocks_per_exchg_region as u32
-                    * num_block_exchg_regions as u32
-                    * cosets_in_tile as u32
-                    * cols_in_chunk as u32)
-                    .into();
-                let config = CudaLaunchConfig::basic(grid_dim, threads as u32, stream);
-                let args = StridedTilesStagesArguments::new(
-                    output_matrix_const,
-                    output_matrix_mut,
-                    log_n as i32,
-                    start_stage as i32,
-                    shared::checked_i32(num_cols_per_coset, "num_cols_per_coset"),
-                    log_cosets_in_tile,
-                );
-                StridedTilesStagesFunction(ab_monomials_to_evals_noninitial_8_stages_kernel)
-                    .launch(&config, &args)?;
-                start_stage += 8;
-            }
+            launch_noninitial_pair(
+                output_matrix_const,
+                output_matrix_mut,
+                log_n,
+                cosets_in_tile * cols_in_chunk,
+                num_cols_per_coset,
+                log_cosets_in_tile,
+                stream,
+            )?;
             coset_tile_start += cosets_in_tile;
         }
         col_start += cols_in_chunk;
     }
     Ok(())
+}
+
+/// First-coset arm of the fused-boundary LDE: the fused kernel (iNTT final +
+/// in-place monomial writeback + coset scale + forward initial) followed by
+/// the two noninitial passes. Transposed-monomial layout only.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn fused_writeback_single_coset_3_pass(
+    scratch_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
+    outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
+    log_n: usize,
+    coset_index_base: usize,
+    coset_factor_shift: u32,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    let n = 1 << log_n;
+    assert_eq!(scratch_matrix.rows(), n);
+    assert_eq!(outputs_matrix.rows(), n);
+    shared::assert_ntt_16b_aligned(scratch_matrix, outputs_matrix);
+    let num_ntts = scratch_matrix.cols();
+    assert_eq!(outputs_matrix.cols(), num_ntts);
+    let fused_function = match log_n {
+        21 => LdeFusedWritebackFunction(ab_lde_fused_boundary_writeback_5_stages_kernel),
+        22 => LdeFusedWritebackFunction(ab_lde_fused_boundary_writeback_6_stages_kernel),
+        23 => LdeFusedWritebackFunction(ab_lde_fused_boundary_writeback_7_stages_kernel),
+        24 => LdeFusedWritebackFunction(ab_lde_fused_boundary_writeback_8_stages_kernel),
+        _ => unreachable!("fused LDE boundary kernels are only generated for log_n in 21..=24"),
+    };
+    let scratch = scratch_matrix.as_mut_ptr_and_stride();
+    let output_matrix_const = {
+        let output_slice_const = unsafe {
+            DeviceSlice::from_raw_parts(
+                outputs_matrix.slice().as_ptr(),
+                outputs_matrix.slice().len(),
+            )
+        };
+        DeviceMatrixChunk::new(
+            output_slice_const,
+            outputs_matrix.stride(),
+            outputs_matrix.offset(),
+            n,
+        )
+        .as_ptr_and_stride()
+    };
+    let output_matrix_mut = outputs_matrix.as_mut_ptr_and_stride();
+    let bf_vals_per_block = 1 << 13; // 8192
+    let blocks = n.get_chunks_count(bf_vals_per_block);
+    let grid_dim: Dim3 = (blocks as u32 * num_ntts as u32).into();
+    let config = CudaLaunchConfig::basic(grid_dim, 256, stream);
+    let args = LdeFusedWritebackArguments::new(
+        scratch,
+        output_matrix_mut,
+        log_n as i32,
+        shared::checked_i32(coset_index_base, "coset_index_base"),
+        shared::checked_i32(coset_factor_shift as usize, "coset_factor_shift"),
+        shared::checked_i32(num_ntts, "num_cols_per_coset"),
+        0,
+    );
+    fused_function.launch(&config, &args)?;
+    launch_noninitial_pair(
+        output_matrix_const,
+        output_matrix_mut,
+        log_n,
+        num_ntts,
+        num_ntts,
+        0,
+        stream,
+    )
 }
 
 pub(crate) fn monomials_to_evals_compact_1_pass(
@@ -607,7 +702,7 @@ pub(crate) fn monomials_to_evals_2_pass_compact_initial(
             );
             pass1_function.launch(&config, &args)?;
             // Pass 2: noninitial_8 with start_stage = log_k.
-            let threads_pass2 = 512;
+            let threads_pass2 = 256;
             let bf_vals_per_block_pass2 = 1 << 13;
             let start_stage = log_k;
             let num_block_exchg_regions = n >> (start_stage + 8);

--- a/gpu/ntt/src/ntt/hypercube.rs
+++ b/gpu/ntt/src/ntt/hypercube.rs
@@ -55,6 +55,43 @@ hypercube_evals_to_monomials_final!(ab_hypercube_evals_to_monomials_final_6_stag
 hypercube_evals_to_monomials_final!(ab_hypercube_evals_to_monomials_final_7_stages_kernel);
 hypercube_evals_to_monomials_final!(ab_hypercube_evals_to_monomials_final_8_stages_kernel);
 
+/// The two hypercube nonfinal passes for one column (pass 1 reads the
+/// hypercube evals, pass 2 runs in place on the output).
+fn launch_nonfinal_passes(
+    input_matrix: PtrAndStride<BF>,
+    output_matrix_const: PtrAndStride<BF>,
+    output_matrix_mut: MutPtrAndStride<BF>,
+    log_n: usize,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    let n = 1usize << log_n;
+    let bf_vals_per_block = 1usize << 13; // 8192
+    let mut start_stage = 0;
+    for i in 0..2 {
+        let num_exchg_regions = 1 << start_stage;
+        let exchg_region_size = n >> start_stage;
+        let blocks_per_exchg_region = exchg_region_size / bf_vals_per_block;
+        assert_eq!(
+            blocks_per_exchg_region * num_exchg_regions,
+            n / bf_vals_per_block
+        );
+        let mut grid_dim: Dim3 = (blocks_per_exchg_region as u32).into();
+        grid_dim.y = num_exchg_regions as u32;
+        let config = CudaLaunchConfig::basic(grid_dim, 256, stream);
+        let input = if i == 0 {
+            input_matrix
+        } else {
+            output_matrix_const
+        };
+        let args =
+            StridedTilesStagesArguments::new(input, output_matrix_mut, log_n as i32, start_stage);
+        StridedTilesStagesFunction(ab_hypercube_evals_to_monomials_nonfinal_8_stages_kernel)
+            .launch(&config, &args)?;
+        start_stage += 8;
+    }
+    Ok(())
+}
+
 pub(crate) fn hypercube_evals_to_monomials_3_pass(
     inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
     outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
@@ -67,6 +104,7 @@ pub(crate) fn hypercube_evals_to_monomials_3_pass(
     assert_eq!(outputs_matrix.rows(), n);
     shared::assert_ntt_16b_aligned(inputs_matrix, outputs_matrix);
     let num_ntts = outputs_matrix.cols();
+    assert_eq!(inputs_matrix.cols(), num_ntts);
     let inputs_slice = inputs_matrix.slice();
     let stride = outputs_matrix.stride();
     let offset = outputs_matrix.offset();
@@ -89,35 +127,13 @@ pub(crate) fn hypercube_evals_to_monomials_3_pass(
         let input_matrix = input_matrix.as_ptr_and_stride();
         let output_matrix_const = output_matrix_const.as_ptr_and_stride();
         let output_matrix_mut = output_matrix_mut.as_mut_ptr_and_stride();
-        let threads = 512;
-        let bf_vals_per_block = 1 << 13; // 8192
-        let mut start_stage = 0;
-        for i in 0..2 {
-            let num_exchg_regions = 1 << start_stage;
-            let exchg_region_size = n >> start_stage;
-            let blocks_per_exchg_region = exchg_region_size / bf_vals_per_block;
-            assert_eq!(
-                blocks_per_exchg_region * num_exchg_regions,
-                n / bf_vals_per_block
-            );
-            let mut grid_dim: Dim3 = (blocks_per_exchg_region as u32).into();
-            grid_dim.y = num_exchg_regions as u32;
-            let config = CudaLaunchConfig::basic(grid_dim, threads as u32, stream);
-            let input = if i == 0 {
-                input_matrix
-            } else {
-                output_matrix_const
-            };
-            let args = StridedTilesStagesArguments::new(
-                input,
-                output_matrix_mut,
-                log_n as i32,
-                start_stage,
-            );
-            StridedTilesStagesFunction(ab_hypercube_evals_to_monomials_nonfinal_8_stages_kernel)
-                .launch(&config, &args)?;
-            start_stage += 8;
-        }
+        launch_nonfinal_passes(
+            input_matrix,
+            output_matrix_const,
+            output_matrix_mut,
+            log_n,
+            stream,
+        )?;
         let threads = 256;
         let bf_vals_per_block = 1 << 13; // 8192
         let blocks = n.get_chunks_count(bf_vals_per_block);
@@ -147,6 +163,55 @@ pub(crate) fn hypercube_evals_to_monomials_3_pass(
             }
             _ => unreachable!("hypercube 3-pass kernels are only generated for log_n in 21..=24"),
         }
+    }
+    Ok(())
+}
+
+/// [`hypercube_evals_to_monomials_3_pass`] minus the final pass: leaves the
+/// PRE-TAIL intermediate in `outputs_matrix` for the fused LDE boundary kernel
+/// (which applies the final `log_n - 16` stages inline for the first coset,
+/// materializing the monomials in place as it goes).
+pub(crate) fn hypercube_evals_to_pre_tail_monomials_3_pass(
+    inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
+    log_n: usize,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    let n = 1 << log_n;
+    assert_eq!(inputs_matrix.rows(), n);
+    assert_eq!(outputs_matrix.rows(), n);
+    shared::assert_ntt_16b_aligned(inputs_matrix, outputs_matrix);
+    let num_ntts = outputs_matrix.cols();
+    assert_eq!(inputs_matrix.cols(), num_ntts);
+    let inputs_slice = inputs_matrix.slice();
+    let stride = outputs_matrix.stride();
+    let offset = outputs_matrix.offset();
+    let outputs_slice_const = unsafe {
+        DeviceSlice::from_raw_parts(
+            outputs_matrix.slice().as_ptr(),
+            outputs_matrix.slice().len(),
+        )
+    };
+    let outputs_slice_mut = outputs_matrix.slice_mut();
+    // Work on 1 column at a time to leverage whatever L2 persistence we can
+    for col in 0..num_ntts {
+        let range = col * stride..(col + 1) * stride;
+        let input_slice = &inputs_slice[range.clone()];
+        let output_slice_const = &outputs_slice_const[range.clone()];
+        let output_slice_mut = &mut outputs_slice_mut[range.clone()];
+        let input_matrix = DeviceMatrixChunk::new(input_slice, stride, offset, n);
+        let output_matrix_const = DeviceMatrixChunk::new(output_slice_const, stride, offset, n);
+        let mut output_matrix_mut = DeviceMatrixChunkMut::new(output_slice_mut, stride, offset, n);
+        let input_matrix = input_matrix.as_ptr_and_stride();
+        let output_matrix_const = output_matrix_const.as_ptr_and_stride();
+        let output_matrix_mut = output_matrix_mut.as_mut_ptr_and_stride();
+        launch_nonfinal_passes(
+            input_matrix,
+            output_matrix_const,
+            output_matrix_mut,
+            log_n,
+            stream,
+        )?;
     }
     Ok(())
 }

--- a/gpu/ntt/src/ntt/inverse.rs
+++ b/gpu/ntt/src/ntt/inverse.rs
@@ -62,7 +62,7 @@ pub(crate) fn evals_to_monomials_3_pass(
         let input_matrix = input_matrix.as_ptr_and_stride();
         let output_matrix_const = output_matrix_const.as_ptr_and_stride();
         let output_matrix_mut = output_matrix_mut.as_mut_ptr_and_stride();
-        let threads = 512;
+        let threads = 256;
         let bf_vals_per_block = 1 << 13; // 8192
         let mut start_stage = 0;
         for i in 0..2 {

--- a/gpu/ntt/src/ntt/kernels.rs
+++ b/gpu/ntt/src/ntt/kernels.rs
@@ -52,6 +52,8 @@ strided_tiles_stages!(ab_monomials_to_evals_last_10_stages_kernel);
 
 // 3-pass monomials to evals
 strided_tiles_stages!(ab_monomials_to_evals_noninitial_8_stages_kernel);
+// evict-first variant for the LAST noninitial pass (hybrid LDE path)
+strided_tiles_stages!(ab_monomials_to_evals_noninitial_8_stages_evict_kernel);
 
 cuda_kernel_signature_and_arguments!(
     pub(super) EvalsToMonomialsFinal,
@@ -90,6 +92,44 @@ evals_to_monomials_final!(ab_evals_to_monomials_final_5_stages_kernel);
 evals_to_monomials_final!(ab_evals_to_monomials_final_6_stages_kernel);
 evals_to_monomials_final!(ab_evals_to_monomials_final_7_stages_kernel);
 evals_to_monomials_final!(ab_evals_to_monomials_final_8_stages_kernel);
+
+cuda_kernel_signature_and_arguments!(
+    pub(super) LdeFusedWriteback,
+    scratch_matrix: MutPtrAndStride<BF>,
+    outputs_matrix: MutPtrAndStride<BF>,
+    log_n: i32,
+    coset_index_base: i32,
+    coset_factor_shift: i32,
+    num_cols_per_coset: i32,
+    log_cosets_in_tile: i32,
+);
+pub(super) struct LdeFusedWritebackFunction(pub(super) LdeFusedWritebackSignature);
+impl era_cudart::execution::KernelFunction for LdeFusedWritebackFunction {
+    type Signature = LdeFusedWritebackSignature;
+    fn as_ptr(&self) -> *const std::os::raw::c_void {
+        self.0 as *const std::os::raw::c_void
+    }
+}
+macro_rules! lde_fused_writeback {
+    ($kernel_name:ident) => {
+        ::era_cudart::cuda_kernel_declaration!(pub(super) $kernel_name(
+    scratch_matrix: MutPtrAndStride<BF>,
+    outputs_matrix: MutPtrAndStride<BF>,
+    log_n: i32,
+    coset_index_base: i32,
+    coset_factor_shift: i32,
+    num_cols_per_coset: i32,
+    log_cosets_in_tile: i32,
+        ));
+    };
+}
+
+// Fused hypercube-iNTT-final + monomial writeback + coset-scale +
+// forward-initial (transposed path, first coset of a column)
+lde_fused_writeback!(ab_lde_fused_boundary_writeback_5_stages_kernel);
+lde_fused_writeback!(ab_lde_fused_boundary_writeback_6_stages_kernel);
+lde_fused_writeback!(ab_lde_fused_boundary_writeback_7_stages_kernel);
+lde_fused_writeback!(ab_lde_fused_boundary_writeback_8_stages_kernel);
 
 cuda_kernel_signature_and_arguments!(
     pub(super) MonomialsToEvalsInitial,

--- a/gpu/ntt/src/ntt/lde.rs
+++ b/gpu/ntt/src/ntt/lde.rs
@@ -8,9 +8,11 @@ use era_cudart::stream::CudaStream;
 use super::dispatch::dispatch_strategy;
 use super::dit::monomials_to_evals_dit;
 use super::forward::{
-    monomials_to_evals_2_pass_compact_initial, monomials_to_evals_3_pass,
-    monomials_to_evals_compact_1_pass, monomials_to_evals_smem_packed, monomials_to_evals_subwarp,
+    fused_writeback_single_coset_3_pass, monomials_to_evals_2_pass_compact_initial,
+    monomials_to_evals_3_pass, monomials_to_evals_compact_1_pass, monomials_to_evals_smem_packed,
+    monomials_to_evals_subwarp,
 };
+use super::hypercube::hypercube_evals_to_pre_tail_monomials_3_pass;
 use super::kernels::*;
 use super::shared;
 
@@ -163,7 +165,7 @@ pub(crate) fn lde_intermediate_range(
         "cosets_in_tile must be a power of 2 (got {cosets_in_tile})"
     );
     let log_cosets_in_tile = cosets_in_tile.trailing_zeros();
-    let threads_pass2 = 512;
+    let threads_pass2 = 256;
     let bf_vals_per_block_pass2 = 1 << 13;
     let start_stage = log_k;
     let num_block_exchg_regions = trace_len >> (start_stage + 8);
@@ -241,6 +243,108 @@ pub fn bitreversed_monomials_to_natural_evals_multi_coset(
 }
 
 pub const MAX_LOG_N_FOR_SINGLE_KERNEL_LDE: usize = 13;
+
+/// Fused-boundary LDE for the trace-holder hypercube path: the standalone
+/// hypercube final pass disappears into the first coset's fused launch, which
+/// also materializes the monomials in place for the remaining cosets. Returns
+/// `Ok(false)` without scheduling anything when ineligible (non-transposed
+/// log_n or a 2-pass regime); callers fall back to the unfused sequence.
+#[allow(clippy::too_many_arguments)]
+pub fn hypercube_to_multi_coset_evals_fused(
+    inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    coeff_scratch: &mut DeviceSlice<BF>,
+    outputs: &mut DeviceSlice<BF>,
+    log_n: usize,
+    log_lde_factor: usize,
+    num_cols_per_coset_stride: usize,
+    stream: &CudaStream,
+    device_properties: &DeviceProperties,
+) -> CudaResult<bool> {
+    if !super::log_size_supports_transposed_monomials(log_n) {
+        return Ok(false);
+    }
+    if !matches!(
+        super::ntt_pass_selection(log_n, device_properties),
+        super::NttPassCount::Three
+    ) {
+        return Ok(false);
+    }
+    let trace_len = 1usize << log_n;
+    let num_cosets = 1usize << log_lde_factor;
+    let num_cols = inputs_matrix.cols();
+    let strategy = super::select_ntt_strategy(
+        super::NttDirection::Forward,
+        log_n,
+        num_cols,
+        num_cosets,
+        device_properties,
+    )
+    .unwrap_or_else(|e| unreachable!("forward strategy unavailable: {e:?}"));
+    if strategy.passes.len() != 3 {
+        return Ok(false);
+    }
+    assert!(
+        log_n + log_lde_factor <= OMEGA_LOG_ORDER as usize,
+        "log_n ({log_n}) + log_lde_factor ({log_lde_factor}) > OMEGA_LOG_ORDER ({OMEGA_LOG_ORDER})",
+    );
+    assert!(num_cols_per_coset_stride >= num_cols);
+    let scratch_len = num_cols * trace_len;
+    assert!(coeff_scratch.len() >= scratch_len);
+    let max_col_offset_exclusive = (num_cosets - 1) * num_cols_per_coset_stride + num_cols;
+    assert!(outputs.len() >= max_col_offset_exclusive * trace_len);
+
+    let mut scratch_matrix = DeviceMatrixMut::new(&mut coeff_scratch[0..scratch_len], trace_len);
+    hypercube_evals_to_pre_tail_monomials_3_pass(
+        inputs_matrix,
+        &mut scratch_matrix,
+        log_n,
+        stream,
+    )?;
+
+    let coset_factor_shift = (OMEGA_LOG_ORDER as usize - log_n - log_lde_factor) as u32;
+    {
+        let coset0_chunk = &mut outputs[0..num_cols * trace_len];
+        let mut coset0_matrix = DeviceMatrixMut::new(coset0_chunk, trace_len);
+        fused_writeback_single_coset_3_pass(
+            &mut scratch_matrix,
+            &mut coset0_matrix,
+            log_n,
+            0,
+            coset_factor_shift,
+            stream,
+        )?;
+    }
+    // Cosets 1..K over the materialized monomials.
+    let monomials_const =
+        unsafe { DeviceSlice::from_raw_parts(coeff_scratch.as_ptr(), scratch_len) };
+    let monomials_matrix =
+        gpu_core::primitives::device_structures::DeviceMatrix::new(monomials_const, trace_len);
+    let mut coset = 1usize;
+    while coset < num_cosets {
+        let remaining = num_cosets - coset;
+        let tile = strategy.cosets_per_launch.min(1usize << remaining.ilog2());
+        let chunk_start = coset * num_cols_per_coset_stride * trace_len;
+        let chunk_end =
+            (coset + tile - 1) * num_cols_per_coset_stride * trace_len + num_cols * trace_len;
+        let chunk = &mut outputs[chunk_start..chunk_end];
+        let mut coset_matrix = DeviceMatrixMut::new(chunk, trace_len);
+        monomials_to_evals_3_pass(
+            &monomials_matrix,
+            &mut coset_matrix,
+            log_n,
+            coset,
+            coset_factor_shift,
+            tile,
+            num_cols_per_coset_stride,
+            tile,
+            strategy.columns_per_launch,
+            true,
+            stream,
+        )?;
+        coset += tile;
+    }
+    Ok(true)
+}
 
 /// Multi-coset forward NTT over a caller-selected coset range.
 ///

--- a/gpu/ntt/src/ntt/mod.rs
+++ b/gpu/ntt/src/ntt/mod.rs
@@ -55,8 +55,8 @@ pub(crate) use forward::{monomials_to_evals_2_pass_smem, monomials_to_evals_3_pa
 #[cfg(test)]
 pub(crate) use inverse::{evals_to_monomials_2_pass, evals_to_monomials_3_pass};
 pub use lde::{
-    bitreversed_monomials_to_natural_evals_multi_coset, lde_with_coset_range,
-    MAX_LOG_N_FOR_SINGLE_KERNEL_LDE,
+    bitreversed_monomials_to_natural_evals_multi_coset, hypercube_to_multi_coset_evals_fused,
+    lde_with_coset_range, MAX_LOG_N_FOR_SINGLE_KERNEL_LDE,
 };
 pub(crate) use strategy::{select_ntt_strategy, NttDirection, NttKernelKind, NttStrategy};
 

--- a/gpu/ntt/src/ntt/tests/lde_writeback_hybrid.rs
+++ b/gpu/ntt/src/ntt/tests/lde_writeback_hybrid.rs
@@ -1,0 +1,100 @@
+//! Parity gates for the fused-boundary LDE path: the hybrid must produce
+//! byte-identical coset outputs AND a byte-identical materialized monomial
+//! scratch (the fused kernel's in-place side output) versus the unfused
+//! hypercube-final + multi-coset-initial sequence.
+
+use era_cudart::memory::{memory_copy_async, DeviceAllocation};
+
+use super::super::{
+    bitreversed_monomials_to_natural_evals_multi_coset, hypercube_to_multi_coset_evals_fused,
+    hypercube_x1_msb_evals_to_x1_msb_monomials,
+};
+use super::make_context;
+use gpu_core::primitives::device_structures::DeviceMatrixChunk;
+use gpu_core::primitives::field::BaseField;
+
+type BF = BaseField;
+
+fn check_case(log_n: usize, log_lde_factor: usize) {
+    let ctx = make_context();
+    let stream = ctx.get_exec_stream();
+    let n = 1usize << log_n;
+    let num_cosets = 1usize << log_lde_factor;
+
+    let input = (0..n)
+        .map(|idx| BF::new(29 + (idx as u32).wrapping_mul(2654435761)))
+        .collect::<Vec<_>>();
+    let mut d_in = DeviceAllocation::<BF>::alloc(n).unwrap();
+    let mut d_scratch_old = DeviceAllocation::<BF>::alloc(n).unwrap();
+    let mut d_scratch_new = DeviceAllocation::<BF>::alloc(n).unwrap();
+    let mut d_out_old = DeviceAllocation::<BF>::alloc(num_cosets * n).unwrap();
+    let mut d_out_new = DeviceAllocation::<BF>::alloc(num_cosets * n).unwrap();
+    memory_copy_async(&mut d_in, &input[..], stream).unwrap();
+
+    // Old sequence: standalone hypercube final into scratch, then the
+    // multi-coset initial path over the monomials.
+    hypercube_x1_msb_evals_to_x1_msb_monomials(
+        &d_in[..],
+        &mut d_scratch_old[..],
+        log_n,
+        true,
+        stream,
+        ctx.get_device_properties(),
+    )
+    .unwrap();
+    let monomials = DeviceMatrixChunk::new(&d_scratch_old[..], n, 0, n);
+    bitreversed_monomials_to_natural_evals_multi_coset(
+        &monomials,
+        &mut d_out_old[..],
+        log_n,
+        log_lde_factor,
+        1,
+        true,
+        ctx.device_context(),
+        None,
+        stream,
+        ctx.get_device_properties(),
+    )
+    .unwrap();
+
+    // Hybrid path.
+    let fused = hypercube_to_multi_coset_evals_fused(
+        &d_in[..],
+        &mut d_scratch_new[..],
+        &mut d_out_new[..],
+        log_n,
+        log_lde_factor,
+        1,
+        stream,
+        ctx.get_device_properties(),
+    )
+    .unwrap();
+    assert!(fused, "hybrid path must be eligible at log_n {log_n}");
+
+    let mut h_scratch_old = vec![BF::new(0); n];
+    let mut h_scratch_new = vec![BF::new(0); n];
+    let mut h_out_old = vec![BF::new(0); num_cosets * n];
+    let mut h_out_new = vec![BF::new(0); num_cosets * n];
+    memory_copy_async(&mut h_scratch_old[..], &d_scratch_old, stream).unwrap();
+    memory_copy_async(&mut h_scratch_new[..], &d_scratch_new, stream).unwrap();
+    memory_copy_async(&mut h_out_old[..], &d_out_old, stream).unwrap();
+    memory_copy_async(&mut h_out_new[..], &d_out_new, stream).unwrap();
+    stream.synchronize().unwrap();
+
+    assert_ne!(h_out_old, vec![BF::new(0); num_cosets * n]);
+    assert_eq!(
+        h_scratch_old, h_scratch_new,
+        "materialized monomials mismatch at log_n {log_n}, K {num_cosets}"
+    );
+    assert_eq!(
+        h_out_old, h_out_new,
+        "coset outputs mismatch at log_n {log_n}, K {num_cosets}"
+    );
+}
+
+#[test]
+fn test_lde_writeback_hybrid_matches_unfused() {
+    for (log_n, log_lde_factor) in [(21, 1), (22, 1), (23, 1), (24, 1), (22, 2), (24, 0)] {
+        check_case(log_n, log_lde_factor);
+    }
+}

--- a/gpu/ntt/src/ntt/tests/mod.rs
+++ b/gpu/ntt/src/ntt/tests/mod.rs
@@ -1672,6 +1672,7 @@ multi_coset_parity_test!(multi_coset_monomials_to_evals_log_n_1_cosets_32, 1, 32
 
 mod dit_engine;
 mod helpers;
+mod lde_writeback_hybrid;
 use crate::upstream::{Field, PrimeField};
 #[allow(unused_imports)]
 use helpers::*;

--- a/gpu/trace/src/trace/holder/mod.rs
+++ b/gpu/trace/src/trace/holder/mod.rs
@@ -22,8 +22,8 @@ use gpu_hash::blake2s::{
     gather_leaf_rows, gather_merkle_paths_device, gather_merkle_paths_from_rows,
 };
 use gpu_ntt::ntt::{
-    bitreversed_monomials_to_natural_evals_multi_coset, hypercube_x1_msb_evals_to_x1_msb_monomials,
-    log_size_supports_transposed_monomials,
+    bitreversed_monomials_to_natural_evals_multi_coset, hypercube_to_multi_coset_evals_fused,
+    hypercube_x1_msb_evals_to_x1_msb_monomials, log_size_supports_transposed_monomials,
 };
 use gpu_prover_context::ProverContext;
 
@@ -370,14 +370,6 @@ impl TraceHolder<BF> {
         for column in 0..self.columns_count {
             let offset = column * domain_size;
             let source_column = &source[offset..offset + domain_size];
-            hypercube_x1_msb_evals_to_x1_msb_monomials(
-                source_column,
-                &mut coeff_scratch[0..domain_size],
-                self.log_domain_size as usize,
-                use_transposed_monomials,
-                stream,
-                context.get_device_properties(),
-            )?;
 
             match &mut self.cosets {
                 CosetsHolder::Full(backing) => {
@@ -387,25 +379,49 @@ impl TraceHolder<BF> {
                     // column's position and uses num_cols_per_coset_stride =
                     // columns_count to write each coset's slab in one launch,
                     // replacing the per-coset NTT loop.
-                    let monomials = DeviceMatrixChunk::new(
-                        &coeff_scratch[0..domain_size],
-                        domain_size,
-                        0,
-                        domain_size,
-                    );
                     let backing_from_col = &mut backing[offset..];
-                    bitreversed_monomials_to_natural_evals_multi_coset(
-                        &monomials,
+                    // Hybrid fused-boundary path: the hypercube final pass runs
+                    // once, fused with coset 0's forward initial + in-place
+                    // monomial writeback (transposed 3-pass regime only; falls
+                    // back below).
+                    let fused = hypercube_to_multi_coset_evals_fused(
+                        source_column,
+                        &mut coeff_scratch[0..domain_size],
                         backing_from_col,
                         self.log_domain_size as usize,
                         self.log_lde_factor as usize,
                         self.columns_count,
-                        use_transposed_monomials,
-                        ntt_ctx,
-                        scratch_opt.as_deref_mut(),
                         stream,
                         context.get_device_properties(),
                     )?;
+                    if !fused {
+                        hypercube_x1_msb_evals_to_x1_msb_monomials(
+                            source_column,
+                            &mut coeff_scratch[0..domain_size],
+                            self.log_domain_size as usize,
+                            use_transposed_monomials,
+                            stream,
+                            context.get_device_properties(),
+                        )?;
+                        let monomials = DeviceMatrixChunk::new(
+                            &coeff_scratch[0..domain_size],
+                            domain_size,
+                            0,
+                            domain_size,
+                        );
+                        bitreversed_monomials_to_natural_evals_multi_coset(
+                            &monomials,
+                            backing_from_col,
+                            self.log_domain_size as usize,
+                            self.log_lde_factor as usize,
+                            self.columns_count,
+                            use_transposed_monomials,
+                            ntt_ctx,
+                            scratch_opt.as_deref_mut(),
+                            stream,
+                            context.get_device_properties(),
+                        )?;
+                    }
                 }
                 CosetsHolder::None(_) => {
                     panic!("cosets not allocated — call ensure_cosets_materialized first")


### PR DESCRIPTION
## What ❔

- Fuses the hypercube-iNTT final pass with the first coset's forward initial in the trace-holder LDE (transposed 3-pass regime, with fallback): one kernel computes the tail, materializes the transposed monomials in place over the pre-tail scratch, and produces coset 0; later cosets run the plain initial path with no tail recompute.
- The last forward noninitial pass gets an `ld.cs`/`st.cs` variant — its inputs are dead after the read and its output is not re-read within the phase — so its dead lines stop evicting the materialized monomials.
- The 3-pass middle kernels (forward noninitial + evict, inverse and hypercube nonfinal) switch from 512 threads × 2 blocks/SM to 256 × 3 with two tile roles per thread — byte-identical address permutation, more independent `__syncthreads` domains per SM.

## Why ❔

The standalone final pass disappears, the monomials stay L2-resident for the coset sweep, and the middles gain occupancy: memory commit 13.23 → 12.26 ms, witness commit 11.05 → 10.21, setup cosets 3.25 → 2.96 = **−2.10 ms/proof** in the commit phases plus ~−0.4 in whir (add_sub 2^24, 3 runs each). Proofs byte-identical (add_sub sec100 + unified); new gpu_ntt gates compare coset outputs and the materialized scratch against the unfused sequence (log 21–24, K ∈ {1,2,4}); compute-sanitizer clean.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.