### PR TITLE
perf(gpu_hash): fuse the Merkle node ladder into a multi-layer tower

### DIFF
--- a/gpu/hash/native/hash.cu
+++ b/gpu/hash/native/hash.cu
@@ -2,18 +2,6 @@
 
 namespace airbender::hash {
 
-// Hash one 64-byte block (2 adjacent digests) into a single output digest.
-DEVICE_FORCEINLINE void hash_two_digests(const digest *in2, digest *out) {
-  digest state;
-  digest block[2];
-  block[0] = load_cs(in2);
-  block[1] = load_cs(in2 + 1);
-  initialize(state.words);
-  u32 t = 0;
-  compress<true>(state.words, t, reinterpret_cast<const u32 *>(block), BLOCK_SIZE);
-  store_cs(out, state);
-}
-
 // One transcript squeeze round: seed_io <- Blake2s(seed_io), in place.
 DEVICE_FORCEINLINE void advance_seed(u32 seed_io[STATE_SIZE]) {
   u32 state[STATE_SIZE];
@@ -214,32 +202,63 @@ EXTERN __global__ void ab_blake2s_leaves_from_ntt_flat_range_to_staging_kernel(c
   store_cs(reinterpret_cast<digest *>(staging) + gid, state);
 }
 
-EXTERN __global__ void ab_blake2s_nodes_kernel(const u32 *values, u32 *results, const unsigned count) {
-  const unsigned gid = threadIdx.x + blockIdx.x * blockDim.x;
-  if (gid >= count)
-    return;
-  // Input block = 64 B = 2 digests; address is 64-aligned, so hash_two_digests
-  // loads via two 256-bit ops (LDG.E.ENL2.256 on sm_100+ / 2× LDG.E.128 on
-  // older) instead of 16× LDG.E.
-  hash_two_digests(reinterpret_cast<const digest *>(values) + gid * 2, reinterpret_cast<digest *>(results) + gid);
-}
+// Fused node tower: one launch folds `layers` Merkle layers instead of one
+// launch per layer. Every intermediate layer is still written at its flat
+// prefix-sum offset, because gather.cu resolves a layer by closed form
+// (`(1<<(L+1)) - (1<<(L+1-layer))`) with no per-layer pointer table — no layer
+// may be skipped or displaced. `src`/`dst` are independent bases so this serves
+// both the flat single-tree build and the multi-coset build.
+EXTERN __global__ void ab_blake2s_nodes_tower_multi_coset_kernel(const u32 *src, u32 *dst, const unsigned layers, const unsigned log_blocks_per_coset,
+                                                                 const unsigned stride_digests, const unsigned src_count_per_coset) {
+  extern __shared__ digest values[];
+  const unsigned threads = blockDim.x;
+  const unsigned coset = blockIdx.x >> log_blocks_per_coset;
+  const unsigned block_in_coset = blockIdx.x & ((1u << log_blocks_per_coset) - 1u);
 
-// Multi-coset nodes kernel: hashes `(1 << log_per_coset_count) *
-// cosets_in_tile` pairs of digests into the same number of output digests.
-// Each coset's layer-input and layer-output sit in independent slabs offset
-// by `per_coset_values_stride_digests` and `per_coset_results_stride_digests`.
-EXTERN __global__ void ab_blake2s_nodes_multi_coset_kernel(const u32 *values, u32 *results, const unsigned log_per_coset_count,
-                                                           const unsigned per_coset_values_stride_digests, const unsigned per_coset_results_stride_digests,
-                                                           const unsigned count) {
-  const unsigned gid_global = threadIdx.x + blockIdx.x * blockDim.x;
-  if (gid_global >= count)
-    return;
-  const unsigned coset = gid_global >> log_per_coset_count;
-  const unsigned gid = gid_global & ((1u << log_per_coset_count) - 1u);
-  // Each leaf pair is 2 adjacent digests (64 B), 64-aligned at every (coset, gid).
-  const digest *values_d = reinterpret_cast<const digest *>(values) + static_cast<size_t>(coset) * per_coset_values_stride_digests + gid * 2;
-  digest *results_d = reinterpret_cast<digest *>(results) + static_cast<size_t>(coset) * per_coset_results_stride_digests + gid;
-  hash_two_digests(values_d, results_d);
+  const digest *src_d = reinterpret_cast<const digest *>(src) + static_cast<size_t>(coset) * stride_digests + static_cast<size_t>(block_in_coset) * 2 * threads;
+  digest *dst_d = reinterpret_cast<digest *>(dst) + static_cast<size_t>(coset) * stride_digests;
+
+  unsigned layer_count = src_count_per_coset >> 1;
+  unsigned layer_off = 0;
+
+  // Layer 0 reads from gmem; only its output is staged in smem, which halves
+  // the footprint and doubles the block-per-SM limit.
+  {
+    digest children[2];
+    children[0] = load_cs(src_d + 2 * threadIdx.x);
+    children[1] = load_cs(src_d + 2 * threadIdx.x + 1);
+    digest state;
+    initialize(state.words);
+    u32 t = 0;
+    compress<true>(state.words, t, reinterpret_cast<const u32 *>(children), BLOCK_SIZE);
+    values[threadIdx.x] = state;
+    store_cs(dst_d + layer_off + static_cast<size_t>(block_in_coset) * threads + threadIdx.x, state);
+  }
+  __syncthreads();
+  layer_off += layer_count;
+  layer_count >>= 1;
+
+  for (unsigned layer = 1; layer < layers; layer++) {
+    const unsigned n_active = threads >> layer;
+    const bool enabled = threadIdx.x < n_active;
+    digest children[2];
+    if (enabled) {
+      children[0] = values[2 * threadIdx.x];
+      children[1] = values[2 * threadIdx.x + 1];
+    }
+    __syncthreads(); // children read before any thread overwrites the lower half
+    if (enabled) {
+      digest state;
+      initialize(state.words);
+      u32 t = 0;
+      compress<true>(state.words, t, reinterpret_cast<const u32 *>(children), BLOCK_SIZE);
+      values[threadIdx.x] = state;
+      store_cs(dst_d + layer_off + static_cast<size_t>(block_in_coset) * n_active + threadIdx.x, state);
+    }
+    __syncthreads();
+    layer_off += layer_count;
+    layer_count >>= 1;
+  }
 }
 
 EXTERN __global__ void ab_blake2s_pow_kernel(const u64 *seed, const u32 bits_count, const u64 max_nonce, volatile u64 *result) {

--- a/gpu/hash/src/blake2s/merkle.rs
+++ b/gpu/hash/src/blake2s/merkle.rs
@@ -1,6 +1,6 @@
-//! Blake2s Merkle-tree construction: node (2→1 digest) hashing and the
-//! single-launch-per-layer multi-coset tree builders used by the prover's
-//! commit paths.
+//! Blake2s Merkle-tree construction: the fused node tower (many Merkle layers
+//! per launch) and the multi-coset tree builders used by the prover's commit
+//! paths.
 
 use era_cudart::cuda_kernel;
 use era_cudart::execution::{CudaLaunchConfig, KernelFunction};
@@ -8,95 +8,93 @@ use era_cudart::result::CudaResult;
 use era_cudart::slice::DeviceSlice;
 use era_cudart::stream::CudaStream;
 use gpu_core::primitives::field::BF;
-use gpu_core::primitives::utils::{get_grid_block_dims_for_threads_count, WARP_SIZE};
+use gpu_core::primitives::utils::WARP_SIZE;
 
 use super::hash::{hash_leaves, hash_leaves_multi_coset};
 use super::{checked_u32, Digest};
 
 cuda_kernel!(
-    Nodes,
-    ab_blake2s_nodes_kernel(values: *const Digest, results: *mut Digest, count: u32)
-);
-
-pub(super) fn hash_nodes(
-    values: &DeviceSlice<Digest>,
-    results: &mut DeviceSlice<Digest>,
-    stream: &CudaStream,
-) -> CudaResult<()> {
-    let values_len = values.len();
-    let results_len = results.len();
-    assert_eq!(values_len, results_len * 2);
-    let values = values.as_ptr();
-    let results = results.as_mut_ptr();
-    let count = checked_u32(results_len);
-    let (grid_dim, block_dim) = get_grid_block_dims_for_threads_count(WARP_SIZE * 4, count);
-    let config = CudaLaunchConfig::basic(grid_dim, block_dim, stream);
-    let args = NodesArguments::new(values, results, count);
-    NodesFunction::default().launch(&config, &args)
-}
-
-/// Hash `layers_count` node layers up from the `values` layer, writing each
-/// successive (halving) layer contiguously into `results`.
-pub fn build_merkle_tree_nodes(
-    values: &DeviceSlice<Digest>,
-    results: &mut DeviceSlice<Digest>,
-    layers_count: u32,
-    stream: &CudaStream,
-) -> CudaResult<()> {
-    if layers_count == 0 {
-        Ok(())
-    } else {
-        let values_len = values.len();
-        let results_len = results.len();
-        let layer = values_len.trailing_zeros();
-        assert_eq!(values_len, 1 << layer);
-        assert_eq!(values_len, results_len);
-        let (nodes, nodes_remaining) = results.split_at_mut(results_len >> 1);
-        hash_nodes(values, nodes, stream)?;
-        build_merkle_tree_nodes(nodes, nodes_remaining, layers_count - 1, stream)
-    }
-}
-
-cuda_kernel!(
-    NodesMultiCoset,
-    ab_blake2s_nodes_multi_coset_kernel(
-        values: *const Digest,
-        results: *mut Digest,
-        log_per_coset_count: u32,
-        per_coset_values_stride_digests: u32,
-        per_coset_results_stride_digests: u32,
-        count: u32,
+    NodesTower,
+    ab_blake2s_nodes_tower_multi_coset_kernel(
+        src: *const Digest,
+        dst: *mut Digest,
+        layers: u32,
+        log_blocks_per_coset: u32,
+        stride_digests: u32,
+        src_count_per_coset: u32,
     )
 );
 
-/// Launch the multi-coset nodes kernel against a single backing slab using
-/// per-coset src/dst offsets (in digests, relative to each coset's
-/// `per_coset_stride_digests` slab). Callers express a virtual src/dst view
-/// inside the per-coset slabs without re-slicing the backing buffer (which
-/// would violate Rust aliasing rules when src and dst sit in the same
-/// allocation).
-fn launch_nodes_kernel_multi_coset_at_offsets(
+/// Layers one tower launch folds. A block owns one subtree and emits one digest
+/// per thread at layer 0, so it runs `1 << (LAYERS - 1)` threads over
+/// `1 << LAYERS` source digests, with that many digests of shared memory.
+const NODES_TOWER_MAX_LAYERS: u32 = 10;
+
+/// Digests a `layers`-deep tower writes over a `src_count`-digest source layer.
+fn tower_output_count(src_count: usize, layers: u32) -> usize {
+    src_count - (src_count >> layers)
+}
+
+/// Offset, relative to the tower's first output layer, of the last layer it
+/// writes — i.e. where the next tower's source layer begins.
+fn tower_last_layer_offset(src_count: usize, layers: u32) -> usize {
+    tower_output_count(src_count, layers - 1)
+}
+
+fn launch_nodes_tower(
+    src: *const Digest,
+    dst: *mut Digest,
+    layers: u32,
+    cosets_in_tile: usize,
+    stride_digests: usize,
+    src_count_per_coset: usize,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    assert!(src_count_per_coset.is_power_of_two());
+    assert!((1..=src_count_per_coset.trailing_zeros()).contains(&layers));
+    let threads = 1u32 << (layers - 1);
+    let blocks_per_coset = src_count_per_coset >> layers;
+    let grid = checked_u32(blocks_per_coset * cosets_in_tile);
+    let mut config = CudaLaunchConfig::basic(grid, threads, stream);
+    config.dynamic_smem_bytes = threads as usize * core::mem::size_of::<Digest>();
+    let args = NodesTowerArguments::new(
+        src,
+        dst,
+        layers,
+        blocks_per_coset.trailing_zeros(),
+        checked_u32(stride_digests),
+        checked_u32(src_count_per_coset),
+    );
+    NodesTowerFunction::default().launch(&config, &args)
+}
+
+/// Tower launch against a single backing slab, using per-coset src/dst offsets.
+/// Callers express a virtual src/dst view inside the per-coset slabs without
+/// re-slicing the backing buffer (which would violate Rust aliasing rules when
+/// src and dst sit in the same allocation).
+fn launch_nodes_tower_in_backing(
     backing: &mut DeviceSlice<Digest>,
     cosets_in_tile: usize,
     per_coset_stride_digests: usize,
     src_offset_in_coset: usize,
     dst_offset_in_coset: usize,
-    output_per_coset_count: usize,
+    src_count_per_coset: usize,
+    layers: u32,
     stream: &CudaStream,
 ) -> CudaResult<()> {
     // Per-coset containment: each coset's read/write window must fit inside
     // its own slab — the aggregate end checks below cannot see a window that
     // spills into the next coset's slab.
     let src_window_end = src_offset_in_coset
-        .checked_add(output_per_coset_count * 2)
+        .checked_add(src_count_per_coset)
         .expect("src window overflow");
     let dst_window_end = dst_offset_in_coset
-        .checked_add(output_per_coset_count)
+        .checked_add(tower_output_count(src_count_per_coset, layers))
         .expect("dst window overflow");
     assert!(src_window_end <= per_coset_stride_digests);
     assert!(dst_window_end <= per_coset_stride_digests);
-    // Same-backing launch: the write window must not overlap the read window
-    // within a slab (containment above already separates distinct cosets).
+    // The write window must not overlap the read window within a slab
+    // (containment above already separates distinct cosets).
     assert!(
         dst_offset_in_coset >= src_window_end || src_offset_in_coset >= dst_window_end,
         "src/dst windows overlap within the per-coset slab"
@@ -120,26 +118,76 @@ fn launch_nodes_kernel_multi_coset_at_offsets(
     let base = backing.as_mut_ptr();
     let src_ptr = unsafe { base.add(src_offset_in_coset) } as *const Digest;
     let dst_ptr = unsafe { base.add(dst_offset_in_coset) };
-    assert!(
-        output_per_coset_count.is_power_of_two(),
-        "output_per_coset_count must be a power of two (got {output_per_coset_count})"
-    );
-    let total_count = checked_u32(
-        output_per_coset_count
-            .checked_mul(cosets_in_tile)
-            .expect("nodes total count overflow"),
-    );
-    let (grid_dim, block_dim) = get_grid_block_dims_for_threads_count(WARP_SIZE * 4, total_count);
-    let config = CudaLaunchConfig::basic(grid_dim, block_dim, stream);
-    let args = NodesMultiCosetArguments::new(
+    launch_nodes_tower(
         src_ptr,
         dst_ptr,
-        output_per_coset_count.trailing_zeros(),
-        checked_u32(per_coset_stride_digests),
-        checked_u32(per_coset_stride_digests),
-        total_count,
+        layers,
+        cosets_in_tile,
+        per_coset_stride_digests,
+        src_count_per_coset,
+        stream,
+    )
+}
+
+fn tower_step_layers(remaining: u32, src_count: usize) -> u32 {
+    let layers = remaining
+        .min(NODES_TOWER_MAX_LAYERS)
+        .min(src_count.trailing_zeros());
+    assert!(
+        layers >= 1,
+        "source layer too small for another Merkle layer"
     );
-    NodesMultiCosetFunction::default().launch(&config, &args)
+    layers
+}
+
+/// Hash `layers_count` node layers up from the `values` layer, writing each
+/// successive (halving) layer contiguously into `results`.
+pub fn build_merkle_tree_nodes(
+    values: &DeviceSlice<Digest>,
+    results: &mut DeviceSlice<Digest>,
+    layers_count: u32,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    if layers_count == 0 {
+        return Ok(());
+    }
+    let values_len = values.len();
+    let results_len = results.len();
+    assert!(values_len.is_power_of_two());
+    assert_eq!(values_len, results_len);
+    // The first tower's source layer lives outside `results`; every later one
+    // reads a layer it already wrote.
+    let layers = tower_step_layers(layers_count, values_len);
+    launch_nodes_tower(
+        values.as_ptr(),
+        results.as_mut_ptr(),
+        layers,
+        1,
+        0,
+        values_len,
+        stream,
+    )?;
+    let mut src_offset = tower_last_layer_offset(values_len, layers);
+    let mut src_count = values_len >> layers;
+    let mut remaining = layers_count - layers;
+    while remaining > 0 {
+        let layers = tower_step_layers(remaining, src_count);
+        let dst_offset = src_offset + src_count;
+        launch_nodes_tower_in_backing(
+            results,
+            1,
+            results_len,
+            src_offset,
+            dst_offset,
+            src_count,
+            layers,
+            stream,
+        )?;
+        src_offset = dst_offset + tower_last_layer_offset(src_count, layers);
+        src_count >>= layers;
+        remaining -= layers;
+    }
+    Ok(())
 }
 
 /// Iteratively hash up `layers_count` Merkle layers across `cosets_in_tile`
@@ -158,21 +206,23 @@ fn build_merkle_tree_nodes_multi_coset(
 ) -> CudaResult<()> {
     let mut src_offset = initial_src_offset_in_coset;
     let mut src_count = initial_src_layer_count_per_coset;
-    for _ in 0..layers_count {
-        assert_eq!(src_count % 2, 0);
-        let output_count_per_coset = src_count / 2;
+    let mut remaining = layers_count;
+    while remaining > 0 {
+        let layers = tower_step_layers(remaining, src_count);
         let dst_offset = src_offset + src_count;
-        launch_nodes_kernel_multi_coset_at_offsets(
+        launch_nodes_tower_in_backing(
             tree_backing,
             cosets_in_tile,
             per_coset_tree_stride_digests,
             src_offset,
             dst_offset,
-            output_count_per_coset,
+            src_count,
+            layers,
             stream,
         )?;
-        src_offset = dst_offset;
-        src_count = output_count_per_coset;
+        src_offset = dst_offset + tower_last_layer_offset(src_count, layers);
+        src_count >>= layers;
+        remaining -= layers;
     }
     Ok(())
 }

--- a/gpu/hash/src/blake2s/tests/merkle_tests.rs
+++ b/gpu/hash/src/blake2s/tests/merkle_tests.rs
@@ -19,15 +19,17 @@ fn blake2s_nodes() {
     const N: usize = 1 << LOG_N;
     let mut values_host = vec![Digest::default(); N * 2];
     values_host.fill_with(random_digest);
-    let mut results_host = vec![Digest::default(); N];
+    // One layer through the public builder: `results` is sized like `values`,
+    // and a single layer fills its first `N` digests.
+    let mut results_host = vec![Digest::default(); N * 2];
     let stream = CudaStream::default();
     let mut values_device = DeviceAllocation::alloc(values_host.len()).unwrap();
     let mut results_device = DeviceAllocation::alloc(results_host.len()).unwrap();
     memory_copy_async(&mut values_device, &values_host, &stream).unwrap();
-    hash_nodes(&values_device, &mut results_device, &stream).unwrap();
+    build_merkle_tree_nodes(&values_device, &mut results_device, 1, &stream).unwrap();
     memory_copy_async(&mut results_host, &results_device, &stream).unwrap();
     stream.synchronize().unwrap();
-    verify_nodes(&values_host, &results_host);
+    verify_nodes(&values_host, &results_host[..N]);
 }
 
 fn verify_tree(values: &[Digest], results: &[Digest], layers_count: u32) {


### PR DESCRIPTION
## What ❔

Replaces the one-launch-per-layer Merkle node ladders with a fused kernel, `ab_blake2s_nodes_tower_multi_coset_kernel`, folding up to 10 layers per launch. Both call sites move onto it, so `ab_blake2s_nodes_kernel`, `ab_blake2s_nodes_multi_coset_kernel` and `hash_two_digests` are deleted.

Per proof: **94 node launches → 14**, ladder wall time **198.5 µs → 131.5 µs (−66.9 µs, −33.7%)**.

## Why ❔

The bottom five layers were already fused; everything above, up to the cap, ran one launch per layer. Each layer halves, so those launches cannot fill the GPU — the tail of every ladder sits at the device's ~1.2 µs launch floor, and each boundary forces the next layer to re-read its input from L2 instead of shared memory.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
