### PR TITLE
refactor(gpu_gkr): fixed 5-slot dim-reducing backward descriptor

### DIFF
--- a/gpu/gkr/native/gkr/backward/dim_reducing.cu
+++ b/gpu/gkr/native/gkr/backward/dim_reducing.cu
@@ -65,17 +65,11 @@ EXTERN __global__ void ab_gkr_dim_reducing_trace_holder_column_sums_e4_kernel(co
   gkr_trace_holder_column_sums(block_partials, column_sums, blocks_count);
 }
 
-EXTERN __global__ void ab_gkr_dim_reducing_round0_batched_compact_e4_kernel(const __grid_constant__ gkr_dim_reducing_round0_batch_compact<e4> batch,
-                                                                            const unsigned acc_size) {
+EXTERN __global__ void ab_gkr_dim_reducing_round0_batched_compact_e4_kernel(const __grid_constant__ gkr_dim_reducing_batch<e4> batch, const unsigned acc_size) {
   gkr_dim_reducing_round0_batched_compact(batch, acc_size);
 }
 
-EXTERN __global__ void ab_gkr_dim_reducing_round1_batched_compact_e4_kernel(const __grid_constant__ gkr_dim_reducing_continuation_batch_compact<e4> batch,
-                                                                            const unsigned acc_size) {
-  gkr_dim_reducing_round1_batched_compact_inner<e4>(batch, acc_size);
-}
-
-EXTERN __global__ void ab_gkr_dim_reducing_continuation_batched_compact_e4_kernel(const __grid_constant__ gkr_dim_reducing_continuation_batch_compact<e4> batch,
+EXTERN __global__ void ab_gkr_dim_reducing_continuation_batched_compact_e4_kernel(const __grid_constant__ gkr_dim_reducing_batch<e4> batch,
                                                                                   const unsigned acc_size, const unsigned step) {
   gkr_dim_reducing_continuation_batched_compact_inner<e4>(batch, acc_size, step);
 }

--- a/gpu/gkr/native/gkr/support/descriptors.cuh
+++ b/gpu/gkr/native/gkr/support/descriptors.cuh
@@ -138,7 +138,10 @@ static_assert(__builtin_offsetof(gkr_dim_reducing_batch<e4>, enabled_mask) == 0 
 static_assert(sizeof(gkr_dim_reducing_batch<e4>) + 2 * sizeof(u32) <= 32764, "dim-reducing kernel parameters exceed CUDA limit");
 
 // Merged tower batch (blockIdx.y selects the pair). A pair's two streams are either two
-// independent product towers (PAIRWISE2) or one lookup tower's num/den (LOOKUP).
+// independent product towers (PAIRWISE2) or one lookup tower's num/den (LOOKUP). The kind
+// is not per-pair wire data: `pairwise_mask` carries one bit per pair index, so pairs stay
+// densely packed and the grid's y extent stays `pair_count`. The PAIRWISE2 / LOOKUP tags
+// remain the shared vocabulary of the forward VM's own reduction-pair descriptor.
 static constexpr unsigned GKR_DIM_REDUCING_FORWARD_TOWER_PAIR_CAP = 5;
 static constexpr unsigned GKR_DIM_REDUCING_FORWARD_TOWER_PAIRWISE2 = 0;
 static constexpr unsigned GKR_DIM_REDUCING_FORWARD_TOWER_LOOKUP = 1;
@@ -146,8 +149,6 @@ static constexpr unsigned GKR_DIM_REDUCING_FORWARD_TOWER_LOOKUP = 1;
 template <typename E> struct gkr_dim_reducing_forward_tower_pair {
   const E *input[2];
   E *round_outputs[GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS][2];
-  u32 kind;
-  u32 reserved;
 };
 
 template <typename E> struct gkr_dim_reducing_forward_tower_batch {
@@ -155,11 +156,11 @@ template <typename E> struct gkr_dim_reducing_forward_tower_batch {
   u32 pair_count;
   u32 input_len;
   u32 round_count;
-  u32 reserved;
+  u32 pairwise_mask;
 };
 
-static_assert(sizeof(gkr_dim_reducing_forward_tower_pair<e4>) == 152, "tower pair ABI size drift");
-static_assert(sizeof(gkr_dim_reducing_forward_tower_batch<e4>) == 776, "tower batch ABI size drift");
+static_assert(sizeof(gkr_dim_reducing_forward_tower_pair<e4>) == 144, "tower pair ABI size drift");
+static_assert(sizeof(gkr_dim_reducing_forward_tower_batch<e4>) == 736, "tower batch ABI size drift");
 static_assert(alignof(gkr_dim_reducing_forward_tower_batch<e4>) == 8, "tower batch ABI alignment drift");
 
 struct gkr_forward_setup_generic_lookup_descriptor {

--- a/gpu/gkr/native/gkr/support/descriptors.cuh
+++ b/gpu/gkr/native/gkr/support/descriptors.cuh
@@ -31,12 +31,13 @@ template <typename E> struct gkr_ext_continuing_source {
   bool first_access;
 };
 
-// Dim-reducing layers are keyed by OutputType: 2 pairwise records for
-// PermutationProduct, up to 3 lookup records, plus (unified circuit)
-// 2 pairwise records for InitsAndTeardownsProduct = 7 records / 10 challenges.
+// One slot per OutputType; `enabled_mask` selects the ones this circuit uses.
 // Kept in lockstep with the Rust mirror by `compact_cuda_constants_match_rust`.
-static constexpr unsigned GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER = 7;
-static constexpr unsigned GKR_DIM_REDUCING_BATCH_CHALLENGE_TABLE_LEN = 10;
+static constexpr unsigned GKR_DIM_REDUCING_SLOTS = 5;
+static constexpr unsigned GKR_DIM_REDUCING_INPUTS_PER_SLOT = 2;
+static constexpr unsigned GKR_DIM_REDUCING_OUTPUTS_PER_SLOT = 2;
+static constexpr unsigned GKR_DIM_REDUCING_IO_PER_SLOT = GKR_DIM_REDUCING_INPUTS_PER_SLOT + GKR_DIM_REDUCING_OUTPUTS_PER_SLOT;
+static constexpr unsigned GKR_DIM_REDUCING_BATCH_CHALLENGE_TABLE_LEN = GKR_DIM_REDUCING_SLOTS * GKR_DIM_REDUCING_OUTPUTS_PER_SLOT;
 static constexpr unsigned GKR_BACKWARD_MAX_TRACE_LEN_LOG2 = 24;
 // Dim-reducing stores folding_steps - 1 round challenges plus 3 transcript challenges.
 static constexpr unsigned GKR_DIM_REDUCING_LAYER_CLAIM_POINT_LEN = GKR_BACKWARD_MAX_TRACE_LEN_LOG2 + 2;
@@ -71,29 +72,23 @@ struct gkr_eq_sizes {
 static_assert(alignof(gkr_eq_sizes) == 4 && sizeof(gkr_eq_sizes) == 12, "eq sizes ABI drift");
 static_assert(__builtin_offsetof(gkr_eq_sizes, high) == 0 && __builtin_offsetof(gkr_eq_sizes, low) == 8, "eq sizes offsets drift");
 
-enum gkr_dim_reducing_kernel_kind : u32 {
-  GKR_DIM_REDUCING_PAIRWISE = 0,
-  GKR_DIM_REDUCING_LOOKUP = 1,
+// Slot index == OutputType discriminant, so a slot's kind is a compile-time
+// property of its index rather than wire data.
+enum gkr_dim_reducing_slot_index : u32 {
+  GKR_DIM_REDUCING_SLOT_PERMUTATION_PRODUCT = 0,
+  GKR_DIM_REDUCING_SLOT_LOOKUP_16_BITS = 1,
+  GKR_DIM_REDUCING_SLOT_LOOKUP_TIMESTAMPS = 2,
+  GKR_DIM_REDUCING_SLOT_GENERIC_LOOKUP = 3,
+  GKR_DIM_REDUCING_SLOT_INITS_AND_TEARDOWNS_PRODUCT = 4,
 };
 
-constexpr unsigned GKR_DIM_REDUCING_INLINE_RECORD_CAP = 28;
+// Slots whose two inputs are independent product towers; the rest are one
+// coupled numerator/denominator fraction tower.
+static constexpr u32 GKR_DIM_REDUCING_PAIRWISE_SLOT_MASK =
+    (1u << GKR_DIM_REDUCING_SLOT_PERMUTATION_PRODUCT) | (1u << GKR_DIM_REDUCING_SLOT_INITS_AND_TEARDOWNS_PRODUCT);
+
 // The 4-bit pointer index in each source encoding addresses this table.
 constexpr unsigned GKR_DIM_REDUCING_BASE_SLOTS = 16;
-
-struct gkr_dim_reducing_payload_range_16 {
-  u16 offset;
-  u16 count;
-};
-
-struct gkr_dim_reducing_batch_record_compact {
-  u32 kind;
-  gkr_dim_reducing_payload_range_16 inputs;
-  gkr_dim_reducing_payload_range_16 outputs;
-  u16 batch_challenge_offset;
-  u16 reserved;
-};
-
-static_assert(sizeof(gkr_dim_reducing_batch_record_compact) == 16, "compact batch record must be 16 B");
 
 struct gkr_dim_reducing_tables {
   const u8 *bases[GKR_DIM_REDUCING_BASE_SLOTS];
@@ -105,70 +100,42 @@ struct gkr_source_record {
   u16 cache;
 };
 
-template <typename E> struct gkr_dim_reducing_round0_batch_compact {
-  u32 record_count;
+// `io` is inputs then outputs; only round 0 reads the outputs. The host packs
+// `batch_exp` densely over enabled slots, which is what keeps the generated
+// verifier's batching exponents in agreement.
+struct gkr_dim_reducing_slot {
+  gkr_source_record io[GKR_DIM_REDUCING_IO_PER_SLOT];
+  u16 batch_exp[GKR_DIM_REDUCING_OUTPUTS_PER_SLOT];
+};
+
+template <typename E> struct gkr_dim_reducing_batch {
+  u32 enabled_mask;
   u32 reserved0;
   const E *eq_low;
   gkr_eq_sizes eq_sizes;
   u32 eq_sizes_pad;
   E *contributions;
   gkr_dim_reducing_tables tables;
-  gkr_dim_reducing_batch_record_compact records[GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER];
-  gkr_source_record inline_payload[GKR_DIM_REDUCING_INLINE_RECORD_CAP];
+  gkr_dim_reducing_slot slots[GKR_DIM_REDUCING_SLOTS];
+  u32 slots_pad;
 };
 
-template <typename E> struct gkr_dim_reducing_continuation_batch_compact {
-  u32 record_count;
-  u32 reserved0;
-  const E *eq_low;
-  gkr_eq_sizes eq_sizes;
-  u32 eq_sizes_pad;
-  E *contributions;
-  gkr_dim_reducing_tables tables;
-  gkr_dim_reducing_batch_record_compact records[GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER];
-  gkr_source_record inline_payload[GKR_DIM_REDUCING_INLINE_RECORD_CAP];
-};
-
-static_assert(sizeof(gkr_dim_reducing_round0_batch_compact<e4>) == 456, "round-0 descriptor ABI drift");
-static_assert(sizeof(gkr_dim_reducing_continuation_batch_compact<e4>) == 456, "continuation descriptor ABI drift");
-static_assert(alignof(gkr_dim_reducing_payload_range_16) == 2 && sizeof(gkr_dim_reducing_payload_range_16) == 4, "payload range ABI drift");
-static_assert(__builtin_offsetof(gkr_dim_reducing_payload_range_16, offset) == 0 && __builtin_offsetof(gkr_dim_reducing_payload_range_16, count) == 2,
-              "payload range offsets drift");
-static_assert(alignof(gkr_dim_reducing_batch_record_compact) == 4 && sizeof(gkr_dim_reducing_batch_record_compact) == 16, "batch record ABI drift");
-static_assert(__builtin_offsetof(gkr_dim_reducing_batch_record_compact, kind) == 0 && __builtin_offsetof(gkr_dim_reducing_batch_record_compact, inputs) == 4 &&
-                  __builtin_offsetof(gkr_dim_reducing_batch_record_compact, outputs) == 8 &&
-                  __builtin_offsetof(gkr_dim_reducing_batch_record_compact, batch_challenge_offset) == 12 &&
-                  __builtin_offsetof(gkr_dim_reducing_batch_record_compact, reserved) == 14,
-              "batch record offsets drift");
+static_assert(alignof(gkr_dim_reducing_slot) == 2 && sizeof(gkr_dim_reducing_slot) == 20, "dim-reducing slot ABI drift");
+static_assert(__builtin_offsetof(gkr_dim_reducing_slot, io) == 0 && __builtin_offsetof(gkr_dim_reducing_slot, batch_exp) == 16,
+              "dim-reducing slot offsets drift");
 static_assert(alignof(gkr_dim_reducing_tables) == 8 && sizeof(gkr_dim_reducing_tables) == 192, "dim-reducing tables ABI drift");
 static_assert(__builtin_offsetof(gkr_dim_reducing_tables, bases) == 0 && __builtin_offsetof(gkr_dim_reducing_tables, log2_stride) == 128,
               "dim-reducing table offsets drift");
 static_assert(alignof(gkr_source_record) == 2 && sizeof(gkr_source_record) == 4, "source record ABI drift");
 static_assert(__builtin_offsetof(gkr_source_record, src) == 0 && __builtin_offsetof(gkr_source_record, cache) == 2, "source record offsets drift");
-static_assert(alignof(gkr_dim_reducing_round0_batch_compact<e4>) == 8, "round-0 descriptor alignment drift");
-static_assert(__builtin_offsetof(gkr_dim_reducing_round0_batch_compact<e4>, record_count) == 0 &&
-                  __builtin_offsetof(gkr_dim_reducing_round0_batch_compact<e4>, reserved0) == 4 &&
-                  __builtin_offsetof(gkr_dim_reducing_round0_batch_compact<e4>, eq_low) == 8 &&
-                  __builtin_offsetof(gkr_dim_reducing_round0_batch_compact<e4>, eq_sizes) == 16 &&
-                  __builtin_offsetof(gkr_dim_reducing_round0_batch_compact<e4>, eq_sizes_pad) == 28 &&
-                  __builtin_offsetof(gkr_dim_reducing_round0_batch_compact<e4>, contributions) == 32 &&
-                  __builtin_offsetof(gkr_dim_reducing_round0_batch_compact<e4>, tables) == 40 &&
-                  __builtin_offsetof(gkr_dim_reducing_round0_batch_compact<e4>, records) == 232 &&
-                  __builtin_offsetof(gkr_dim_reducing_round0_batch_compact<e4>, inline_payload) == 344,
-              "round-0 descriptor offsets drift");
-static_assert(sizeof(gkr_dim_reducing_round0_batch_compact<e4>) + sizeof(u32) <= 32764, "round-0 kernel parameters exceed CUDA limit");
-static_assert(alignof(gkr_dim_reducing_continuation_batch_compact<e4>) == 8, "continuation descriptor alignment drift");
-static_assert(__builtin_offsetof(gkr_dim_reducing_continuation_batch_compact<e4>, record_count) == 0 &&
-                  __builtin_offsetof(gkr_dim_reducing_continuation_batch_compact<e4>, reserved0) == 4 &&
-                  __builtin_offsetof(gkr_dim_reducing_continuation_batch_compact<e4>, eq_low) == 8 &&
-                  __builtin_offsetof(gkr_dim_reducing_continuation_batch_compact<e4>, eq_sizes) == 16 &&
-                  __builtin_offsetof(gkr_dim_reducing_continuation_batch_compact<e4>, eq_sizes_pad) == 28 &&
-                  __builtin_offsetof(gkr_dim_reducing_continuation_batch_compact<e4>, contributions) == 32 &&
-                  __builtin_offsetof(gkr_dim_reducing_continuation_batch_compact<e4>, tables) == 40 &&
-                  __builtin_offsetof(gkr_dim_reducing_continuation_batch_compact<e4>, records) == 232 &&
-                  __builtin_offsetof(gkr_dim_reducing_continuation_batch_compact<e4>, inline_payload) == 344,
-              "continuation descriptor offsets drift");
-static_assert(sizeof(gkr_dim_reducing_continuation_batch_compact<e4>) + 2 * sizeof(u32) <= 32764, "continuation kernel parameters exceed CUDA limit");
+static_assert(alignof(gkr_dim_reducing_batch<e4>) == 8 && sizeof(gkr_dim_reducing_batch<e4>) == 336, "dim-reducing descriptor ABI drift");
+static_assert(__builtin_offsetof(gkr_dim_reducing_batch<e4>, enabled_mask) == 0 && __builtin_offsetof(gkr_dim_reducing_batch<e4>, reserved0) == 4 &&
+                  __builtin_offsetof(gkr_dim_reducing_batch<e4>, eq_low) == 8 && __builtin_offsetof(gkr_dim_reducing_batch<e4>, eq_sizes) == 16 &&
+                  __builtin_offsetof(gkr_dim_reducing_batch<e4>, eq_sizes_pad) == 28 && __builtin_offsetof(gkr_dim_reducing_batch<e4>, contributions) == 32 &&
+                  __builtin_offsetof(gkr_dim_reducing_batch<e4>, tables) == 40 && __builtin_offsetof(gkr_dim_reducing_batch<e4>, slots) == 232 &&
+                  __builtin_offsetof(gkr_dim_reducing_batch<e4>, slots_pad) == 332,
+              "dim-reducing descriptor offsets drift");
+static_assert(sizeof(gkr_dim_reducing_batch<e4>) + 2 * sizeof(u32) <= 32764, "dim-reducing kernel parameters exceed CUDA limit");
 
 // Merged tower batch (blockIdx.y selects the pair). A pair's two streams are either two
 // independent product towers (PAIRWISE2) or one lookup tower's num/den (LOOKUP).
@@ -208,11 +175,6 @@ template <typename E> struct gkr_forward_setup_generic_lookup_batch {
 };
 
 static constexpr unsigned GKR_TIMESTAMP_COLUMNS_NUM_BITS = 19;
-
-// Maximum inputs / outputs read by a dim-reducing kernel-kind. Pairwise uses (1 input, 1 output);
-// Lookup uses (2 inputs, 2 outputs). Sized to the lookup case so the stack array never overflows.
-constexpr unsigned GKR_DIM_REDUCING_MAX_INPUTS_PER_RECORD = 2;
-constexpr unsigned GKR_DIM_REDUCING_MAX_OUTPUTS_PER_RECORD = 2;
 
 } // namespace airbender::gkr
 

--- a/gpu/gkr/native/gkr/support/lookup_helpers.cuh
+++ b/gpu/gkr/native/gkr/support/lookup_helpers.cuh
@@ -117,6 +117,7 @@ template <typename E> DEVICE_FORCEINLINE void gkr_dim_reducing_forward_tower(con
   E *smem_b = smem_tower + blockDim.x;
 
   const gkr_dim_reducing_forward_tower_pair<E> &pair = batch.pairs[blockIdx.y];
+  const bool pairwise = ((batch.pairwise_mask >> blockIdx.y) & 1u) != 0u;
   const unsigned tid = threadIdx.x;
   const unsigned bid = blockIdx.x;
   const unsigned base = bid * blockDim.x;
@@ -136,7 +137,7 @@ template <typename E> DEVICE_FORCEINLINE void gkr_dim_reducing_forward_tower(con
     E out_b;
     const bool active = tid < cur_len;
     if (active) {
-      if (pair.kind == GKR_DIM_REDUCING_FORWARD_TOWER_PAIRWISE2) {
+      if (pairwise) {
         gkr_eval_product(smem_a[2 * tid], smem_a[2 * tid + 1], out_a);
         gkr_eval_product(smem_b[2 * tid], smem_b[2 * tid + 1], out_b);
       } else {

--- a/gpu/gkr/native/gkr/support/lookup_helpers.cuh
+++ b/gpu/gkr/native/gkr/support/lookup_helpers.cuh
@@ -5,23 +5,31 @@
 
 namespace airbender::gkr {
 
+// Slot bodies accumulate into the round's (constant-term, t^2-coefficient) pair;
+// the round's linear coefficient is recovered from the running claim downstream,
+// which is why only two values per round leave the kernel.
+
 template <typename E>
-DEVICE_FORCEINLINE void gkr_pairwise_round0_values(const gkr_ext_initial_source<E> *inputs, const gkr_ext_initial_source<E> *outputs, const E batch_challenge,
-                                                   const unsigned gid, E &c0, E &c1) {
+DEVICE_FORCEINLINE void gkr_pairwise_round0_accumulate(const gkr_ext_initial_source<E> *inputs, const gkr_ext_initial_source<E> *outputs, const E *bc,
+                                                       const unsigned gid, E &acc0, E &acc1) {
   const unsigned even_index = gid * 2;
   const unsigned odd_index = even_index + 1;
 
-  const E output_value = gkr_get_initial_value(outputs[0], gid);
-  const E delta_even = gkr_get_initial_delta(inputs[0], even_index);
-  const E delta_odd = gkr_get_initial_delta(inputs[0], odd_index);
+#pragma unroll
+  for (unsigned t = 0; t < GKR_DIM_REDUCING_OUTPUTS_PER_SLOT; ++t) {
+    // Round 0 reads the forward tower's own output as the value at t = 0.
+    const E output_value = gkr_get_initial_value(outputs[t], gid);
+    const E delta_even = gkr_get_initial_delta(inputs[t], even_index);
+    const E delta_odd = gkr_get_initial_delta(inputs[t], odd_index);
 
-  c0 = E::mul(batch_challenge, output_value);
-  c1 = E::mul(batch_challenge, E::mul(delta_even, delta_odd));
+    acc0 = E::fma(bc[t], output_value, acc0);
+    acc1 = E::fma(bc[t], E::mul(delta_even, delta_odd), acc1);
+  }
 }
 
 template <typename E>
-DEVICE_FORCEINLINE void gkr_lookup_round0_values(const gkr_ext_initial_source<E> *inputs, const gkr_ext_initial_source<E> *outputs, const E batch_challenge_0,
-                                                 const E batch_challenge_1, const unsigned gid, E &c0, E &c1) {
+DEVICE_FORCEINLINE void gkr_lookup_round0_accumulate(const gkr_ext_initial_source<E> *inputs, const gkr_ext_initial_source<E> *outputs, const E *bc,
+                                                     const unsigned gid, E &acc0, E &acc1) {
   const unsigned even_index = gid * 2;
   const unsigned odd_index = even_index + 1;
 
@@ -36,33 +44,36 @@ DEVICE_FORCEINLINE void gkr_lookup_round0_values(const gkr_ext_initial_source<E>
   const E num = E::fma(a, d, E::mul(c, b));
   const E den = E::mul(b, d);
 
-  c0 = E::fma(batch_challenge_0, output_num, E::mul(batch_challenge_1, output_den));
-  c1 = E::fma(batch_challenge_0, num, E::mul(batch_challenge_1, den));
+  acc0 = E::fma(bc[0], output_num, E::fma(bc[1], output_den, acc0));
+  acc1 = E::fma(bc[0], num, E::fma(bc[1], den, acc1));
 }
 
 template <typename E>
-DEVICE_FORCEINLINE void gkr_pairwise_continuation_values(const gkr_ext_continuing_source<E> *inputs, const E *folding_challenge, const E batch_challenge,
-                                                         const unsigned gid, E &c0, E &c1) {
+DEVICE_FORCEINLINE void gkr_pairwise_continuation_accumulate(const gkr_ext_continuing_source<E> *inputs, const E *folding_challenge, const E *bc,
+                                                             const unsigned gid, E &acc0, E &acc1) {
   const E current_folding_challenge = folding_challenge[0];
 
   const unsigned even_index = gid * 2;
   const unsigned odd_index = even_index + 1;
 
-  E even_f0;
-  E even_f1_or_delta;
-  gkr_get_continuing_points<E>(inputs[0], current_folding_challenge, even_index, even_f0, even_f1_or_delta);
+#pragma unroll
+  for (unsigned t = 0; t < GKR_DIM_REDUCING_INPUTS_PER_SLOT; ++t) {
+    E even_f0;
+    E even_delta;
+    gkr_get_continuing_points<E>(inputs[t], current_folding_challenge, even_index, even_f0, even_delta);
 
-  E odd_f0;
-  E odd_f1_or_delta;
-  gkr_get_continuing_points<E>(inputs[0], current_folding_challenge, odd_index, odd_f0, odd_f1_or_delta);
+    E odd_f0;
+    E odd_delta;
+    gkr_get_continuing_points<E>(inputs[t], current_folding_challenge, odd_index, odd_f0, odd_delta);
 
-  c0 = E::mul(batch_challenge, E::mul(even_f0, odd_f0));
-  c1 = E::mul(batch_challenge, E::mul(even_f1_or_delta, odd_f1_or_delta));
+    acc0 = E::fma(bc[t], E::mul(even_f0, odd_f0), acc0);
+    acc1 = E::fma(bc[t], E::mul(even_delta, odd_delta), acc1);
+  }
 }
 
 template <typename E>
-DEVICE_FORCEINLINE void gkr_lookup_continuation_values(const gkr_ext_continuing_source<E> *inputs, const E *folding_challenge, const E batch_challenge_0,
-                                                       const E batch_challenge_1, const unsigned gid, E &out0, E &out1) {
+DEVICE_FORCEINLINE void gkr_lookup_continuation_accumulate(const gkr_ext_continuing_source<E> *inputs, const E *folding_challenge, const E *bc,
+                                                           const unsigned gid, E &acc0, E &acc1) {
   const E current_folding_challenge = folding_challenge[0];
 
   const unsigned even_index = gid * 2;
@@ -86,8 +97,8 @@ DEVICE_FORCEINLINE void gkr_lookup_continuation_values(const gkr_ext_continuing_
   const E num1 = E::fma(a1, d1, E::mul(c1, b1));
   const E den1 = E::mul(b1, d1);
 
-  out0 = E::fma(batch_challenge_0, num0, E::mul(batch_challenge_1, den0));
-  out1 = E::fma(batch_challenge_0, num1, E::mul(batch_challenge_1, den1));
+  acc0 = E::fma(bc[0], num0, E::fma(bc[1], den0, acc0));
+  acc1 = E::fma(bc[0], num1, E::fma(bc[1], den1, acc1));
 }
 
 template <typename E> DEVICE_FORCEINLINE void gkr_eval_product(const E a, const E b, E &value) { value = E::mul(a, b); }
@@ -189,39 +200,44 @@ DEVICE_FORCEINLINE gkr_ext_initial_source<E> gkr_resolve_dim_reducing_initial_so
   return gkr_ext_initial_source<E>{start, 2u * acc_size};
 }
 
-template <typename E>
-DEVICE_FORCEINLINE void gkr_dim_reducing_round0_batched_compact(const gkr_dim_reducing_round0_batch_compact<E> &batch, const unsigned acc_size) {
+// Loads a slot's 2 batch challenges from the __constant__ table.
+DEVICE_FORCEINLINE void gkr_load_slot_batch_challenges(const gkr_dim_reducing_slot &slot, e4 (&bc)[GKR_DIM_REDUCING_OUTPUTS_PER_SLOT]) {
+#pragma unroll
+  for (unsigned t = 0; t < GKR_DIM_REDUCING_OUTPUTS_PER_SLOT; ++t)
+    bc[t] = ::ab_gkr_dim_reducing_batch_challenge_table[slot.batch_exp[t]];
+}
+
+template <typename E> DEVICE_FORCEINLINE void gkr_dim_reducing_round0_batched_compact(const gkr_dim_reducing_batch<E> &batch, const unsigned acc_size) {
   const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
   if (gid >= acc_size)
     return;
 
   E total0 = E::ZERO();
   E total1 = E::ZERO();
-  for (unsigned i = 0; i < batch.record_count; ++i) {
-    const auto &record = batch.records[i];
-    gkr_ext_initial_source<E> inputs[GKR_DIM_REDUCING_MAX_INPUTS_PER_RECORD];
-    gkr_ext_initial_source<E> outputs[GKR_DIM_REDUCING_MAX_OUTPUTS_PER_RECORD];
-    for (unsigned k = 0; k < record.inputs.count; ++k) {
-      inputs[k] = gkr_resolve_dim_reducing_initial_source<E>(batch.tables, batch.inline_payload[record.inputs.offset + k], acc_size);
-    }
-    for (unsigned k = 0; k < record.outputs.count; ++k) {
-      outputs[k] = gkr_resolve_dim_reducing_initial_source<E>(batch.tables, batch.inline_payload[record.outputs.offset + k], acc_size);
-    }
-    E c0;
-    E c1;
-    switch (record.kind) {
-    case GKR_DIM_REDUCING_PAIRWISE:
-      gkr_pairwise_round0_values(inputs, outputs, ::ab_gkr_dim_reducing_batch_challenge_table[record.batch_challenge_offset], gid, c0, c1);
-      break;
-    case GKR_DIM_REDUCING_LOOKUP:
-      gkr_lookup_round0_values(inputs, outputs, ::ab_gkr_dim_reducing_batch_challenge_table[record.batch_challenge_offset],
-                               ::ab_gkr_dim_reducing_batch_challenge_table[record.batch_challenge_offset + 1], gid, c0, c1);
-      break;
-    default:
-      return;
-    }
-    total0 = E::add(total0, c0);
-    total1 = E::add(total1, c1);
+  // Fully unrolled: `slot` is a compile-time constant in each copy, so the
+  // pairwise/lookup selection folds away and no dispatch survives codegen.
+#pragma unroll
+  for (unsigned slot = 0; slot < GKR_DIM_REDUCING_SLOTS; ++slot) {
+    if ((batch.enabled_mask & (1u << slot)) == 0)
+      continue;
+    const gkr_dim_reducing_slot &desc = batch.slots[slot];
+
+    E bc[GKR_DIM_REDUCING_OUTPUTS_PER_SLOT];
+    gkr_load_slot_batch_challenges(desc, bc);
+
+    gkr_ext_initial_source<E> inputs[GKR_DIM_REDUCING_INPUTS_PER_SLOT];
+    gkr_ext_initial_source<E> outputs[GKR_DIM_REDUCING_OUTPUTS_PER_SLOT];
+#pragma unroll
+    for (unsigned k = 0; k < GKR_DIM_REDUCING_INPUTS_PER_SLOT; ++k)
+      inputs[k] = gkr_resolve_dim_reducing_initial_source<E>(batch.tables, desc.io[k], acc_size);
+#pragma unroll
+    for (unsigned k = 0; k < GKR_DIM_REDUCING_OUTPUTS_PER_SLOT; ++k)
+      outputs[k] = gkr_resolve_dim_reducing_initial_source<E>(batch.tables, desc.io[GKR_DIM_REDUCING_INPUTS_PER_SLOT + k], acc_size);
+
+    if ((GKR_DIM_REDUCING_PAIRWISE_SLOT_MASK >> slot) & 1u)
+      gkr_pairwise_round0_accumulate<E>(inputs, outputs, bc, gid, total0, total1);
+    else
+      gkr_lookup_round0_accumulate<E>(inputs, outputs, bc, gid, total0, total1);
   }
 
   const E eq = gkr_compute_eq_inline<E>(batch.eq_low, batch.eq_sizes, gid);
@@ -229,73 +245,14 @@ DEVICE_FORCEINLINE void gkr_dim_reducing_round0_batched_compact(const gkr_dim_re
   store<E, st_modifier::cs>(batch.contributions + acc_size, E::mul(total1, eq), gid);
 }
 
-// Round-1 (sumcheck step 1) source resolver. The u16 encodes the GKR ext
-// storage slot of the original input poly; `previous_layer_start` is that
-// poly's start, and `this_layer_start` is the matching folding-buffer slot
-// from the record's cache half. this_layer_size and
-// next_layer_size at step 1 are uniformly `2 * acc_size` and `acc_size`.
-template <typename E>
-DEVICE_FORCEINLINE gkr_ext_continuing_source<E> gkr_resolve_dim_reducing_round1_source(const gkr_dim_reducing_tables &tables, const gkr_source_record record,
-                                                                                       const unsigned acc_size) {
-  bool first_access;
-  u32 ptr_idx;
-  u32 poly_idx;
-  unpack_dim_reducing_source_u16(record.src, first_access, ptr_idx, poly_idx);
-  const E *poly_base = reinterpret_cast<const E *>(tables.bases[ptr_idx]);
-  const u32 poly_log2_stride = tables.log2_stride[ptr_idx];
-  const E *previous = poly_base + (static_cast<size_t>(poly_idx) << poly_log2_stride);
-  u32 buffer_slot;
-  u32 buffer_poly_idx;
-  unpack_dim_reducing_cache_u16(record.cache, buffer_slot, buffer_poly_idx);
-  E *buffer_base = reinterpret_cast<E *>(const_cast<u8 *>(tables.bases[buffer_slot]));
-  const u32 buffer_log2_stride = tables.log2_stride[buffer_slot];
-  E *this_layer = buffer_base + (static_cast<size_t>(buffer_poly_idx) << buffer_log2_stride);
-  // At sumcheck step 1, `this_layer_size` is the f0/f1 stride within the
-  // previous (= original input) poly, which is `poly_size / 2 = 4 * acc_size`
-  // (input size at step 1 = 8 * acc_size since acc_size = trace_len_after_reduction/4).
-  // `next_layer_size` is the produced fold's stride = `this_layer_size / 2 = 2 * acc_size`.
-  return gkr_ext_continuing_source<E>{previous, this_layer, 4u * acc_size, 2u * acc_size, first_access};
-}
-
-template <typename E>
-DEVICE_FORCEINLINE void gkr_dim_reducing_round1_batched_compact_inner(const gkr_dim_reducing_continuation_batch_compact<E> &batch, const unsigned acc_size) {
-  const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
-  if (gid >= acc_size)
-    return;
-
-  E total0 = E::ZERO();
-  E total1 = E::ZERO();
-  for (unsigned i = 0; i < batch.record_count; ++i) {
-    const auto &record = batch.records[i];
-    gkr_ext_continuing_source<E> inputs[GKR_DIM_REDUCING_MAX_INPUTS_PER_RECORD];
-    for (unsigned k = 0; k < record.inputs.count; ++k) {
-      inputs[k] = gkr_resolve_dim_reducing_round1_source<E>(batch.tables, batch.inline_payload[record.inputs.offset + k], acc_size);
-    }
-    E c0;
-    E c1;
-    switch (record.kind) {
-    case GKR_DIM_REDUCING_PAIRWISE:
-      gkr_pairwise_continuation_values<E>(inputs, &::ab_gkr_dim_reducing_layer_claim_point[0],
-                                          ::ab_gkr_dim_reducing_batch_challenge_table[record.batch_challenge_offset], gid, c0, c1);
-      break;
-    case GKR_DIM_REDUCING_LOOKUP:
-      gkr_lookup_continuation_values<E>(inputs, &::ab_gkr_dim_reducing_layer_claim_point[0],
-                                        ::ab_gkr_dim_reducing_batch_challenge_table[record.batch_challenge_offset],
-                                        ::ab_gkr_dim_reducing_batch_challenge_table[record.batch_challenge_offset + 1], gid, c0, c1);
-      break;
-    default:
-      return;
-    }
-    total0 = E::add(total0, c0);
-    total1 = E::add(total1, c1);
-  }
-
-  const E eq = gkr_compute_eq_inline<E>(batch.eq_low, batch.eq_sizes, gid);
-  store<E, st_modifier::cs>(batch.contributions, E::mul(total0, eq), gid);
-  store<E, st_modifier::cs>(batch.contributions + acc_size, E::mul(total1, eq), gid);
-}
-
-// Continuation sources read the current round arena and write the next one.
+// `src` names the poly being folded -- the original GKR ext storage poly at step
+// 1, the previous round's arena from step 2 on -- and `cache` the arena slot the
+// fold is written to. Both resolve through the same pointer table, so one kernel
+// serves every step past 0; only the host encoder distinguishes the two cases.
+//
+// `this_layer_size` is the f0/f1 stride within the source span
+// (trace_len_after_reduction >> (step - 1) = 4 * acc_size); `next_layer_size` is
+// the produced fold's stride, half of it.
 template <typename E>
 DEVICE_FORCEINLINE gkr_ext_continuing_source<E> gkr_resolve_dim_reducing_continuation_source(const gkr_dim_reducing_tables &tables,
                                                                                              const gkr_source_record record, const unsigned acc_size) {
@@ -312,44 +269,40 @@ DEVICE_FORCEINLINE gkr_ext_continuing_source<E> gkr_resolve_dim_reducing_continu
   E *cache_base = reinterpret_cast<E *>(const_cast<u8 *>(tables.bases[cache_slot]));
   const u32 cache_log2_stride = tables.log2_stride[cache_slot];
   E *cache_start = cache_base + (static_cast<size_t>(cache_poly_idx) << cache_log2_stride);
-  // At step k >= 2, `this_layer_size = 4 * acc_size` (the f0/f1 stride within
-  // the previous-layer span = trace_len_after_reduction >> (k-1) = 4 * acc_size_at_step_k);
-  // `next_layer_size = this_layer_size / 2 = 2 * acc_size`.
   return gkr_ext_continuing_source<E>{source_start, cache_start, 4u * acc_size, 2u * acc_size, first_access};
 }
 
 template <typename E>
-DEVICE_FORCEINLINE void gkr_dim_reducing_continuation_batched_compact_inner(const gkr_dim_reducing_continuation_batch_compact<E> &batch,
-                                                                            const unsigned acc_size, const unsigned step) {
+DEVICE_FORCEINLINE void gkr_dim_reducing_continuation_batched_compact_inner(const gkr_dim_reducing_batch<E> &batch, const unsigned acc_size,
+                                                                            const unsigned step) {
   const unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
   if (gid >= acc_size)
     return;
 
+  const E *folding_challenge = &::ab_gkr_dim_reducing_layer_claim_point[step - 1];
+
   E total0 = E::ZERO();
   E total1 = E::ZERO();
-  for (unsigned i = 0; i < batch.record_count; ++i) {
-    const auto &record = batch.records[i];
-    gkr_ext_continuing_source<E> inputs[GKR_DIM_REDUCING_MAX_INPUTS_PER_RECORD];
-    for (unsigned k = 0; k < record.inputs.count; ++k) {
-      inputs[k] = gkr_resolve_dim_reducing_continuation_source<E>(batch.tables, batch.inline_payload[record.inputs.offset + k], acc_size);
-    }
-    E c0;
-    E c1;
-    switch (record.kind) {
-    case GKR_DIM_REDUCING_PAIRWISE:
-      gkr_pairwise_continuation_values<E>(inputs, &::ab_gkr_dim_reducing_layer_claim_point[step - 1],
-                                          ::ab_gkr_dim_reducing_batch_challenge_table[record.batch_challenge_offset], gid, c0, c1);
-      break;
-    case GKR_DIM_REDUCING_LOOKUP:
-      gkr_lookup_continuation_values<E>(inputs, &::ab_gkr_dim_reducing_layer_claim_point[step - 1],
-                                        ::ab_gkr_dim_reducing_batch_challenge_table[record.batch_challenge_offset],
-                                        ::ab_gkr_dim_reducing_batch_challenge_table[record.batch_challenge_offset + 1], gid, c0, c1);
-      break;
-    default:
-      return;
-    }
-    total0 = E::add(total0, c0);
-    total1 = E::add(total1, c1);
+  // Fully unrolled: `slot` is a compile-time constant in each copy, so the
+  // pairwise/lookup selection folds away and no dispatch survives codegen.
+#pragma unroll
+  for (unsigned slot = 0; slot < GKR_DIM_REDUCING_SLOTS; ++slot) {
+    if ((batch.enabled_mask & (1u << slot)) == 0)
+      continue;
+    const gkr_dim_reducing_slot &desc = batch.slots[slot];
+
+    E bc[GKR_DIM_REDUCING_OUTPUTS_PER_SLOT];
+    gkr_load_slot_batch_challenges(desc, bc);
+
+    gkr_ext_continuing_source<E> inputs[GKR_DIM_REDUCING_INPUTS_PER_SLOT];
+#pragma unroll
+    for (unsigned k = 0; k < GKR_DIM_REDUCING_INPUTS_PER_SLOT; ++k)
+      inputs[k] = gkr_resolve_dim_reducing_continuation_source<E>(batch.tables, desc.io[k], acc_size);
+
+    if ((GKR_DIM_REDUCING_PAIRWISE_SLOT_MASK >> slot) & 1u)
+      gkr_pairwise_continuation_accumulate<E>(inputs, folding_challenge, bc, gid, total0, total1);
+    else
+      gkr_lookup_continuation_accumulate<E>(inputs, folding_challenge, bc, gid, total0, total1);
   }
 
   const E eq = gkr_compute_eq_inline<E>(batch.eq_low, batch.eq_sizes, gid);

--- a/gpu/gkr/src/backward/dim_reducing_encoder.rs
+++ b/gpu/gkr/src/backward/dim_reducing_encoder.rs
@@ -18,12 +18,9 @@ use super::super::storage_layout::address_storage_layer;
 use super::super::GpuGKRStorage;
 use super::kernels::FoldingArenaBinding;
 use super::kernels::{
-    pack_cache_u16, pack_source_u16, GpuGKRDimensionReducingBatchRecordCompact,
-    GpuGKRDimensionReducingContinuationBatchCompact, GpuGKRDimensionReducingKernelPlan,
-    GpuGKRDimensionReducingRound0BatchCompact, GpuGKRDimensionReducingTables, GpuGKRSourceRecord,
-    PayloadRange16, GKR_DIM_REDUCING_BASE_SLOTS, GKR_DIM_REDUCING_INLINE_RECORD_CAP,
-    GKR_DIM_REDUCING_MAX_INPUTS_PER_RECORD, GKR_DIM_REDUCING_MAX_OUTPUTS_PER_RECORD,
-    GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER,
+    pack_cache_u16, pack_source_u16, GpuGKRDimensionReducingBatch,
+    GpuGKRDimensionReducingLayerSlots, GpuGKRDimensionReducingSlot, GpuGKRDimensionReducingTables,
+    GpuGKRSourceRecord, GKR_DIM_REDUCING_BASE_SLOTS, GKR_DIM_REDUCING_IO_PER_SLOT,
 };
 use crate::upstream::{Field, GKRAddress};
 
@@ -114,27 +111,6 @@ fn resolve_ext_consolidated<B, E: Field>(
     )
 }
 
-/// `PayloadRange16`.
-fn push_payload_record(
-    inline_payload: &mut [GpuGKRSourceRecord; GKR_DIM_REDUCING_INLINE_RECORD_CAP],
-    cursor: &mut usize,
-    value: GpuGKRSourceRecord,
-) {
-    assert!(
-        *cursor < GKR_DIM_REDUCING_INLINE_RECORD_CAP,
-        "compact dim-reducing inline_payload overflow at cursor {cursor} (cap {GKR_DIM_REDUCING_INLINE_RECORD_CAP})",
-    );
-    inline_payload[*cursor] = value;
-    *cursor += 1;
-}
-
-fn check_record_count(blueprints_len: usize) {
-    assert!(
-        blueprints_len <= GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER,
-        "compact dim-reducing encoder: {blueprints_len} blueprints exceeds GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER={GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER}",
-    );
-}
-
 fn folding_index<B, E>(
     storage: &GpuGKRStorage<B, E>,
     folding_addresses: &[GKRAddress],
@@ -153,53 +129,38 @@ fn folding_index<B, E>(
         .expect("folding source index exceeds u16")
 }
 
+/// Step-1 descriptor: `src` names the original poly in consolidated ext storage,
+/// where later steps name a prior folding arena. Both feed the same continuation
+/// kernel.
 pub(in crate::backward) fn build_round1_batch_compact_for_arena<B, E: Field>(
-    kernel_plans: &[GpuGKRDimensionReducingKernelPlan],
+    layer_slots: &GpuGKRDimensionReducingLayerSlots,
     storage: &GpuGKRStorage<B, E>,
     folding_addresses: &[GKRAddress],
     destination: FoldingArenaBinding,
-) -> GpuGKRDimensionReducingContinuationBatchCompact<E> {
-    check_record_count(kernel_plans.len());
-    let mut batch = GpuGKRDimensionReducingContinuationBatchCompact::<E> {
-        record_count: kernel_plans.len() as u32,
+) -> GpuGKRDimensionReducingBatch<E> {
+    let mut batch = GpuGKRDimensionReducingBatch::<E> {
+        enabled_mask: layer_slots.enabled_mask(),
         ..Default::default()
     };
     let mut tables = SlotTableBuilder::new();
     let destination_slot = tables.get_or_create(destination.base, destination.log2_stride);
-    let mut payload_cursor = 0usize;
     let mut first_access_seen = BTreeSet::new();
 
-    for (idx, kernel) in kernel_plans.iter().enumerate() {
-        let inputs_offset = payload_cursor as u16;
-        let mut inputs_count = 0u16;
-        for address in kernel.inputs.inputs_in_extension.iter().copied() {
-            if address == GKRAddress::placeholder() {
-                continue;
-            }
+    for (slot_idx, slot) in layer_slots.iter_enabled() {
+        let mut io = [GpuGKRSourceRecord::default(); GKR_DIM_REDUCING_IO_PER_SLOT];
+        for (k, address) in slot.inputs.iter().copied().enumerate() {
             let (input_ptr, input_stride, input_idx) = resolve_ext_consolidated(storage, address);
             let input_slot = tables.get_or_create(input_ptr, input_stride);
             let cache_idx = folding_index(storage, folding_addresses, address);
             let first_access = first_access_seen.insert(cache_idx);
-            push_payload_record(
-                &mut batch.inline_payload,
-                &mut payload_cursor,
-                GpuGKRSourceRecord::new(
-                    pack_source_u16(first_access, input_slot, input_idx),
-                    pack_cache_u16(destination_slot, cache_idx),
-                ),
+            io[k] = GpuGKRSourceRecord::new(
+                pack_source_u16(first_access, input_slot, input_idx),
+                pack_cache_u16(destination_slot, cache_idx),
             );
-            inputs_count += 1;
         }
-        assert!(usize::from(inputs_count) <= GKR_DIM_REDUCING_MAX_INPUTS_PER_RECORD);
-        batch.records[idx] = GpuGKRDimensionReducingBatchRecordCompact {
-            kind: kernel.kind.as_u32(),
-            inputs: PayloadRange16 {
-                offset: inputs_offset,
-                count: inputs_count,
-            },
-            outputs: PayloadRange16::default(),
-            batch_challenge_offset: kernel.batch_challenge_offset as u16,
-            _reserved: 0,
+        batch.slots[slot_idx] = GpuGKRDimensionReducingSlot {
+            io,
+            batch_exp: slot.batch_exp,
         };
     }
     batch.tables = tables.into_tables();
@@ -207,60 +168,42 @@ pub(in crate::backward) fn build_round1_batch_compact_for_arena<B, E: Field>(
 }
 
 pub(in crate::backward) fn build_continuation_batch_compact_for_arenas<B, E: Field>(
-    kernel_plans: &[GpuGKRDimensionReducingKernelPlan],
+    layer_slots: &GpuGKRDimensionReducingLayerSlots,
     storage: &GpuGKRStorage<B, E>,
     folding_addresses: &[GKRAddress],
     current: FoldingArenaBinding,
     destination: FoldingArenaBinding,
-) -> GpuGKRDimensionReducingContinuationBatchCompact<E> {
-    check_record_count(kernel_plans.len());
-    let mut batch = GpuGKRDimensionReducingContinuationBatchCompact::<E> {
-        record_count: kernel_plans.len() as u32,
+) -> GpuGKRDimensionReducingBatch<E> {
+    let mut batch = GpuGKRDimensionReducingBatch::<E> {
+        enabled_mask: layer_slots.enabled_mask(),
         ..Default::default()
     };
     let mut tables = SlotTableBuilder::new();
     let current_slot = tables.get_or_create(current.base, current.log2_stride);
     let destination_slot = tables.get_or_create(destination.base, destination.log2_stride);
-    let mut payload_cursor = 0usize;
     let mut first_access_seen = BTreeSet::new();
 
-    for (idx, kernel) in kernel_plans.iter().enumerate() {
-        let inputs_offset = payload_cursor as u16;
-        let mut inputs_count = 0u16;
-        for address in kernel.inputs.inputs_in_extension.iter().copied() {
-            if address == GKRAddress::placeholder() {
-                continue;
-            }
+    for (slot_idx, slot) in layer_slots.iter_enabled() {
+        let mut io = [GpuGKRSourceRecord::default(); GKR_DIM_REDUCING_IO_PER_SLOT];
+        for (k, address) in slot.inputs.iter().copied().enumerate() {
             let poly_idx = folding_index(storage, folding_addresses, address);
             let first_access = first_access_seen.insert(poly_idx);
-            push_payload_record(
-                &mut batch.inline_payload,
-                &mut payload_cursor,
-                GpuGKRSourceRecord::new(
-                    pack_source_u16(first_access, current_slot, poly_idx),
-                    pack_cache_u16(destination_slot, poly_idx),
-                ),
+            io[k] = GpuGKRSourceRecord::new(
+                pack_source_u16(first_access, current_slot, poly_idx),
+                pack_cache_u16(destination_slot, poly_idx),
             );
-            inputs_count += 1;
         }
-        assert!(usize::from(inputs_count) <= GKR_DIM_REDUCING_MAX_INPUTS_PER_RECORD);
-        batch.records[idx] = GpuGKRDimensionReducingBatchRecordCompact {
-            kind: kernel.kind.as_u32(),
-            inputs: PayloadRange16 {
-                offset: inputs_offset,
-                count: inputs_count,
-            },
-            outputs: PayloadRange16::default(),
-            batch_challenge_offset: kernel.batch_challenge_offset as u16,
-            _reserved: 0,
+        batch.slots[slot_idx] = GpuGKRDimensionReducingSlot {
+            io,
+            batch_exp: slot.batch_exp,
         };
     }
     batch.tables = tables.into_tables();
     batch
 }
 
-/// Build the compact round-0 batch descriptor. Both inputs and outputs
-/// resolve through the consolidated `ext_class_backings`; the kernel uses
+/// Build the round-0 batch descriptor. Both inputs and outputs resolve through
+/// the consolidated `ext_class_backings`; the kernel uses
 /// `gkr_resolve_dim_reducing_initial_source` which simply reads
 /// `bases[ptr_idx] + (poly_idx << log2_stride[ptr_idx])`.
 ///
@@ -268,72 +211,26 @@ pub(in crate::backward) fn build_continuation_batch_compact_for_arenas<B, E: Fie
 /// `contributions`) left null — the launcher fills these from the round
 /// scratch.
 pub(in crate::backward) fn build_round0_batch_compact<B, E: Field>(
-    blueprints: &[GpuGKRDimensionReducingKernelPlan],
+    layer_slots: &GpuGKRDimensionReducingLayerSlots,
     storage: &GpuGKRStorage<B, E>,
-) -> GpuGKRDimensionReducingRound0BatchCompact<E> {
-    check_record_count(blueprints.len());
-
-    let mut batch = GpuGKRDimensionReducingRound0BatchCompact::<E> {
-        record_count: blueprints.len() as u32,
+) -> GpuGKRDimensionReducingBatch<E> {
+    let mut batch = GpuGKRDimensionReducingBatch::<E> {
+        enabled_mask: layer_slots.enabled_mask(),
         ..Default::default()
     };
     let mut tables = SlotTableBuilder::new();
-    let mut payload_cursor = 0usize;
 
-    for (idx, blueprint) in blueprints.iter().enumerate() {
-        debug_assert!(blueprint.inputs.inputs_in_base.is_empty());
-        debug_assert!(blueprint.inputs.outputs_in_base.is_empty());
-
-        // Inputs.
-        let inputs_offset = payload_cursor as u16;
-        let mut inputs_count = 0u16;
-        for addr in blueprint.inputs.inputs_in_extension.iter().copied() {
-            if addr == GKRAddress::placeholder() {
-                continue;
-            }
-            let (ptr, log2_stride, poly_idx) = resolve_ext_consolidated(storage, addr);
-            let slot = tables.get_or_create(ptr, log2_stride);
-            let packed = pack_source_u16(false, slot, poly_idx);
-            push_payload_record(
-                &mut batch.inline_payload,
-                &mut payload_cursor,
-                GpuGKRSourceRecord::source_only(packed),
-            );
-            inputs_count += 1;
+    for (slot_idx, slot) in layer_slots.iter_enabled() {
+        let mut io = [GpuGKRSourceRecord::default(); GKR_DIM_REDUCING_IO_PER_SLOT];
+        let addresses = slot.inputs.iter().chain(slot.outputs.iter()).copied();
+        for (k, address) in addresses.enumerate() {
+            let (ptr, log2_stride, poly_idx) = resolve_ext_consolidated(storage, address);
+            let table_slot = tables.get_or_create(ptr, log2_stride);
+            io[k] = GpuGKRSourceRecord::source_only(pack_source_u16(false, table_slot, poly_idx));
         }
-        assert!(usize::from(inputs_count) <= GKR_DIM_REDUCING_MAX_INPUTS_PER_RECORD);
-
-        // Outputs.
-        let outputs_offset = payload_cursor as u16;
-        let mut outputs_count = 0u16;
-        for addr in blueprint.inputs.outputs_in_extension.iter().copied() {
-            if addr == GKRAddress::placeholder() {
-                continue;
-            }
-            let (ptr, log2_stride, poly_idx) = resolve_ext_consolidated(storage, addr);
-            let slot = tables.get_or_create(ptr, log2_stride);
-            let packed = pack_source_u16(false, slot, poly_idx);
-            push_payload_record(
-                &mut batch.inline_payload,
-                &mut payload_cursor,
-                GpuGKRSourceRecord::source_only(packed),
-            );
-            outputs_count += 1;
-        }
-        assert!(usize::from(outputs_count) <= GKR_DIM_REDUCING_MAX_OUTPUTS_PER_RECORD);
-
-        batch.records[idx] = GpuGKRDimensionReducingBatchRecordCompact {
-            kind: blueprint.kind.as_u32(),
-            inputs: PayloadRange16 {
-                offset: inputs_offset,
-                count: inputs_count,
-            },
-            outputs: PayloadRange16 {
-                offset: outputs_offset,
-                count: outputs_count,
-            },
-            batch_challenge_offset: blueprint.batch_challenge_offset as u16,
-            _reserved: 0,
+        batch.slots[slot_idx] = GpuGKRDimensionReducingSlot {
+            io,
+            batch_exp: slot.batch_exp,
         };
     }
 

--- a/gpu/gkr/src/backward/dim_reducing_sumcheck_plan.rs
+++ b/gpu/gkr/src/backward/dim_reducing_sumcheck_plan.rs
@@ -26,21 +26,9 @@ impl GpuGKRDimensionReducingSumcheckLayerPlan {
         launch_dim_reducing_round0_batched_compact(&batch, acc_size, context)
     }
 
-    fn launch_round1_kernels(
-        &mut self,
-        mut batch: GpuGKRDimensionReducingContinuationBatchCompact<E4>,
-        acc_size: usize,
-        context: &ProverContext,
-    ) -> CudaResult<()> {
-        batch.eq_low = self.round_scratch.eq_low_group.as_ptr();
-        batch.eq_sizes = self.eq_sizes;
-        batch.contributions = self.round_scratch.accumulator.as_mut_ptr();
-        launch_dim_reducing_round1_batched_compact(&batch, acc_size, context)
-    }
-
     fn launch_continuation_kernels(
         &mut self,
-        mut batch: GpuGKRDimensionReducingContinuationBatchCompact<E4>,
+        mut batch: GpuGKRDimensionReducingBatch<E4>,
         step: usize,
         acc_size: usize,
         context: &ProverContext,
@@ -124,24 +112,22 @@ impl GpuGKRDimensionReducingSumcheckLayerPlan {
         per_poly_len: usize,
     ) -> BTreeMap<GKRAddress, *const E4> {
         let mut result = BTreeMap::new();
-        for kernel in self.kernel_plans.iter() {
-            for address in kernel.inputs.inputs_in_extension.iter() {
-                if *address == GKRAddress::placeholder() || result.contains_key(address) {
-                    continue;
-                }
-                let canonical = storage
-                    .layout
-                    .as_ref()
-                    .and_then(|layout| layout.aliases.get(address))
-                    .copied()
-                    .unwrap_or(*address);
-                let poly_idx = self
-                    .folding_addresses
-                    .binary_search(&canonical)
-                    .expect("final folding source missing from dense arena");
-                let pointer = unsafe { folding.as_ptr().add(poly_idx * per_poly_len) };
-                result.insert(*address, pointer);
+        for address in self.layer_slots.input_addresses() {
+            if result.contains_key(&address) {
+                continue;
             }
+            let canonical = storage
+                .layout
+                .as_ref()
+                .and_then(|layout| layout.aliases.get(&address))
+                .copied()
+                .unwrap_or(address);
+            let poly_idx = self
+                .folding_addresses
+                .binary_search(&canonical)
+                .expect("final folding source missing from dense arena");
+            let pointer = unsafe { folding.as_ptr().add(poly_idx * per_poly_len) };
+            result.insert(address, pointer);
         }
 
         result
@@ -175,15 +161,12 @@ impl GpuGKRDimensionReducingSumcheckLayerPlan {
         } else {
             None
         };
-        let mut desc_pairs: Vec<u32> = Vec::with_capacity(
-            self.kernel_plans
-                .iter()
-                .map(|kernel| kernel.inputs.outputs_in_extension.len() * 2)
-                .sum(),
-        );
-        for kernel in self.kernel_plans.iter() {
-            for (j, output) in kernel.inputs.outputs_in_extension.iter().enumerate() {
-                desc_pairs.push((kernel.batch_challenge_offset + j) as u32);
+        // Exponents come from the same slot table the kernels read, so the claim
+        // combination and the per-output kernel weights cannot disagree.
+        let mut desc_pairs: Vec<u32> = Vec::new();
+        for (_, slot) in self.layer_slots.iter_enabled() {
+            for (output, batch_exp) in slot.outputs.iter().zip(slot.batch_exp.iter()) {
+                desc_pairs.push(u32::from(*batch_exp));
                 desc_pairs.push(claim_layout.claim_idx(output));
             }
         }
@@ -271,12 +254,12 @@ impl GpuGKRDimensionReducingSumcheckLayerPlan {
                 );
                 if step == 1 {
                     let batch = dim_reducing_encoder::build_round1_batch_compact_for_arena(
-                        &self.kernel_plans,
+                        &self.layer_slots,
                         storage,
                         &self.folding_addresses,
                         destination_binding,
                     );
-                    self.launch_round1_kernels(batch, acc_size, context)?;
+                    self.launch_continuation_kernels(batch, step, acc_size, context)?;
                 } else {
                     let current = folding_current
                         .as_ref()
@@ -286,7 +269,7 @@ impl GpuGKRDimensionReducingSumcheckLayerPlan {
                         folding_current_len.trailing_zeros(),
                     );
                     let batch = dim_reducing_encoder::build_continuation_batch_compact_for_arenas(
-                        &self.kernel_plans,
+                        &self.layer_slots,
                         storage,
                         &self.folding_addresses,
                         current_binding,
@@ -332,12 +315,12 @@ impl GpuGKRDimensionReducingSumcheckLayerPlan {
         );
         if last_step == 1 {
             let batch = dim_reducing_encoder::build_round1_batch_compact_for_arena(
-                &self.kernel_plans,
+                &self.layer_slots,
                 storage,
                 &self.folding_addresses,
                 destination_binding,
             );
-            self.launch_round1_kernels(batch, 1, context)?;
+            self.launch_continuation_kernels(batch, last_step, 1, context)?;
         } else {
             let current = folding_current
                 .as_ref()
@@ -347,7 +330,7 @@ impl GpuGKRDimensionReducingSumcheckLayerPlan {
                 folding_current_len.trailing_zeros(),
             );
             let batch = dim_reducing_encoder::build_continuation_batch_compact_for_arenas(
-                &self.kernel_plans,
+                &self.layer_slots,
                 storage,
                 &self.folding_addresses,
                 current_binding,

--- a/gpu/gkr/src/backward/kernels/dim_reducing.rs
+++ b/gpu/gkr/src/backward/kernels/dim_reducing.rs
@@ -7,45 +7,41 @@ use era_cudart::slice::{DeviceSlice, DeviceVariable};
 use era_cudart_sys::{cudaGetSymbolAddress, cuda_struct_and_stub};
 
 use super::super::super::GpuGKRStorage;
-use super::encoding::GpuGKRDimensionReducingRound0BatchCompact;
+use super::encoding::GpuGKRDimensionReducingBatch;
 use super::launchers::GkrEqSizes;
 use super::shared::{
     ClaimBufferLayout, DeviceClaimPointAndBatching, GKR_BACKWARD_MAX_TRACE_LEN_LOG2,
 };
-use crate::upstream::{DimensionReducingInputOutput, GKRAddress, GKRInputs, OutputType};
+use crate::upstream::{DimensionReducingInputOutput, GKRAddress, OutputType};
 use gpu_core::primitives::context::DeviceAllocation;
 use gpu_core::primitives::device_tracing::Range;
 use gpu_core::primitives::field::{BF, E4};
 use gpu_prover_context::ProverContext;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u32)]
-pub(crate) enum GpuGKRDimensionReducingKernelKind {
-    Pairwise = 0,
-    Lookup = 1,
+// Dim-reducing layers carry one slot per OutputType, in OutputType discriminant
+// order, each with 2 inputs / 2 outputs / 2 batch challenges. MUST stay in
+// lockstep with the native mirror in native/gkr/support/descriptors.cuh.
+pub(crate) const GKR_DIM_REDUCING_SLOTS: usize = 5;
+pub(crate) const GKR_DIM_REDUCING_INPUTS_PER_SLOT: usize = 2;
+pub(crate) const GKR_DIM_REDUCING_OUTPUTS_PER_SLOT: usize = 2;
+pub(crate) const GKR_DIM_REDUCING_IO_PER_SLOT: usize =
+    GKR_DIM_REDUCING_INPUTS_PER_SLOT + GKR_DIM_REDUCING_OUTPUTS_PER_SLOT;
+pub(crate) const GKR_DIM_REDUCING_BATCH_CHALLENGE_TABLE_LEN: usize =
+    GKR_DIM_REDUCING_SLOTS * GKR_DIM_REDUCING_OUTPUTS_PER_SLOT;
+
+/// Wire slot index for an output type. The device derives each slot's kind from
+/// this index at compile time, and exponents are packed densely in this order,
+/// which must stay the `OutputType` `Ord` order the generated verifier walks.
+pub(crate) const fn dim_reducing_slot_index(output_type: OutputType) -> usize {
+    match output_type {
+        OutputType::PermutationProduct => 0,
+        OutputType::Lookup16Bits => 1,
+        OutputType::LookupTimestamps => 2,
+        OutputType::GenericLookup => 3,
+        OutputType::InitsAndTeardownsProduct => 4,
+    }
 }
 
-impl GpuGKRDimensionReducingKernelKind {
-    pub(crate) const fn as_u32(self) -> u32 {
-        self as u32
-    }
-
-    pub(crate) const fn challenge_count(self) -> usize {
-        match self {
-            Self::Pairwise => 1,
-            Self::Lookup => 2,
-        }
-    }
-}
-
-// Dim-reducing layers are keyed by OutputType: 2 pairwise records for
-// PermutationProduct, up to 3 lookup records, plus (unified circuit)
-// 2 pairwise records for InitsAndTeardownsProduct = 7 records / 10 challenges.
-// MUST stay in lockstep with the native mirror in
-// native/gkr/support/descriptors.cuh (GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER /
-// GKR_DIM_REDUCING_BATCH_CHALLENGE_TABLE_LEN).
-pub(crate) const GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER: usize = 7;
-pub(crate) const GKR_DIM_REDUCING_BATCH_CHALLENGE_TABLE_LEN: usize = 10;
 /// Dim-reducing next-layer state stores `(folding_steps - 1)` per-round
 /// challenges plus 3 transcript-squeezed values:
 /// `[folding_challenges, r_before_last, r_last, next_batching]`.
@@ -114,11 +110,46 @@ pub(crate) struct GpuGKRDimensionReducingRoundScratch {
     pub(crate) partials: DeviceAllocation<E4>,
 }
 
+/// Host-side plan for one enabled slot: its 2 input and 2 output addresses, and
+/// the batch-challenge table index carried by each output.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct GpuGKRDimensionReducingKernelPlan {
-    pub(crate) kind: GpuGKRDimensionReducingKernelKind,
-    pub(crate) inputs: GKRInputs,
-    pub(crate) batch_challenge_offset: usize,
+pub(crate) struct GpuGKRDimensionReducingSlotPlan {
+    pub(crate) inputs: [GKRAddress; GKR_DIM_REDUCING_INPUTS_PER_SLOT],
+    pub(crate) outputs: [GKRAddress; GKR_DIM_REDUCING_OUTPUTS_PER_SLOT],
+    pub(crate) batch_exp: [u16; GKR_DIM_REDUCING_OUTPUTS_PER_SLOT],
+}
+
+/// The fixed slot table for one dim-reducing layer. `None` means the circuit
+/// does not use that output type.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct GpuGKRDimensionReducingLayerSlots {
+    pub(crate) slots: [Option<GpuGKRDimensionReducingSlotPlan>; GKR_DIM_REDUCING_SLOTS],
+}
+
+impl GpuGKRDimensionReducingLayerSlots {
+    pub(crate) fn enabled_mask(&self) -> u32 {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter(|(_, slot)| slot.is_some())
+            .fold(0u32, |mask, (idx, _)| mask | (1u32 << idx))
+    }
+
+    /// Enabled slots in wire order, paired with their slot index.
+    pub(crate) fn iter_enabled(
+        &self,
+    ) -> impl Iterator<Item = (usize, &GpuGKRDimensionReducingSlotPlan)> {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, slot)| slot.as_ref().map(|slot| (idx, slot)))
+    }
+
+    /// Every input address read by this layer, in wire order.
+    pub(crate) fn input_addresses(&self) -> impl Iterator<Item = GKRAddress> + '_ {
+        self.iter_enabled()
+            .flat_map(|(_, slot)| slot.inputs.iter().copied())
+    }
 }
 
 #[doc(hidden)]
@@ -126,9 +157,9 @@ pub(crate) struct GpuGKRDimensionReducingSumcheckLayerPlan {
     pub layer_idx: usize,
     pub(crate) trace_len_after_reduction: usize,
     pub(crate) folding_steps: usize,
-    pub(crate) kernel_plans: Vec<GpuGKRDimensionReducingKernelPlan>,
+    pub(crate) layer_slots: GpuGKRDimensionReducingLayerSlots,
     pub(crate) folding_addresses: Vec<GKRAddress>,
-    pub(crate) round0_batch_template_compact: GpuGKRDimensionReducingRound0BatchCompact<E4>,
+    pub(crate) round0_batch_template_compact: GpuGKRDimensionReducingBatch<E4>,
     pub(crate) round_scratch: GpuGKRDimensionReducingRoundScratch,
     /// Strict 3-slot eq-sizes descriptor. Initialised at layer start from
     /// `make_eq_sizes(folding_steps - 1)`, updated between sumcheck rounds,

--- a/gpu/gkr/src/backward/kernels/encoding.rs
+++ b/gpu/gkr/src/backward/kernels/encoding.rs
@@ -1,7 +1,9 @@
 use std::ffi::c_void;
 use std::ptr::{null, null_mut};
 
-use super::dim_reducing::GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER;
+use super::dim_reducing::{
+    GKR_DIM_REDUCING_IO_PER_SLOT, GKR_DIM_REDUCING_OUTPUTS_PER_SLOT, GKR_DIM_REDUCING_SLOTS,
+};
 use super::launchers::GkrEqSizes;
 use crate::upstream::Field;
 use era_cudart::result::CudaResultWrap;
@@ -46,32 +48,17 @@ pub(crate) fn get_main_layer_claim_point_device_ptr() -> *mut E4 {
 // halves resolve against the same per-launch `bases` / `log2_stride` tables.
 // ---------------------------------------------------------------------------
 
-pub(crate) const GKR_DIM_REDUCING_MAX_INPUTS_PER_RECORD: usize = 2;
-pub(crate) const GKR_DIM_REDUCING_MAX_OUTPUTS_PER_RECORD: usize = 2;
-pub(crate) const GKR_DIM_REDUCING_INLINE_RECORD_CAP: usize = GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER
-    * (GKR_DIM_REDUCING_MAX_INPUTS_PER_RECORD + GKR_DIM_REDUCING_MAX_OUTPUTS_PER_RECORD);
-
 /// Number of base pointers addressable by the 4-bit source pointer index.
 pub(crate) const GKR_DIM_REDUCING_BASE_SLOTS: usize = 16;
 
-/// `(offset, count)` over the `inline_payload[GpuGKRSourceRecord]` array.
-/// 4 B per range record.
+/// One dim-reducing slot: `io[0..2]` inputs then `io[2..4]` outputs, plus the
+/// batch-challenge table index for each output. Mirrors
+/// `gkr_dim_reducing_slot` in `native/gkr/support/descriptors.cuh`.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(crate) struct PayloadRange16 {
-    pub(crate) offset: u16,
-    pub(crate) count: u16,
-}
-
-/// One dim-reducing record (kernel-batch entry).
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default)]
-pub(crate) struct GpuGKRDimensionReducingBatchRecordCompact {
-    pub(crate) kind: u32,
-    pub(crate) inputs: PayloadRange16,
-    pub(crate) outputs: PayloadRange16,
-    pub(crate) batch_challenge_offset: u16,
-    pub(crate) _reserved: u16,
+pub(crate) struct GpuGKRDimensionReducingSlot {
+    pub(crate) io: [GpuGKRSourceRecord; GKR_DIM_REDUCING_IO_PER_SLOT],
+    pub(crate) batch_exp: [u16; GKR_DIM_REDUCING_OUTPUTS_PER_SLOT],
 }
 
 /// Per-launch pointer + stride tables.
@@ -115,66 +102,34 @@ impl GpuGKRSourceRecord {
     }
 }
 
+/// Mirrors `gkr_dim_reducing_batch<E>`, shared by both dim-reducing round
+/// kernels.
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub(crate) struct GpuGKRDimensionReducingRound0BatchCompact<E> {
-    pub(crate) record_count: u32,
+pub(crate) struct GpuGKRDimensionReducingBatch<E> {
+    pub(crate) enabled_mask: u32,
     pub(crate) _reserved0: u32,
     pub(crate) eq_low: *const E,
     pub(crate) eq_sizes: GkrEqSizes,
     pub(crate) _eq_sizes_pad: u32,
     pub(crate) contributions: *mut E,
     pub(crate) tables: GpuGKRDimensionReducingTables,
-    pub(crate) records:
-        [GpuGKRDimensionReducingBatchRecordCompact; GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER],
-    pub(crate) inline_payload: [GpuGKRSourceRecord; GKR_DIM_REDUCING_INLINE_RECORD_CAP],
+    pub(crate) slots: [GpuGKRDimensionReducingSlot; GKR_DIM_REDUCING_SLOTS],
+    pub(crate) _slots_pad: u32,
 }
 
-impl<E: Field> Default for GpuGKRDimensionReducingRound0BatchCompact<E> {
+impl<E: Field> Default for GpuGKRDimensionReducingBatch<E> {
     fn default() -> Self {
         Self {
-            record_count: 0,
+            enabled_mask: 0,
             _reserved0: 0,
             eq_low: null(),
             eq_sizes: GkrEqSizes::zeroed(),
             _eq_sizes_pad: 0,
             contributions: null_mut(),
             tables: GpuGKRDimensionReducingTables::default(),
-            records: [GpuGKRDimensionReducingBatchRecordCompact::default();
-                GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER],
-            inline_payload: [GpuGKRSourceRecord::default(); GKR_DIM_REDUCING_INLINE_RECORD_CAP],
-        }
-    }
-}
-
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub(crate) struct GpuGKRDimensionReducingContinuationBatchCompact<E> {
-    pub(crate) record_count: u32,
-    pub(crate) _reserved0: u32,
-    pub(crate) eq_low: *const E,
-    pub(crate) eq_sizes: GkrEqSizes,
-    pub(crate) _eq_sizes_pad: u32,
-    pub(crate) contributions: *mut E,
-    pub(crate) tables: GpuGKRDimensionReducingTables,
-    pub(crate) records:
-        [GpuGKRDimensionReducingBatchRecordCompact; GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER],
-    pub(crate) inline_payload: [GpuGKRSourceRecord; GKR_DIM_REDUCING_INLINE_RECORD_CAP],
-}
-
-impl<E: Field> Default for GpuGKRDimensionReducingContinuationBatchCompact<E> {
-    fn default() -> Self {
-        Self {
-            record_count: 0,
-            _reserved0: 0,
-            eq_low: null(),
-            eq_sizes: GkrEqSizes::zeroed(),
-            _eq_sizes_pad: 0,
-            contributions: null_mut(),
-            tables: GpuGKRDimensionReducingTables::default(),
-            records: [GpuGKRDimensionReducingBatchRecordCompact::default();
-                GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER],
-            inline_payload: [GpuGKRSourceRecord::default(); GKR_DIM_REDUCING_INLINE_RECORD_CAP],
+            slots: [GpuGKRDimensionReducingSlot::default(); GKR_DIM_REDUCING_SLOTS],
+            _slots_pad: 0,
         }
     }
 }

--- a/gpu/gkr/src/backward/kernels/launchers.rs
+++ b/gpu/gkr/src/backward/kernels/launchers.rs
@@ -5,9 +5,7 @@ use era_cudart::result::{CudaResult, CudaResultWrap};
 use era_cudart::{cuda_kernel_declaration, cuda_kernel_signature_arguments_and_function};
 use era_cudart_sys::{cudaGetSymbolAddress, cuda_struct_and_stub};
 
-use super::encoding::{
-    GpuGKRDimensionReducingContinuationBatchCompact, GpuGKRDimensionReducingRound0BatchCompact,
-};
+use super::encoding::GpuGKRDimensionReducingBatch;
 use gpu_core::primitives::field::{BF, E4};
 use gpu_core::primitives::utils::{get_grid_block_dims_for_threads_count, WARP_SIZE};
 use gpu_prover_context::ProverContext;
@@ -154,19 +152,13 @@ cuda_kernel_signature_arguments_and_function!(
 
 cuda_kernel_signature_arguments_and_function!(
     pub(crate) GpuDimensionReducingRound0BatchedCompact<T>,
-    batch: GpuGKRDimensionReducingRound0BatchCompact<T>,
-    acc_size: u32,
-);
-
-cuda_kernel_signature_arguments_and_function!(
-    pub(crate) GpuDimensionReducingRound1BatchedCompact<T>,
-    batch: GpuGKRDimensionReducingContinuationBatchCompact<T>,
+    batch: GpuGKRDimensionReducingBatch<T>,
     acc_size: u32,
 );
 
 cuda_kernel_signature_arguments_and_function!(
     pub(crate) GpuDimensionReducingContinuationBatchedCompact<T>,
-    batch: GpuGKRDimensionReducingContinuationBatchCompact<T>,
+    batch: GpuGKRDimensionReducingBatch<T>,
     acc_size: u32,
     step: u32,
 );
@@ -228,19 +220,13 @@ cuda_kernel_declaration!(pub(crate)
 );
 cuda_kernel_declaration!(pub(crate)
     ab_gkr_dim_reducing_round0_batched_compact_e4_kernel(
-        batch: GpuGKRDimensionReducingRound0BatchCompact<E4>,
-        acc_size: u32,
-    )
-);
-cuda_kernel_declaration!(pub(crate)
-    ab_gkr_dim_reducing_round1_batched_compact_e4_kernel(
-        batch: GpuGKRDimensionReducingContinuationBatchCompact<E4>,
+        batch: GpuGKRDimensionReducingBatch<E4>,
         acc_size: u32,
     )
 );
 cuda_kernel_declaration!(pub(crate)
     ab_gkr_dim_reducing_continuation_batched_compact_e4_kernel(
-        batch: GpuGKRDimensionReducingContinuationBatchCompact<E4>,
+        batch: GpuGKRDimensionReducingBatch<E4>,
         acc_size: u32,
         step: u32,
     )
@@ -264,7 +250,7 @@ pub(crate) fn gkr_trace_holder_partials_launch_config(
 }
 
 pub(crate) fn launch_dim_reducing_round0_batched_compact(
-    batch: &GpuGKRDimensionReducingRound0BatchCompact<E4>,
+    batch: &GpuGKRDimensionReducingBatch<E4>,
     acc_size: usize,
     context: &ProverContext,
 ) -> CudaResult<()> {
@@ -276,21 +262,8 @@ pub(crate) fn launch_dim_reducing_round0_batched_compact(
     .launch(&config, &args)
 }
 
-pub(crate) fn launch_dim_reducing_round1_batched_compact(
-    batch: &GpuGKRDimensionReducingContinuationBatchCompact<E4>,
-    acc_size: usize,
-    context: &ProverContext,
-) -> CudaResult<()> {
-    let config = gkr_dim_reducing_launch_config(acc_size as u32, context);
-    let args = GpuDimensionReducingRound1BatchedCompactArguments::new(*batch, acc_size as u32);
-    GpuDimensionReducingRound1BatchedCompactFunction(
-        ab_gkr_dim_reducing_round1_batched_compact_e4_kernel,
-    )
-    .launch(&config, &args)
-}
-
 pub(crate) fn launch_dim_reducing_continuation_batched_compact(
-    batch: &GpuGKRDimensionReducingContinuationBatchCompact<E4>,
+    batch: &GpuGKRDimensionReducingBatch<E4>,
     acc_size: usize,
     step: usize,
     context: &ProverContext,

--- a/gpu/gkr/src/backward/kernels/tests.rs
+++ b/gpu/gkr/src/backward/kernels/tests.rs
@@ -1,7 +1,28 @@
 use std::mem::{align_of, offset_of, size_of};
 
 use super::*;
+use crate::upstream::OutputType;
 use gpu_core::primitives::field::E4;
+
+const ALL_OUTPUT_TYPES: [OutputType; GKR_DIM_REDUCING_SLOTS] = [
+    OutputType::PermutationProduct,
+    OutputType::Lookup16Bits,
+    OutputType::LookupTimestamps,
+    OutputType::GenericLookup,
+    OutputType::InitsAndTeardownsProduct,
+];
+
+/// Exponents are packed densely in slot order, while the generated verifier packs
+/// them in `OutputType` `Ord` order. The two must agree, or a circuit that skips
+/// an output type gets exponents the verifier does not expect.
+#[test]
+fn cpu_slot_index_follows_output_type_ord() {
+    let mut by_ord = ALL_OUTPUT_TYPES;
+    by_ord.sort();
+    let mut by_slot = ALL_OUTPUT_TYPES;
+    by_slot.sort_by_key(|output_type| dim_reducing_slot_index(*output_type));
+    assert_eq!(by_ord, by_slot);
+}
 
 #[inline]
 pub(crate) const fn unpack_source_u16(packed: u16) -> (bool, u8, u16) {
@@ -40,68 +61,35 @@ fn pack_source_u16_layout_bits() {
 #[test]
 fn compact_descriptor_sizes_under_kernel_arg_ceiling() {
     const KERNEL_ARG_CEILING_BYTES: usize = gpu_gkr_compiler::KERNEL_ARGUMENT_CEILING_BYTES;
-    let r0 = size_of::<GpuGKRDimensionReducingRound0BatchCompact<E4>>();
-    let cont = size_of::<GpuGKRDimensionReducingContinuationBatchCompact<E4>>();
-    assert_eq!(r0, 456);
-    assert_eq!(cont, 456);
-    assert!(r0 + size_of::<u32>() <= KERNEL_ARG_CEILING_BYTES);
-    assert!(cont + 2 * size_of::<u32>() <= KERNEL_ARG_CEILING_BYTES);
+    let batch = size_of::<GpuGKRDimensionReducingBatch<E4>>();
+    assert_eq!(batch, 336);
+    // The continuation kernel carries the widest trailing scalars (acc_size, step).
+    assert!(batch + 2 * size_of::<u32>() <= KERNEL_ARG_CEILING_BYTES);
 
     assert_eq!(size_of::<GkrEqSizes>(), 12);
     assert_eq!(align_of::<GkrEqSizes>(), 4);
     assert_eq!(offset_of!(GkrEqSizes, high), 0);
     assert_eq!(offset_of!(GkrEqSizes, low), 8);
 
-    macro_rules! assert_layout {
-        ($ty:ty) => {
-            assert_eq!(align_of::<$ty>(), 8);
-            assert_eq!(offset_of!($ty, record_count), 0);
-            assert_eq!(offset_of!($ty, _reserved0), 4);
-            assert_eq!(offset_of!($ty, eq_low), 8);
-            assert_eq!(offset_of!($ty, eq_sizes), 16);
-            assert_eq!(offset_of!($ty, _eq_sizes_pad), 28);
-            assert_eq!(offset_of!($ty, contributions), 32);
-            assert_eq!(offset_of!($ty, tables), 40);
-            assert_eq!(offset_of!($ty, records), 232);
-            assert_eq!(offset_of!($ty, inline_payload), 344);
-        };
-    }
-    assert_layout!(GpuGKRDimensionReducingRound0BatchCompact<E4>);
-    assert_layout!(GpuGKRDimensionReducingContinuationBatchCompact<E4>);
+    type Batch = GpuGKRDimensionReducingBatch<E4>;
+    assert_eq!(align_of::<Batch>(), 8);
+    assert_eq!(offset_of!(Batch, enabled_mask), 0);
+    assert_eq!(offset_of!(Batch, _reserved0), 4);
+    assert_eq!(offset_of!(Batch, eq_low), 8);
+    assert_eq!(offset_of!(Batch, eq_sizes), 16);
+    assert_eq!(offset_of!(Batch, _eq_sizes_pad), 28);
+    assert_eq!(offset_of!(Batch, contributions), 32);
+    assert_eq!(offset_of!(Batch, tables), 40);
+    assert_eq!(offset_of!(Batch, slots), 232);
+    assert_eq!(offset_of!(Batch, _slots_pad), 332);
 }
 
 #[test]
-fn compact_record_is_16_bytes() {
-    assert_eq!(size_of::<PayloadRange16>(), 4);
-    assert_eq!(align_of::<PayloadRange16>(), 2);
-    assert_eq!(offset_of!(PayloadRange16, offset), 0);
-    assert_eq!(offset_of!(PayloadRange16, count), 2);
-
-    assert_eq!(size_of::<GpuGKRDimensionReducingBatchRecordCompact>(), 16);
-    assert_eq!(align_of::<GpuGKRDimensionReducingBatchRecordCompact>(), 4);
-    assert_eq!(
-        offset_of!(GpuGKRDimensionReducingBatchRecordCompact, kind),
-        0
-    );
-    assert_eq!(
-        offset_of!(GpuGKRDimensionReducingBatchRecordCompact, inputs),
-        4
-    );
-    assert_eq!(
-        offset_of!(GpuGKRDimensionReducingBatchRecordCompact, outputs),
-        8
-    );
-    assert_eq!(
-        offset_of!(
-            GpuGKRDimensionReducingBatchRecordCompact,
-            batch_challenge_offset
-        ),
-        12
-    );
-    assert_eq!(
-        offset_of!(GpuGKRDimensionReducingBatchRecordCompact, _reserved),
-        14
-    );
+fn compact_slot_is_20_bytes() {
+    assert_eq!(size_of::<GpuGKRDimensionReducingSlot>(), 20);
+    assert_eq!(align_of::<GpuGKRDimensionReducingSlot>(), 2);
+    assert_eq!(offset_of!(GpuGKRDimensionReducingSlot, io), 0);
+    assert_eq!(offset_of!(GpuGKRDimensionReducingSlot, batch_exp), 16);
 
     assert_eq!(size_of::<GpuGKRDimensionReducingTables>(), 192);
     assert_eq!(align_of::<GpuGKRDimensionReducingTables>(), 8);
@@ -118,12 +106,10 @@ fn compact_record_is_16_bytes() {
 fn compact_cuda_constants_match_rust() {
     let header = include_str!("../../../native/gkr/support/descriptors.cuh");
     for declaration in [
-        "GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER = 7;",
-        "GKR_DIM_REDUCING_BATCH_CHALLENGE_TABLE_LEN = 10;",
-        "GKR_DIM_REDUCING_INLINE_RECORD_CAP = 28;",
+        "GKR_DIM_REDUCING_SLOTS = 5;",
+        "GKR_DIM_REDUCING_INPUTS_PER_SLOT = 2;",
+        "GKR_DIM_REDUCING_OUTPUTS_PER_SLOT = 2;",
         "GKR_DIM_REDUCING_BASE_SLOTS = 16;",
-        "GKR_DIM_REDUCING_MAX_INPUTS_PER_RECORD = 2;",
-        "GKR_DIM_REDUCING_MAX_OUTPUTS_PER_RECORD = 2;",
         "GKR_BACKWARD_MAX_TRACE_LEN_LOG2 = 24;",
         "GKR_DIM_REDUCING_LAYER_CLAIM_POINT_LEN = GKR_BACKWARD_MAX_TRACE_LEN_LOG2 + 2;",
         "GKR_MAIN_LAYER_CLAIM_POINT_LEN = GKR_BACKWARD_MAX_TRACE_LEN_LOG2 + 1;",
@@ -136,12 +122,11 @@ fn compact_cuda_constants_match_rust() {
             "missing CUDA declaration: {declaration}"
         );
     }
-    assert_eq!(GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER, 7);
+    assert_eq!(GKR_DIM_REDUCING_SLOTS, 5);
+    assert_eq!(GKR_DIM_REDUCING_INPUTS_PER_SLOT, 2);
+    assert_eq!(GKR_DIM_REDUCING_OUTPUTS_PER_SLOT, 2);
     assert_eq!(GKR_DIM_REDUCING_BATCH_CHALLENGE_TABLE_LEN, 10);
-    assert_eq!(GKR_DIM_REDUCING_INLINE_RECORD_CAP, 28);
     assert_eq!(GKR_DIM_REDUCING_BASE_SLOTS, 16);
-    assert_eq!(GKR_DIM_REDUCING_MAX_INPUTS_PER_RECORD, 2);
-    assert_eq!(GKR_DIM_REDUCING_MAX_OUTPUTS_PER_RECORD, 2);
     assert_eq!(GKR_BACKWARD_MAX_TRACE_LEN_LOG2, 24);
     assert_eq!(GKR_EQ_GROUP_SIZE, 8);
     assert_eq!(GKR_EQ_HIGH_SLOTS, 2);

--- a/gpu/gkr/src/backward/main_layer/blueprints.rs
+++ b/gpu/gkr/src/backward/main_layer/blueprints.rs
@@ -1,55 +1,49 @@
 use std::collections::BTreeMap;
 
-use crate::upstream::{DimensionReducingInputOutput, GKRAddress, GKRInputs, OutputType};
+use crate::upstream::{DimensionReducingInputOutput, GKRAddress, OutputType};
 
-use super::super::kernels::{GpuGKRDimensionReducingKernelKind, GpuGKRDimensionReducingKernelPlan};
+use super::super::kernels::{
+    dim_reducing_slot_index, GpuGKRDimensionReducingLayerSlots, GpuGKRDimensionReducingSlotPlan,
+    GKR_DIM_REDUCING_INPUTS_PER_SLOT, GKR_DIM_REDUCING_OUTPUTS_PER_SLOT,
+};
 
-pub(in crate::backward) fn build_dimension_reducing_kernel_blueprints_static(
+/// Lowers a layer's `OutputType`-keyed IO map onto the fixed slot table; absent
+/// output types leave their slot disabled.
+///
+/// Exponents are packed densely, two per enabled slot. `BTreeMap` iterates in
+/// `OutputType` `Ord` order and slot index is monotonic in that order, so this
+/// reproduces the numbering the generated verifier derives by walking its own
+/// present output groups.
+pub(in crate::backward) fn build_dimension_reducing_slots_static(
     layer: &BTreeMap<OutputType, DimensionReducingInputOutput>,
-) -> Vec<GpuGKRDimensionReducingKernelPlan> {
-    let mut next_batch_challenge_offset = 0;
-    let mut blueprints = Vec::new();
+) -> GpuGKRDimensionReducingLayerSlots {
+    let mut layer_slots = GpuGKRDimensionReducingLayerSlots::default();
+    let mut next_batch_exp = 0u16;
+
     for (output_type, reduced) in layer {
-        match output_type {
-            OutputType::PermutationProduct | OutputType::InitsAndTeardownsProduct => {
-                for (input, output) in reduced.inputs.iter().zip(&reduced.output) {
-                    blueprints.push(GpuGKRDimensionReducingKernelPlan {
-                        kind: GpuGKRDimensionReducingKernelKind::Pairwise,
-                        inputs: GKRInputs {
-                            inputs_in_base: Vec::new(),
-                            inputs_in_extension: vec![*input],
-                            outputs_in_base: Vec::new(),
-                            outputs_in_extension: vec![*output],
-                        },
-                        batch_challenge_offset: next_batch_challenge_offset,
-                    });
-                    next_batch_challenge_offset += 1;
-                }
-            }
-            OutputType::Lookup16Bits | OutputType::LookupTimestamps | OutputType::GenericLookup => {
-                let inputs: [GKRAddress; 2] = reduced
-                    .inputs
-                    .clone()
-                    .try_into()
-                    .expect("dimension-reducing lookup expects two inputs");
-                let outputs: [GKRAddress; 2] = reduced
-                    .output
-                    .clone()
-                    .try_into()
-                    .expect("dimension-reducing lookup expects two outputs");
-                blueprints.push(GpuGKRDimensionReducingKernelPlan {
-                    kind: GpuGKRDimensionReducingKernelKind::Lookup,
-                    inputs: GKRInputs {
-                        inputs_in_base: Vec::new(),
-                        inputs_in_extension: inputs.to_vec(),
-                        outputs_in_base: Vec::new(),
-                        outputs_in_extension: outputs.to_vec(),
-                    },
-                    batch_challenge_offset: next_batch_challenge_offset,
-                });
-                next_batch_challenge_offset += 2;
-            }
-        }
+        let inputs: [GKRAddress; GKR_DIM_REDUCING_INPUTS_PER_SLOT] =
+            reduced.inputs.clone().try_into().unwrap_or_else(|_| {
+                panic!("dimension-reducing {output_type:?} expects two inputs")
+            });
+        let outputs: [GKRAddress; GKR_DIM_REDUCING_OUTPUTS_PER_SLOT] =
+            reduced.output.clone().try_into().unwrap_or_else(|_| {
+                panic!("dimension-reducing {output_type:?} expects two outputs")
+            });
+
+        let batch_exp = [next_batch_exp, next_batch_exp + 1];
+        next_batch_exp += GKR_DIM_REDUCING_OUTPUTS_PER_SLOT as u16;
+
+        let slot_idx = dim_reducing_slot_index(*output_type);
+        let previous = layer_slots.slots[slot_idx].replace(GpuGKRDimensionReducingSlotPlan {
+            inputs,
+            outputs,
+            batch_exp,
+        });
+        assert!(
+            previous.is_none(),
+            "duplicate dimension-reducing slot for {output_type:?}"
+        );
     }
-    blueprints
+
+    layer_slots
 }

--- a/gpu/gkr/src/backward/mod.rs
+++ b/gpu/gkr/src/backward/mod.rs
@@ -29,7 +29,7 @@ pub use stage_snapshots::{GKRBackwardStageSnapshot, GKRBackwardStageSnapshotSink
 pub(crate) use main_layer::extras::derive_dimension_reducing_inputs;
 
 use crate::upstream::{DimensionReducingInputOutput, GKRAddress, OutputType};
-use main_layer::blueprints::build_dimension_reducing_kernel_blueprints_static;
+use main_layer::blueprints::build_dimension_reducing_slots_static;
 impl GpuGKRDimensionReducingBackwardState {
     pub(super) fn new(
         forward_tracing_ranges: Vec<Range>,
@@ -91,38 +91,25 @@ impl GpuGKRDimensionReducingBackwardState {
 }
 
 impl GpuGKRDimensionReducingBackwardState {
-    fn prepare_layer_from_blueprints(
+    fn prepare_layer_from_slots(
         &mut self,
         layer_idx: usize,
-        blueprints: &[GpuGKRDimensionReducingKernelPlan],
+        layer_slots: GpuGKRDimensionReducingLayerSlots,
         context: &ProverContext,
     ) -> CudaResult<GpuGKRDimensionReducingSumcheckLayerPlan> {
         let trace_len_after_reduction = self.next_trace_len_after_reduction;
         assert!(trace_len_after_reduction.is_power_of_two());
         let folding_steps = trace_len_after_reduction.trailing_zeros() as usize;
         assert!(folding_steps >= 2);
-        assert!(
-            blueprints.len() <= GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER,
-            "fused dimension-reducing backward supports at most {} kernels per layer, got {}",
-            GKR_DIM_REDUCING_MAX_RECORDS_PER_LAYER,
-            blueprints.len()
-        );
-        let batch_challenge_count = blueprints
-            .iter()
-            .map(|blueprint| blueprint.kind.challenge_count())
-            .sum::<usize>();
-        assert!(
-            batch_challenge_count <= GKR_DIM_REDUCING_BATCH_CHALLENGE_TABLE_LEN,
-            "fused dimension-reducing backward supports at most {} batch challenges per layer, got {}",
-            GKR_DIM_REDUCING_BATCH_CHALLENGE_TABLE_LEN,
-            batch_challenge_count
+        assert_ne!(
+            layer_slots.enabled_mask(),
+            0,
+            "dimension-reducing layer must enable at least one slot"
         );
 
         let aliases = self.storage.layout.as_ref().map(|layout| &layout.aliases);
-        let dim_reducing_ext_inputs: std::collections::BTreeSet<GKRAddress> = blueprints
-            .iter()
-            .flat_map(|bp| bp.inputs.inputs_in_extension.iter().copied())
-            .filter(|addr| *addr != GKRAddress::placeholder())
+        let dim_reducing_ext_inputs: std::collections::BTreeSet<GKRAddress> = layer_slots
+            .input_addresses()
             .map(|address| {
                 aliases
                     .and_then(|aliases| aliases.get(&address))
@@ -130,10 +117,9 @@ impl GpuGKRDimensionReducingBackwardState {
                     .unwrap_or(address)
             })
             .collect();
-        let kernel_plans = blueprints.to_vec();
 
         let round0_batch_template_compact =
-            self::dim_reducing_encoder::build_round0_batch_compact(blueprints, &self.storage);
+            self::dim_reducing_encoder::build_round0_batch_compact(&layer_slots, &self.storage);
         let max_acc_size = trace_len_after_reduction / 2;
         let partials_len = kernels::max_partials_len(max_acc_size);
         let partials = context.alloc(partials_len, AllocationPlacement::Top)?;
@@ -150,7 +136,7 @@ impl GpuGKRDimensionReducingBackwardState {
             layer_idx,
             trace_len_after_reduction,
             folding_steps,
-            kernel_plans,
+            layer_slots,
             folding_addresses: dim_reducing_ext_inputs.into_iter().collect(),
             round0_batch_template_compact,
             round_scratch,
@@ -165,10 +151,10 @@ impl GpuGKRDimensionReducingBackwardState {
         let Some((layer_idx, layer)) = self.pending_layers.pop_front() else {
             return Ok(None);
         };
-        let blueprints = build_dimension_reducing_kernel_blueprints_static(&layer);
-        Ok(Some(self.prepare_layer_from_blueprints(
+        let layer_slots = build_dimension_reducing_slots_static(&layer);
+        Ok(Some(self.prepare_layer_from_slots(
             layer_idx,
-            &blueprints,
+            layer_slots,
             context,
         )?))
     }

--- a/gpu/gkr/src/backward/tests/dimension_reduction_tests.rs
+++ b/gpu/gkr/src/backward/tests/dimension_reduction_tests.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 
-use crate::backward::kernels::GpuGKRDimensionReducingKernelKind;
-use crate::backward::main_layer::blueprints::build_dimension_reducing_kernel_blueprints_static;
+use crate::backward::kernels::dim_reducing_slot_index;
+use crate::backward::main_layer::blueprints::build_dimension_reducing_slots_static;
 use crate::upstream::{DimensionReducingInputOutput, OutputType};
 
 #[test]
-fn dimension_reducing_kernel_blueprints_match_protocol_order() {
+fn dimension_reducing_slots_match_protocol_order() {
     let layer = BTreeMap::from([
         (
             OutputType::PermutationProduct,
@@ -109,76 +109,22 @@ fn dimension_reducing_kernel_blueprints_match_protocol_order() {
         ),
     ]);
 
-    let blueprints = build_dimension_reducing_kernel_blueprints_static(&layer);
+    let layer_slots = build_dimension_reducing_slots_static(&layer);
 
-    assert_eq!(blueprints.len(), 5);
-    assert_eq!(
-        blueprints[0].inputs.inputs_in_extension,
-        vec![layer[&OutputType::PermutationProduct].inputs[0]]
-    );
-    assert_eq!(
-        blueprints[0].inputs.outputs_in_extension,
-        vec![layer[&OutputType::PermutationProduct].output[0]]
-    );
-    assert_eq!(
-        blueprints[0].kind,
-        GpuGKRDimensionReducingKernelKind::Pairwise
-    );
-    assert_eq!(blueprints[0].batch_challenge_offset, 0);
-
-    assert_eq!(
-        blueprints[1].inputs.inputs_in_extension,
-        vec![layer[&OutputType::PermutationProduct].inputs[1]]
-    );
-    assert_eq!(
-        blueprints[1].inputs.outputs_in_extension,
-        vec![layer[&OutputType::PermutationProduct].output[1]]
-    );
-    assert_eq!(
-        blueprints[1].kind,
-        GpuGKRDimensionReducingKernelKind::Pairwise
-    );
-    assert_eq!(blueprints[1].batch_challenge_offset, 1);
-
-    assert_eq!(
-        blueprints[2].inputs.inputs_in_extension,
-        layer[&OutputType::Lookup16Bits].inputs
-    );
-    assert_eq!(
-        blueprints[2].inputs.outputs_in_extension,
-        layer[&OutputType::Lookup16Bits].output
-    );
-    assert_eq!(
-        blueprints[2].kind,
-        GpuGKRDimensionReducingKernelKind::Lookup
-    );
-    assert_eq!(blueprints[2].batch_challenge_offset, 2);
-
-    assert_eq!(
-        blueprints[3].inputs.inputs_in_extension,
-        layer[&OutputType::LookupTimestamps].inputs
-    );
-    assert_eq!(
-        blueprints[3].inputs.outputs_in_extension,
-        layer[&OutputType::LookupTimestamps].output
-    );
-    assert_eq!(
-        blueprints[3].kind,
-        GpuGKRDimensionReducingKernelKind::Lookup
-    );
-    assert_eq!(blueprints[3].batch_challenge_offset, 4);
-
-    assert_eq!(
-        blueprints[4].inputs.inputs_in_extension,
-        layer[&OutputType::GenericLookup].inputs
-    );
-    assert_eq!(
-        blueprints[4].inputs.outputs_in_extension,
-        layer[&OutputType::GenericLookup].output
-    );
-    assert_eq!(
-        blueprints[4].kind,
-        GpuGKRDimensionReducingKernelKind::Lookup
-    );
-    assert_eq!(blueprints[4].batch_challenge_offset, 6);
+    // The fixture omits InitsAndTeardownsProduct, so exponents must pack densely
+    // across the four present types rather than leaving a hole at its slot.
+    assert_eq!(layer_slots.enabled_mask(), 0b0_1111);
+    for (output_type, expected_exp) in [
+        (OutputType::PermutationProduct, [0u16, 1]),
+        (OutputType::Lookup16Bits, [2, 3]),
+        (OutputType::LookupTimestamps, [4, 5]),
+        (OutputType::GenericLookup, [6, 7]),
+    ] {
+        let slot = layer_slots.slots[dim_reducing_slot_index(output_type)]
+            .as_ref()
+            .unwrap_or_else(|| panic!("{output_type:?} slot must be enabled"));
+        assert_eq!(slot.inputs.as_slice(), layer[&output_type].inputs);
+        assert_eq!(slot.outputs.as_slice(), layer[&output_type].output);
+        assert_eq!(slot.batch_exp, expected_exp, "{output_type:?}");
+    }
 }

--- a/gpu/gkr/src/forward/dimension_reducing.rs
+++ b/gpu/gkr/src/forward/dimension_reducing.rs
@@ -155,6 +155,12 @@ where
     }
     assert!(pair_slots.len() <= REDUCTION_PAIR_CAP);
 
+    let pairwise_mask = pair_slots
+        .iter()
+        .enumerate()
+        .filter(|(_, (kind, _))| *kind == REDUCTION_PAIR_PAIRWISE2)
+        .fold(0u32, |mask, (idx, _)| mask | (1u32 << idx));
+
     let mut round = start_round;
     let mut input_log_2 = prepared.initial_trace_log_2 - start_round;
     while round < prepared.total_rounds {
@@ -164,10 +170,10 @@ where
             pair_count: pair_slots.len() as u32,
             input_len: 1u32 << input_log_2,
             round_count: chunk_rounds,
+            pairwise_mask,
             ..Default::default()
         };
         for (pair, &(kind, slots)) in batch.pairs.iter_mut().zip(&pair_slots) {
-            pair.kind = kind;
             pair.input = pair_input_streams(prepared, round, kind, slots);
             for local_r in 0..chunk_rounds as usize {
                 pair.round_outputs[local_r] =

--- a/gpu/gkr/src/forward/kernels/mod.rs
+++ b/gpu/gkr/src/forward/kernels/mod.rs
@@ -14,14 +14,10 @@ pub(crate) const GKR_DIM_REDUCING_FORWARD_TOWER_BLOCK: u32 =
 pub(crate) const GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS: usize =
     GKR_DIM_REDUCING_FORWARD_TOWER_LOG_BLOCK as usize;
 
-/// `kind` is `vm::desc::REDUCTION_PAIR_*`: PAIRWISE2 folds two independent
-/// product towers, LOOKUP folds one lookup tower's (num, den).
 #[repr(C)]
 pub(crate) struct GpuGKRDimensionReducingForwardTowerPair<E> {
     pub(crate) input: [*const E; 2],
     pub(crate) round_outputs: [[*mut E; 2]; GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS],
-    pub(crate) kind: u32,
-    pub(crate) reserved: u32,
 }
 
 impl<E> Copy for GpuGKRDimensionReducingForwardTowerPair<E> {}
@@ -37,19 +33,20 @@ impl<E> Default for GpuGKRDimensionReducingForwardTowerPair<E> {
         Self {
             input: [null(); 2],
             round_outputs: [[null_mut(); 2]; GKR_DIM_REDUCING_FORWARD_TOWER_MAX_ROUNDS],
-            kind: 0,
-            reserved: 0,
         }
     }
 }
 
+/// `pairwise_mask` carries bit `i` for pair `i`: set means PAIRWISE2 (two
+/// independent product towers), clear means LOOKUP (one tower's num/den). Pairs
+/// stay densely packed, so the grid's y extent stays `pair_count`.
 #[repr(C)]
 pub(crate) struct GpuGKRDimensionReducingForwardTowerBatch<E> {
     pub(crate) pairs: [GpuGKRDimensionReducingForwardTowerPair<E>; REDUCTION_PAIR_CAP],
     pub(crate) pair_count: u32,
     pub(crate) input_len: u32,
     pub(crate) round_count: u32,
-    pub(crate) reserved: u32,
+    pub(crate) pairwise_mask: u32,
 }
 
 impl<E> Default for GpuGKRDimensionReducingForwardTowerBatch<E> {
@@ -59,15 +56,15 @@ impl<E> Default for GpuGKRDimensionReducingForwardTowerBatch<E> {
             pair_count: 0,
             input_len: 0,
             round_count: 0,
-            reserved: 0,
+            pairwise_mask: 0,
         }
     }
 }
 
 /// ABI size guards, paired with the CUDA `static_assert`s in `descriptors.cuh`.
 const _: () = {
-    assert!(core::mem::size_of::<GpuGKRDimensionReducingForwardTowerPair<E4>>() == 152);
-    assert!(core::mem::size_of::<GpuGKRDimensionReducingForwardTowerBatch<E4>>() == 776);
+    assert!(core::mem::size_of::<GpuGKRDimensionReducingForwardTowerPair<E4>>() == 144);
+    assert!(core::mem::size_of::<GpuGKRDimensionReducingForwardTowerBatch<E4>>() == 736);
     assert!(core::mem::align_of::<GpuGKRDimensionReducingForwardTowerBatch<E4>>() == 8);
 };
 


### PR DESCRIPTION
## What ❔

Two descriptor cleanups in the dimension-reducing path:

- **Backward rounds:** the dynamic record loop + kind `switch` becomes a fixed 5-slot table, one slot per `OutputType`, selected by an `enabled_mask`. Slot index implies the kind. Batch-challenge exponents become explicit per-slot indexes shared with the claim combination. The round-1 kernel merges into the continuation kernel (their source resolution was identical). Descriptor 456 → 336 B, kernels 3 → 2.
- **Forward tower:** the per-pair `kind` u32 becomes one `pairwise_mask` bit per pair; packing stays dense so the grid is unchanged. Pair 152 → 144 B.

## Why ❔

The record encoding carried what the slot index already determines, so every round paid a runtime dispatch to rediscover a fixed layout. Per-circuit variation now leaves the kernel entirely — a circuit missing an output type just clears a mask bit, same binary and launch shape for all of them.

## Is this a breaking change?
- [ ] Yes
- [x] No

Internal to `gpu_gkr`; proof bytes unchanged.

## Verification

Proofs bit-exact vs the CPU reference (add_sub sec100, blake2 delegation, unified); `gpu_gkr` 66/66; no register spills; dim-reducing kernel time −1.1% (nsys), whole proof within noise.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.