### PR TITLE
refactor(gpu): source program setup caps from GPU setup hosts

### DIFF
--- a/gpu/AGENTS.md
+++ b/gpu/AGENTS.md
@@ -139,7 +139,7 @@ root in `gkr_eval_ir`; `gpu_gkr_compiler` depends on it.
 `gpu_whir` (and `gpu_core`/`gpu_hash`) as ordinary Cargo
 dependencies — there are no more in-crate facade re-exports for the kernel
 crates, and **no `native/` tree at all**: its `build.rs` only emits the
-`no_cuda` cfg its test sites key off. `execution_prover` holds `ExecutionProver` + the 9-symbol facade.
+`no_cuda` cfg its test sites key off. `execution_prover` holds `ExecutionProver` + the 12-symbol facade.
 `program_prover` is the program-level driver on top of `execution_prover`: it
 assembles `ProveResult` into `full_statement_verifier::ProgramProof`, builds the
 non-determinism streams the `fsv_*` verifier binaries consume, and (behind its

--- a/gpu/AGENTS.md
+++ b/gpu/AGENTS.md
@@ -139,7 +139,7 @@ root in `gkr_eval_ir`; `gpu_gkr_compiler` depends on it.
 `gpu_whir` (and `gpu_core`/`gpu_hash`) as ordinary Cargo
 dependencies — there are no more in-crate facade re-exports for the kernel
 crates, and **no `native/` tree at all**: its `build.rs` only emits the
-`no_cuda` cfg its test sites key off. `execution_prover` holds `ExecutionProver` + the 12-symbol facade.
+`no_cuda` cfg its test sites key off. `execution_prover` holds `ExecutionProver` + the 11-symbol facade.
 `program_prover` is the program-level driver on top of `execution_prover`: it
 assembles `ProveResult` into `full_statement_verifier::ProgramProof`, builds the
 non-determinism streams the `fsv_*` verifier binaries consume, and (behind its

--- a/gpu/docs/gpu_scheduling_contract.md
+++ b/gpu/docs/gpu_scheduling_contract.md
@@ -310,20 +310,3 @@ Callbacks must **not**:
 - Create or destroy any allocation backed by one of the context's memory pools
   (device or host). Pool operations are not safe to perform from callback
   context.
-
-## One-shot setup precomputation
-
-`GpuGKRSetupHost::precompute_from_cpu_setup` runs once per
-`CircuitPrecomputations` instance (each `ExecutionProver` and each registered
-binary owns its own instances), only inside a GPU worker's phase-1 slot while
-serving a `SetupInitialization` work request from the synchronous setup
-batches that `ExecutionProver::with_configuration` and `add_binary` drain
-before returning. It is a sanctioned, deliberate exception to two rules
-above: it D2Hs the partial trees and the unified cap into dedicated
-static-pinned host boxes (normally never a DMA destination), and it ends
-with a full exec-stream synchronize (normally host blocking belongs in
-`finish()`). The synchronize is a hard invariant: it is what makes the D2H
-destinations safe to read and what allows the setup batch to acknowledge a
-result only after the pinned host data is complete. Its transient device
-allocations are released before it returns, so it leaves no state in the
-worker's alternating allocation-placement scheme.

--- a/gpu/docs/gpu_scheduling_contract.md
+++ b/gpu/docs/gpu_scheduling_contract.md
@@ -310,3 +310,20 @@ Callbacks must **not**:
 - Create or destroy any allocation backed by one of the context's memory pools
   (device or host). Pool operations are not safe to perform from callback
   context.
+
+## One-shot setup precomputation
+
+`GpuGKRSetupHost::precompute_from_cpu_setup` runs once per
+`CircuitPrecomputations` instance (each `ExecutionProver` and each registered
+binary owns its own instances), only inside a GPU worker's phase-1 slot while
+serving a `SetupInitialization` work request from the synchronous setup
+batches that `ExecutionProver::with_configuration` and `add_binary` drain
+before returning. It is a sanctioned, deliberate exception to two rules
+above: it D2Hs the partial trees and the unified cap into dedicated
+static-pinned host boxes (normally never a DMA destination), and it ends
+with a full exec-stream synchronize (normally host blocking belongs in
+`finish()`). The synchronize is a hard invariant: it is what makes the D2H
+destinations safe to read and what allows the setup batch to acknowledge a
+result only after the pinned host data is complete. Its transient device
+allocations are released before it returns, so it leaves no state in the
+worker's alternating allocation-placement scheme.

--- a/gpu/execution_prover/src/lib.rs
+++ b/gpu/execution_prover/src/lib.rs
@@ -29,8 +29,8 @@ pub(crate) type A = ConcurrentStaticHostAllocator;
 pub use gpu_circuit_prover::{UnsupportedGpuSecurityLevel, GPU_SUPPORTED_SECURITY_LEVELS};
 pub use gpu_core::primitives::machine_type::MachineType;
 pub use prover::{
-    BinaryHandle, CommitMemoryResult, CommonCircuitArtifact, ExecutionKind, ExecutionProver,
-    ExecutionProverConfiguration, ProgramArtifacts, ProveResult, RiscvFamilyArtifact,
+    BinaryHandle, CommitMemoryResult, ExecutionKind, ExecutionProver, ExecutionProverConfiguration,
+    ProgramArtifacts, ProveResult, RiscvFamilyArtifact,
 };
 
 #[cfg(test)]

--- a/gpu/execution_prover/src/lib.rs
+++ b/gpu/execution_prover/src/lib.rs
@@ -29,8 +29,8 @@ pub(crate) type A = ConcurrentStaticHostAllocator;
 pub use gpu_circuit_prover::{UnsupportedGpuSecurityLevel, GPU_SUPPORTED_SECURITY_LEVELS};
 pub use gpu_core::primitives::machine_type::MachineType;
 pub use prover::{
-    BinaryHandle, CircuitArtifact, CommitMemoryResult, ExecutionKind, ExecutionProver,
-    ExecutionProverConfiguration, ProgramArtifacts, ProveResult,
+    BinaryHandle, CommitMemoryResult, CommonCircuitArtifact, ExecutionKind, ExecutionProver,
+    ExecutionProverConfiguration, ProgramArtifacts, ProveResult, RiscvFamilyArtifact,
 };
 
 #[cfg(test)]

--- a/gpu/execution_prover/src/messages.rs
+++ b/gpu/execution_prover/src/messages.rs
@@ -67,6 +67,20 @@ pub(crate) struct MemoryCommitmentResult<A: GoodAllocator> {
     pub merkle_tree_caps: Vec<MerkleTreeCapVarLength>,
 }
 
+pub(crate) struct SetupInitializationRequest {
+    pub batch_id: u64,
+    pub circuit_type: CircuitType,
+    pub sequence_id: usize,
+    pub precomputations: CircuitPrecomputations,
+    pub security_level: SecurityLevel,
+}
+
+pub(crate) struct SetupInitializationResult {
+    pub batch_id: u64,
+    pub circuit_type: CircuitType,
+    pub sequence_id: usize,
+}
+
 pub(crate) struct ProofRequest<A: GoodAllocator> {
     pub batch_id: u64,
     pub circuit_type: CircuitType,
@@ -94,6 +108,7 @@ pub(crate) struct ProofResult<A: GoodAllocator> {
 pub(crate) enum GpuWorkRequest<A: GoodAllocator> {
     MemoryCommitment(MemoryCommitmentRequest<A>),
     Proof(ProofRequest<A>),
+    SetupInitialization(SetupInitializationRequest),
 }
 
 impl<A: GoodAllocator> GpuWorkRequest<A> {
@@ -101,6 +116,7 @@ impl<A: GoodAllocator> GpuWorkRequest<A> {
         match self {
             GpuWorkRequest::MemoryCommitment(request) => request.batch_id,
             GpuWorkRequest::Proof(request) => request.batch_id,
+            GpuWorkRequest::SetupInitialization(request) => request.batch_id,
         }
     }
 
@@ -108,6 +124,7 @@ impl<A: GoodAllocator> GpuWorkRequest<A> {
         match self {
             GpuWorkRequest::MemoryCommitment(request) => request.circuit_type,
             GpuWorkRequest::Proof(request) => request.circuit_type,
+            GpuWorkRequest::SetupInitialization(request) => request.circuit_type,
         }
     }
 
@@ -115,6 +132,7 @@ impl<A: GoodAllocator> GpuWorkRequest<A> {
         match self {
             GpuWorkRequest::MemoryCommitment(request) => request.sequence_id,
             GpuWorkRequest::Proof(request) => request.sequence_id,
+            GpuWorkRequest::SetupInitialization(request) => request.sequence_id,
         }
     }
 }
@@ -126,6 +144,7 @@ impl<A: GoodAllocator> GpuWorkRequest<A> {
 pub(crate) enum GpuWorkResult<A: GoodAllocator> {
     MemoryCommitment(MemoryCommitmentResult<A>),
     Proof(ProofResult<A>),
+    SetupInitialization(SetupInitializationResult),
 }
 
 impl<A: GoodAllocator> GpuWorkResult<A> {
@@ -133,6 +152,7 @@ impl<A: GoodAllocator> GpuWorkResult<A> {
         match self {
             GpuWorkResult::MemoryCommitment(result) => result.circuit_type,
             GpuWorkResult::Proof(result) => result.circuit_type,
+            GpuWorkResult::SetupInitialization(result) => result.circuit_type,
         }
     }
 
@@ -140,6 +160,7 @@ impl<A: GoodAllocator> GpuWorkResult<A> {
         match self {
             GpuWorkResult::MemoryCommitment(result) => result.sequence_id,
             GpuWorkResult::Proof(result) => result.sequence_id,
+            GpuWorkResult::SetupInitialization(result) => result.sequence_id,
         }
     }
 }

--- a/gpu/execution_prover/src/precomputations/common.rs
+++ b/gpu/execution_prover/src/precomputations/common.rs
@@ -11,9 +11,7 @@ use std::collections::BTreeMap;
 use worker::Worker;
 
 /// Build the binary-independent precomputations: every delegation circuit
-/// and inits-and-teardowns. CPU-only — no GPU context needed; the
-/// `GpuGKRSetupHost` for each circuit is initialized by the constructor's
-/// synchronous setup batch before `with_configuration` returns.
+/// and inits-and-teardowns.
 ///
 /// `whir_logs_for_circuit` is invoked per-`CircuitType` and must return
 /// `(log_lde_factor, log_rows_per_leaf, log_tree_cap_size)` matching the

--- a/gpu/execution_prover/src/precomputations/common.rs
+++ b/gpu/execution_prover/src/precomputations/common.rs
@@ -12,8 +12,8 @@ use worker::Worker;
 
 /// Build the binary-independent precomputations: every delegation circuit
 /// and inits-and-teardowns. CPU-only — no GPU context needed; the
-/// `GpuGKRSetupHost` for each circuit is materialized lazily on first GPU
-/// worker use.
+/// `GpuGKRSetupHost` for each circuit is initialized by the constructor's
+/// synchronous setup batch before `with_configuration` returns.
 ///
 /// `whir_logs_for_circuit` is invoked per-`CircuitType` and must return
 /// `(log_lde_factor, log_rows_per_leaf, log_tree_cap_size)` matching the

--- a/gpu/execution_prover/src/precomputations/setup_host.rs
+++ b/gpu/execution_prover/src/precomputations/setup_host.rs
@@ -82,9 +82,9 @@ impl LazyGpuGKRSetupHost {
 }
 
 /// Per-circuit precomputations cached across `prove()` invocations.
-/// `setup_host` is a `LazyGpuGKRSetupHost` populated on first GPU-worker
-/// use; the decoder table is host-only and built eagerly in this
-/// constructor.
+/// `setup_host` is a `LazyGpuGKRSetupHost` initialized by the synchronous
+/// setup batches in `ExecutionProver::with_configuration` / `add_binary`;
+/// the decoder table is host-only and built eagerly in this constructor.
 #[derive(Clone)]
 pub(crate) struct CircuitPrecomputations {
     pub gkr_programs: Arc<GkrPrograms>,
@@ -94,8 +94,8 @@ pub(crate) struct CircuitPrecomputations {
 
 impl CircuitPrecomputations {
     /// Build the per-circuit precomputations. The GPU-side `GpuGKRSetupHost`
-    /// is *not* materialized here — `setup_host.get_or_init(context)` does
-    /// that on first use inside a GPU worker.
+    /// is *not* materialized here — the constructor/add_binary setup batch is
+    /// the sole initializer, filling `setup_host` synchronously afterward.
     pub fn new(
         circuit_type: CircuitType,
         compiled_circuit: GKRCircuitArtifact<BF>,

--- a/gpu/execution_prover/src/precomputations/setup_host.rs
+++ b/gpu/execution_prover/src/precomputations/setup_host.rs
@@ -11,17 +11,6 @@ use era_cudart::result::CudaResult;
 use crate::upstream::{CSExecutorFamilyDecoderData, CpuGKRSetup, GKRCircuitArtifact};
 use std::sync::{Arc, OnceLock};
 
-/// Lazy GPU-side setup host: the CPU setup and the geometry needed to
-/// produce a `GpuGKRSetupHost` are stored here, and the actual
-/// `GpuGKRSetupHost::precompute_from_cpu_setup` call (which does GPU LDE +
-/// commit + D2H of partial trees and the unified cap) runs on a GPU worker
-/// serving a `SetupInitialization` request from the synchronous setup
-/// batches in `ExecutionProver::with_configuration` / `add_binary`, against
-/// that worker's already-initialized `ProverContext`.
-///
-/// The `Arc` wrapper around `GpuGKRSetupHost` is what subsequent workers
-/// clone — every prove() that uses this circuit picks up the same cached
-/// pinned-host buffers.
 pub(crate) struct LazyGpuGKRSetupHost {
     inner: OnceLock<Option<Arc<GpuGKRSetupHost>>>,
     cpu_setup: Arc<CpuGKRSetup<BF>>,
@@ -46,11 +35,6 @@ impl LazyGpuGKRSetupHost {
         }
     }
 
-    /// First call: builds the host on `context` (one-shot stream sync inside
-    /// `precompute_from_cpu_setup`) and fills the lock — with `None` when the
-    /// CPU setup has no columns (e.g. InitsAndTeardowns), so "initialized as
-    /// absent" is distinguishable from "never initialized". Subsequent calls
-    /// are no-ops.
     pub fn get_or_init(&self, context: &ProverContext) -> CudaResult<()> {
         self.inner
             .get_or_try_init(|| {
@@ -78,10 +62,6 @@ impl LazyGpuGKRSetupHost {
     }
 }
 
-/// Per-circuit precomputations cached across `prove()` invocations.
-/// `setup_host` is a `LazyGpuGKRSetupHost` initialized by the synchronous
-/// setup batches in `ExecutionProver::with_configuration` / `add_binary`;
-/// the decoder table is host-only and built eagerly in this constructor.
 #[derive(Clone)]
 pub(crate) struct CircuitPrecomputations {
     pub gkr_programs: Arc<GkrPrograms>,
@@ -90,9 +70,6 @@ pub(crate) struct CircuitPrecomputations {
 }
 
 impl CircuitPrecomputations {
-    /// Build the per-circuit precomputations. The GPU-side `GpuGKRSetupHost`
-    /// is *not* materialized here — the constructor/add_binary setup batch is
-    /// the sole initializer, filling `setup_host` synchronously afterward.
     pub fn new(
         circuit_type: CircuitType,
         compiled_circuit: GKRCircuitArtifact<BF>,

--- a/gpu/execution_prover/src/precomputations/setup_host.rs
+++ b/gpu/execution_prover/src/precomputations/setup_host.rs
@@ -14,9 +14,10 @@ use std::sync::{Arc, OnceLock};
 /// Lazy GPU-side setup host: the CPU setup and the geometry needed to
 /// produce a `GpuGKRSetupHost` are stored here, and the actual
 /// `GpuGKRSetupHost::precompute_from_cpu_setup` call (which does GPU LDE +
-/// commit + D2H of partial trees and the unified cap) runs on first use
-/// inside the GPU worker, against that worker's already-initialized
-/// `ProverContext`.
+/// commit + D2H of partial trees and the unified cap) runs on a GPU worker
+/// serving a `SetupInitialization` request from the synchronous setup
+/// batches in `ExecutionProver::with_configuration` / `add_binary`, against
+/// that worker's already-initialized `ProverContext`.
 ///
 /// The `Arc` wrapper around `GpuGKRSetupHost` is what subsequent workers
 /// clone — every prove() that uses this circuit picks up the same cached

--- a/gpu/execution_prover/src/precomputations/setup_host.rs
+++ b/gpu/execution_prover/src/precomputations/setup_host.rs
@@ -16,14 +16,13 @@ use std::sync::{Arc, OnceLock};
 /// `GpuGKRSetupHost::precompute_from_cpu_setup` call (which does GPU LDE +
 /// commit + D2H of partial trees and the unified cap) runs on first use
 /// inside the GPU worker, against that worker's already-initialized
-/// `ProverContext`. Uses a `OnceLock` so concurrent workers race once and
-/// the loser drops its Arc instead of installing a duplicate.
+/// `ProverContext`.
 ///
 /// The `Arc` wrapper around `GpuGKRSetupHost` is what subsequent workers
 /// clone — every prove() that uses this circuit picks up the same cached
 /// pinned-host buffers.
 pub(crate) struct LazyGpuGKRSetupHost {
-    inner: OnceLock<Arc<GpuGKRSetupHost>>,
+    inner: OnceLock<Option<Arc<GpuGKRSetupHost>>>,
     cpu_setup: Arc<CpuGKRSetup<BF>>,
     log_lde_factor: u32,
     log_rows_per_leaf: u32,
@@ -54,28 +53,36 @@ impl LazyGpuGKRSetupHost {
     }
 
     /// First call: builds the host on `context` (one-shot stream sync inside
-    /// `precompute_from_cpu_setup`); subsequent calls return the cached Arc.
-    ///
-    /// Returns `None` when the CPU setup has no columns (e.g.
-    /// InitsAndTeardowns has `generic_lookup_tables_width == 0` and no
-    /// decoder table). The proof flow already treats `setup_transfer` as
-    /// optional, so a column-less circuit simply has no setup to transfer
-    /// or commit.
+    /// `precompute_from_cpu_setup`) and fills the lock — with `None` when the
+    /// CPU setup has no columns (e.g. InitsAndTeardowns), so "initialized as
+    /// absent" is distinguishable from "never initialized". Subsequent calls
+    /// return the cached value.
     pub fn get_or_init(&self, context: &ProverContext) -> CudaResult<Option<Arc<GpuGKRSetupHost>>> {
-        if self.cpu_setup.hypercube_evals.is_empty() {
-            return Ok(None);
-        }
         self.inner
             .get_or_try_init(|| {
-                Ok(Arc::new(GpuGKRSetupHost::precompute_from_cpu_setup(
+                if self.cpu_setup.hypercube_evals.is_empty() {
+                    return Ok(None);
+                }
+                Ok(Some(Arc::new(GpuGKRSetupHost::precompute_from_cpu_setup(
                     &self.cpu_setup,
                     self.log_lde_factor,
                     self.log_rows_per_leaf,
                     self.log_tree_cap_size,
                     context,
-                )?))
+                )?)))
             })
-            .map(|arc| Some(Arc::clone(arc)))
+            .map(|opt| opt.clone())
+    }
+
+    pub fn get_initialized(&self) -> Option<Arc<GpuGKRSetupHost>> {
+        self.inner
+            .get()
+            .expect("setup host must be initialized by a constructor/add_binary setup batch before use")
+            .clone()
+    }
+
+    pub fn is_initialized(&self) -> bool {
+        self.inner.get().is_some()
     }
 }
 

--- a/gpu/execution_prover/src/precomputations/setup_host.rs
+++ b/gpu/execution_prover/src/precomputations/setup_host.rs
@@ -45,13 +45,6 @@ impl LazyGpuGKRSetupHost {
         }
     }
 
-    /// The CPU-side setup this lazy host wraps. Exposed for program-level
-    /// consumers (`gpu_program_prover`) that recompute setup merkle caps on the
-    /// CPU via `GKRSetup::commit` when assembling a `ProgramProof`.
-    pub fn cpu_setup(&self) -> &Arc<CpuGKRSetup<BF>> {
-        &self.cpu_setup
-    }
-
     /// First call: builds the host on `context` (one-shot stream sync inside
     /// `precompute_from_cpu_setup`) and fills the lock — with `None` when the
     /// CPU setup has no columns (e.g. InitsAndTeardowns), so "initialized as
@@ -77,7 +70,9 @@ impl LazyGpuGKRSetupHost {
     pub fn get_initialized(&self) -> Option<Arc<GpuGKRSetupHost>> {
         self.inner
             .get()
-            .expect("setup host must be initialized by a constructor/add_binary setup batch before use")
+            .expect(
+                "setup host must be initialized by a constructor/add_binary setup batch before use",
+            )
             .clone()
     }
 

--- a/gpu/execution_prover/src/precomputations/setup_host.rs
+++ b/gpu/execution_prover/src/precomputations/setup_host.rs
@@ -50,8 +50,8 @@ impl LazyGpuGKRSetupHost {
     /// `precompute_from_cpu_setup`) and fills the lock — with `None` when the
     /// CPU setup has no columns (e.g. InitsAndTeardowns), so "initialized as
     /// absent" is distinguishable from "never initialized". Subsequent calls
-    /// return the cached value.
-    pub fn get_or_init(&self, context: &ProverContext) -> CudaResult<Option<Arc<GpuGKRSetupHost>>> {
+    /// are no-ops.
+    pub fn get_or_init(&self, context: &ProverContext) -> CudaResult<()> {
         self.inner
             .get_or_try_init(|| {
                 if self.cpu_setup.hypercube_evals.is_empty() {
@@ -65,7 +65,7 @@ impl LazyGpuGKRSetupHost {
                     context,
                 )?)))
             })
-            .map(|opt| opt.clone())
+            .map(|_| ())
     }
 
     pub fn get_initialized(&self) -> Option<Arc<GpuGKRSetupHost>> {
@@ -75,10 +75,6 @@ impl LazyGpuGKRSetupHost {
                 "setup host must be initialized by a constructor/add_binary setup batch before use",
             )
             .clone()
-    }
-
-    pub fn is_initialized(&self) -> bool {
-        self.inner.get().is_some()
     }
 }
 

--- a/gpu/execution_prover/src/prover/artifacts.rs
+++ b/gpu/execution_prover/src/prover/artifacts.rs
@@ -8,10 +8,8 @@ use super::*;
 use crate::precomputations::CircuitPrecomputations;
 use crate::upstream::{GKRCircuitArtifact, MerkleTreeCapVarLength};
 
-/// Compiled circuit + GPU-committed setup cap for one RISC-V family circuit.
-/// The cap is copied out of the family's initialized `GpuGKRSetupHost`
-/// (guaranteed by `add_binary`'s setup batch) — it is the exact digest
-/// sequence the GPU committed and every proof of this family binds.
+/// `setup_cap` is the exact digest sequence the GPU committed and every
+/// proof of this family binds.
 pub struct RiscvFamilyArtifact {
     pub compiled_circuit: Arc<GKRCircuitArtifact<BF>>,
     pub setup_cap: MerkleTreeCapVarLength,
@@ -41,8 +39,7 @@ pub struct ProgramArtifacts {
     pub riscv_families: BTreeMap<u32, RiscvFamilyArtifact>,
     /// `None` for `ExecutionKind::Unified` (inits and teardowns are inline in
     /// the unified circuit). Common circuits carry no program-level setup cap:
-    /// delegation setup params are compile-time constants in the fsv verifiers,
-    /// and inits-and-teardowns has no setup columns at all.
+    /// delegation setup params are compile-time constants in the fsv verifiers.
     pub inits_and_teardowns: Option<Arc<GKRCircuitArtifact<BF>>>,
     /// Keyed by delegation type id.
     pub delegations: BTreeMap<u32, Arc<GKRCircuitArtifact<BF>>>,

--- a/gpu/execution_prover/src/prover/artifacts.rs
+++ b/gpu/execution_prover/src/prover/artifacts.rs
@@ -1,28 +1,51 @@
-//! Public read-only access to the compiled circuits and CPU setups behind a
-//! registered binary. `gpu_program_prover` consumes these to assemble a
-//! `full_statement_verifier::ProgramProof` (which embeds the compiled circuit
-//! artifacts) and the per-family setup-cap map its ND streams are prefixed
-//! with — neither of which `ProveResult` carries.
+//! Public read-only access to the compiled circuits and GPU-committed setup
+//! caps behind a registered binary. `gpu_program_prover` consumes these to
+//! assemble a `full_statement_verifier::ProgramProof` (which embeds the compiled
+//! circuit artifacts) and the per-family setup-cap map its ND streams are
+//! prefixed with — neither of which `ProveResult` carries.
 
 use super::*;
 use crate::precomputations::CircuitPrecomputations;
-use crate::upstream::{CpuGKRSetup, GKRCircuitArtifact};
+use crate::upstream::{GKRCircuitArtifact, MerkleTreeCapVarLength};
 
-/// Compiled circuit + CPU setup for one circuit the prover can produce proofs
-/// for. The setup merkle cap is not materialized here; callers commit the CPU
-/// setup themselves (`GKRSetup::commit`) with the prover config matching the
-/// configured security level.
+/// Compiled circuit + GPU-committed setup cap for one RISC-V family circuit.
+/// The cap is copied out of the family's initialized `GpuGKRSetupHost`
+/// (guaranteed by `add_binary`'s setup batch) — it is the exact digest
+/// sequence the GPU committed and every proof of this family binds.
 #[derive(Clone)]
-pub struct CircuitArtifact {
+pub struct RiscvFamilyArtifact {
     pub compiled_circuit: Arc<GKRCircuitArtifact<BF>>,
-    pub cpu_setup: Arc<CpuGKRSetup<BF>>,
+    pub setup_cap: MerkleTreeCapVarLength,
 }
 
-impl CircuitArtifact {
+impl RiscvFamilyArtifact {
+    fn from_precomputations(precomputations: &CircuitPrecomputations) -> Self {
+        let setup_host = precomputations
+            .setup_host
+            .get_initialized()
+            .expect("RISC-V family setup must have columns");
+        Self {
+            compiled_circuit: Arc::clone(precomputations.gkr_programs.compiled_circuit()),
+            setup_cap: MerkleTreeCapVarLength {
+                cap: setup_host.unified_tree_cap().to_vec(),
+            },
+        }
+    }
+}
+
+/// Compiled circuit for a binary-independent circuit (delegations,
+/// inits-and-teardowns). These carry no program-level setup cap: delegation
+/// setup params are compile-time constants in the fsv verifiers, and
+/// inits-and-teardowns has no setup columns at all.
+#[derive(Clone)]
+pub struct CommonCircuitArtifact {
+    pub compiled_circuit: Arc<GKRCircuitArtifact<BF>>,
+}
+
+impl CommonCircuitArtifact {
     fn from_precomputations(precomputations: &CircuitPrecomputations) -> Self {
         Self {
             compiled_circuit: Arc::clone(precomputations.gkr_programs.compiled_circuit()),
-            cpu_setup: Arc::clone(precomputations.setup_host.cpu_setup()),
         }
     }
 }
@@ -33,12 +56,12 @@ impl CircuitArtifact {
 pub struct ProgramArtifacts {
     /// Keyed by circuit family index. For `ExecutionKind::Unified` this is the
     /// single unified (reduced-machine) family.
-    pub riscv_families: BTreeMap<u32, CircuitArtifact>,
+    pub riscv_families: BTreeMap<u32, RiscvFamilyArtifact>,
     /// `None` for `ExecutionKind::Unified` (inits and teardowns are inline in
     /// the unified circuit).
-    pub inits_and_teardowns: Option<CircuitArtifact>,
+    pub inits_and_teardowns: Option<CommonCircuitArtifact>,
     /// Keyed by delegation type id.
-    pub delegations: BTreeMap<u32, CircuitArtifact>,
+    pub delegations: BTreeMap<u32, CommonCircuitArtifact>,
 }
 
 impl ExecutionProver {
@@ -51,7 +74,7 @@ impl ExecutionProver {
             .map(|(circuit_type, precomputations)| {
                 (
                     circuit_type.get_family_idx() as u32,
-                    CircuitArtifact::from_precomputations(precomputations),
+                    RiscvFamilyArtifact::from_precomputations(precomputations),
                 )
             })
             .collect();
@@ -61,12 +84,12 @@ impl ExecutionProver {
             match circuit_type {
                 CircuitType::Unrolled(UnrolledCircuitType::InitsAndTeardowns) => {
                     inits_and_teardowns =
-                        Some(CircuitArtifact::from_precomputations(precomputations));
+                        Some(CommonCircuitArtifact::from_precomputations(precomputations));
                 }
                 CircuitType::Delegation(delegation_type) => {
                     delegations.insert(
                         delegation_type.get_delegation_type_id() as u32,
-                        CircuitArtifact::from_precomputations(precomputations),
+                        CommonCircuitArtifact::from_precomputations(precomputations),
                     );
                 }
                 _ => {}

--- a/gpu/execution_prover/src/prover/artifacts.rs
+++ b/gpu/execution_prover/src/prover/artifacts.rs
@@ -12,7 +12,6 @@ use crate::upstream::{GKRCircuitArtifact, MerkleTreeCapVarLength};
 /// The cap is copied out of the family's initialized `GpuGKRSetupHost`
 /// (guaranteed by `add_binary`'s setup batch) — it is the exact digest
 /// sequence the GPU committed and every proof of this family binds.
-#[derive(Clone)]
 pub struct RiscvFamilyArtifact {
     pub compiled_circuit: Arc<GKRCircuitArtifact<BF>>,
     pub setup_cap: MerkleTreeCapVarLength,
@@ -33,23 +32,6 @@ impl RiscvFamilyArtifact {
     }
 }
 
-/// Compiled circuit for a binary-independent circuit (delegations,
-/// inits-and-teardowns). These carry no program-level setup cap: delegation
-/// setup params are compile-time constants in the fsv verifiers, and
-/// inits-and-teardowns has no setup columns at all.
-#[derive(Clone)]
-pub struct CommonCircuitArtifact {
-    pub compiled_circuit: Arc<GKRCircuitArtifact<BF>>,
-}
-
-impl CommonCircuitArtifact {
-    fn from_precomputations(precomputations: &CircuitPrecomputations) -> Self {
-        Self {
-            compiled_circuit: Arc::clone(precomputations.gkr_programs.compiled_circuit()),
-        }
-    }
-}
-
 /// Everything program-level proof assembly needs beyond `ProveResult`:
 /// the per-binary RISC-V family circuits plus the binary-independent
 /// inits-and-teardowns and delegation circuits.
@@ -58,10 +40,12 @@ pub struct ProgramArtifacts {
     /// single unified (reduced-machine) family.
     pub riscv_families: BTreeMap<u32, RiscvFamilyArtifact>,
     /// `None` for `ExecutionKind::Unified` (inits and teardowns are inline in
-    /// the unified circuit).
-    pub inits_and_teardowns: Option<CommonCircuitArtifact>,
+    /// the unified circuit). Common circuits carry no program-level setup cap:
+    /// delegation setup params are compile-time constants in the fsv verifiers,
+    /// and inits-and-teardowns has no setup columns at all.
+    pub inits_and_teardowns: Option<Arc<GKRCircuitArtifact<BF>>>,
     /// Keyed by delegation type id.
-    pub delegations: BTreeMap<u32, CommonCircuitArtifact>,
+    pub delegations: BTreeMap<u32, Arc<GKRCircuitArtifact<BF>>>,
 }
 
 impl ExecutionProver {
@@ -84,12 +68,12 @@ impl ExecutionProver {
             match circuit_type {
                 CircuitType::Unrolled(UnrolledCircuitType::InitsAndTeardowns) => {
                     inits_and_teardowns =
-                        Some(CommonCircuitArtifact::from_precomputations(precomputations));
+                        Some(Arc::clone(precomputations.gkr_programs.compiled_circuit()));
                 }
                 CircuitType::Delegation(delegation_type) => {
                     delegations.insert(
                         delegation_type.get_delegation_type_id() as u32,
-                        CommonCircuitArtifact::from_precomputations(precomputations),
+                        Arc::clone(precomputations.gkr_programs.compiled_circuit()),
                     );
                 }
                 _ => {}

--- a/gpu/execution_prover/src/prover/binary.rs
+++ b/gpu/execution_prover/src/prover/binary.rs
@@ -79,9 +79,6 @@ impl ExecutionProver {
                 .collect(),
         );
         pending_setup_initialization.wait();
-        for precomp in precomputations.values() {
-            assert!(precomp.setup_host.is_initialized());
-        }
         let binary_image = Arc::new(binary_image.into_boxed_slice());
         let text_section = Arc::new(text_section.into_boxed_slice());
         let jit_cache = Arc::new(Mutex::new(TypeMap::new()));

--- a/gpu/execution_prover/src/prover/binary.rs
+++ b/gpu/execution_prover/src/prover/binary.rs
@@ -51,7 +51,7 @@ impl ExecutionProver {
         crate::upstream::pad_bytecode_for_proving(&mut padded_binary_image);
         let mut padded_text_section = text_section.clone();
         crate::upstream::pad_bytecode_for_proving(&mut padded_text_section);
-        let precomputations = circuit_types
+        let precomputations: HashMap<_, _> = circuit_types
             .into_iter()
             .map(|circuit_type| {
                 debug!(
@@ -68,6 +68,20 @@ impl ExecutionProver {
                 (circuit_type, precomp)
             })
             .collect();
+        let pending_setup_initialization = request_setup_initialization(
+            &self.gpu_manager,
+            self.configuration.security_level,
+            precomputations
+                .iter()
+                .map(|(circuit_type, precomp)| {
+                    (CircuitType::Unrolled(*circuit_type), precomp.clone())
+                })
+                .collect(),
+        );
+        pending_setup_initialization.wait();
+        for precomp in precomputations.values() {
+            assert!(precomp.setup_host.is_initialized());
+        }
         let binary_image = Arc::new(binary_image.into_boxed_slice());
         let text_section = Arc::new(text_section.into_boxed_slice());
         let jit_cache = Arc::new(Mutex::new(TypeMap::new()));

--- a/gpu/execution_prover/src/prover/lifecycle.rs
+++ b/gpu/execution_prover/src/prover/lifecycle.rs
@@ -66,6 +66,14 @@ impl ExecutionProver {
         let binary_holders = BTreeMap::new();
         info!("PROVER generating common precomputations");
         let common_precomputations = get_common_precomputations_for_all(&worker, security_level);
+        let pending_setup_initialization = request_setup_initialization(
+            &gpu_manager,
+            security_level,
+            common_precomputations
+                .iter()
+                .map(|(circuit_type, precomputations)| (*circuit_type, precomputations.clone()))
+                .collect(),
+        );
         let host_allocators_count = expected_concurrent_jobs * host_allocators_per_job_count
             + device_count * host_allocators_per_device_count;
         let host_allocation_size = host_allocator_backing_allocation_size;
@@ -87,6 +95,10 @@ impl ExecutionProver {
                 .expect("ExecutionProver allocator pool channel closed during initialization");
         });
         gpu_wait_group.wait();
+        pending_setup_initialization.wait();
+        for precomputations in common_precomputations.values() {
+            assert!(precomputations.setup_host.is_initialized());
+        }
         info!("PROVER initialized");
         Ok(Self {
             configuration,

--- a/gpu/execution_prover/src/prover/lifecycle.rs
+++ b/gpu/execution_prover/src/prover/lifecycle.rs
@@ -96,9 +96,6 @@ impl ExecutionProver {
         });
         gpu_wait_group.wait();
         pending_setup_initialization.wait();
-        for precomputations in common_precomputations.values() {
-            assert!(precomputations.setup_host.is_initialized());
-        }
         info!("PROVER initialized");
         Ok(Self {
             configuration,

--- a/gpu/execution_prover/src/prover/mod.rs
+++ b/gpu/execution_prover/src/prover/mod.rs
@@ -14,7 +14,7 @@ mod proof_artifacts;
 mod result;
 mod setup_init;
 
-pub use artifacts::{CircuitArtifact, ProgramArtifacts};
+pub use artifacts::{CommonCircuitArtifact, ProgramArtifacts, RiscvFamilyArtifact};
 pub use config::{ExecutionKind, ExecutionProverConfiguration};
 pub use result::{CommitMemoryResult, ProveResult};
 

--- a/gpu/execution_prover/src/prover/mod.rs
+++ b/gpu/execution_prover/src/prover/mod.rs
@@ -12,6 +12,7 @@ mod non_determinism_wrapper;
 mod pipeline;
 mod proof_artifacts;
 mod result;
+mod setup_init;
 
 pub use artifacts::{CircuitArtifact, ProgramArtifacts};
 pub use config::{ExecutionKind, ExecutionProverConfiguration};
@@ -29,6 +30,7 @@ use cache::{TraceCache, TraceCacheEntry};
 use config::BinaryHolder;
 use non_determinism_wrapper::NonDeterminismWrapper;
 use result::ExecutionProverResult;
+use setup_init::request_setup_initialization;
 
 use crate::messages::{
     GpuWorkBatch, GpuWorkRequest, GpuWorkResult, InitsAndTeardownsData, MemoryCommitmentRequest,
@@ -70,7 +72,7 @@ use riscv_transpiler::ir::{
     FullMachineDecoderConfig, FullUnsignedMachineDecoderConfig, ReducedMachineDecoderConfig,
 };
 use riscv_transpiler::vm::{NonDeterminismCSRSource, SimpleTape};
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;

--- a/gpu/execution_prover/src/prover/mod.rs
+++ b/gpu/execution_prover/src/prover/mod.rs
@@ -82,6 +82,9 @@ use worker::Worker;
 
 pub struct ExecutionProver {
     configuration: ExecutionProverConfiguration,
+    // Field order is load-bearing: `gpu_manager` must be declared (and thus
+    // dropped) before the precomputation maps so workers finish before the
+    // pinned setup hosts drop.
     gpu_manager: GpuManager,
     worker: Arc<Worker>,
     memory_holders_cache: Arc<Mutex<Vec<LockedBoxedMemoryHolder>>>,

--- a/gpu/execution_prover/src/prover/mod.rs
+++ b/gpu/execution_prover/src/prover/mod.rs
@@ -14,7 +14,7 @@ mod proof_artifacts;
 mod result;
 mod setup_init;
 
-pub use artifacts::{CommonCircuitArtifact, ProgramArtifacts, RiscvFamilyArtifact};
+pub use artifacts::{ProgramArtifacts, RiscvFamilyArtifact};
 pub use config::{ExecutionKind, ExecutionProverConfiguration};
 pub use result::{CommitMemoryResult, ProveResult};
 

--- a/gpu/execution_prover/src/prover/pipeline/results.rs
+++ b/gpu/execution_prover/src/prover/pipeline/results.rs
@@ -390,6 +390,11 @@ impl ResultAccumulator {
                     },
                 };
             }
+            GpuWorkResult::SetupInitialization(_) => {
+                panic!(
+                    "setup initialization results must be consumed by the synchronous setup batch"
+                )
+            }
         }
     }
 }

--- a/gpu/execution_prover/src/prover/setup_init.rs
+++ b/gpu/execution_prover/src/prover/setup_init.rs
@@ -1,0 +1,88 @@
+use crate::messages::{
+    GpuWorkBatch, GpuWorkRequest, GpuWorkResult, SetupInitializationRequest, WorkerResult,
+};
+use crate::precomputations::CircuitPrecomputations;
+use crate::upstream::SecurityLevel;
+use crate::workers::gpu_manager::GpuManager;
+use crate::A;
+use crossbeam_channel::{unbounded, Receiver};
+use gpu_trace::witness::circuit_type::CircuitType;
+
+/// Reserved id for the synchronous setup-initialization batches issued by
+/// `with_configuration` and `add_binary`. Collision with caller-chosen batch
+/// ids is structurally impossible: these batches are fully drained before
+/// the constructor / `add_binary` returns, `add_binary` takes `&mut self`,
+/// and user batches are retired from the manager before
+/// `commit_memory`/`prove` return.
+pub(super) const SETUP_BATCH_ID: u64 = 0;
+
+pub(super) struct PendingSetupInitialization {
+    expected_circuit_types: Vec<CircuitType>,
+    result_receiver: Receiver<WorkerResult<A>>,
+}
+
+pub(super) fn request_setup_initialization(
+    gpu_manager: &GpuManager,
+    security_level: SecurityLevel,
+    precomputations: Vec<(CircuitType, CircuitPrecomputations)>,
+) -> PendingSetupInitialization {
+    assert!(
+        !precomputations.is_empty(),
+        "setup initialization batch must contain at least one circuit"
+    );
+    let (request_sender, request_receiver) = unbounded();
+    let (result_sender, result_receiver) = unbounded();
+    gpu_manager.send_batch(GpuWorkBatch {
+        batch_id: SETUP_BATCH_ID,
+        receiver: request_receiver,
+        sender: result_sender,
+    });
+    let expected_circuit_types: Vec<CircuitType> = precomputations
+        .iter()
+        .map(|(circuit_type, _)| *circuit_type)
+        .collect();
+    for (sequence_id, (circuit_type, precomputations)) in precomputations.into_iter().enumerate() {
+        request_sender
+            .send(GpuWorkRequest::SetupInitialization(
+                SetupInitializationRequest {
+                    batch_id: SETUP_BATCH_ID,
+                    circuit_type,
+                    sequence_id,
+                    precomputations,
+                    security_level,
+                },
+            ))
+            .expect("GPU manager batch channel closed before setup initialization was submitted");
+    }
+    PendingSetupInitialization {
+        expected_circuit_types,
+        result_receiver,
+    }
+}
+
+impl PendingSetupInitialization {
+    pub fn wait(self) {
+        let mut seen = vec![false; self.expected_circuit_types.len()];
+        for result in self.result_receiver {
+            match result {
+                WorkerResult::GpuWorkResult(GpuWorkResult::SetupInitialization(result)) => {
+                    assert_eq!(result.batch_id, SETUP_BATCH_ID);
+                    let expected_circuit_type = *self
+                        .expected_circuit_types
+                        .get(result.sequence_id)
+                        .expect("setup initialization result has an out-of-range sequence id");
+                    assert_eq!(result.circuit_type, expected_circuit_type);
+                    assert!(
+                        !std::mem::replace(&mut seen[result.sequence_id], true),
+                        "duplicate setup initialization result for {expected_circuit_type:?}"
+                    );
+                }
+                _ => panic!("unexpected worker result in setup initialization batch"),
+            }
+        }
+        assert!(
+            seen.iter().all(|&seen| seen),
+            "GPU manager terminated before all setup initializations completed"
+        );
+    }
+}

--- a/gpu/execution_prover/src/prover/setup_init.rs
+++ b/gpu/execution_prover/src/prover/setup_init.rs
@@ -8,12 +8,10 @@ use crate::A;
 use crossbeam_channel::{unbounded, Receiver};
 use gpu_trace::witness::circuit_type::CircuitType;
 
-/// Reserved id for the synchronous setup-initialization batches issued by
-/// `with_configuration` and `add_binary`. Collision with caller-chosen batch
-/// ids is structurally impossible: these batches are fully drained before
-/// the constructor / `add_binary` returns, `add_binary` takes `&mut self`,
-/// and user batches are retired from the manager before
-/// `commit_memory`/`prove` return.
+/// Collision with caller-chosen batch ids is structurally impossible: setup
+/// batches are fully drained before the constructor / `add_binary` returns
+/// (`add_binary` is `&mut self`), and user batches are retired from the
+/// manager before `commit_memory`/`prove` return.
 pub(super) const SETUP_BATCH_ID: u64 = 0;
 
 pub(super) struct PendingSetupInitialization {

--- a/gpu/execution_prover/src/prover/tests.rs
+++ b/gpu/execution_prover/src/prover/tests.rs
@@ -1,7 +1,7 @@
 use super::{ExecutionKind, ExecutionProver, ExecutionProverConfiguration, ProveResult};
 use crate::upstream::{read_binary, SecurityLevel};
 use gpu_core::primitives::machine_type::MachineType;
-use gpu_trace::witness::circuit_type::{DelegationCircuitType, UnrolledCircuitType};
+use gpu_trace::witness::circuit_type::{CircuitType, DelegationCircuitType, UnrolledCircuitType};
 use riscv_transpiler::abstractions::non_determinism::QuasiUARTSource;
 
 fn test_artifact(relative_path: &str) -> std::path::PathBuf {
@@ -207,6 +207,56 @@ fn cpu_all_security_levels_supported_in_configuration() {
         assert!(
             configuration.validate().is_ok(),
             "{level:?} must pass configuration validation"
+        );
+    }
+}
+
+#[test]
+#[cfg(not(no_cuda))]
+#[ignore]
+fn test_setup_hosts_initialized_by_constructor_and_add_binary() {
+    init_test_logger();
+    let configuration = ExecutionProverConfiguration::default();
+    let mut prover = ExecutionProver::with_configuration(configuration).unwrap();
+    for (circuit_type, precomputations) in prover.common_precomputations.iter() {
+        assert!(
+            precomputations.setup_host.is_initialized(),
+            "{circuit_type:?} setup lock not filled by the constructor batch"
+        );
+        let expected_columns = match circuit_type {
+            CircuitType::Unrolled(UnrolledCircuitType::InitsAndTeardowns) => false,
+            _ => true,
+        };
+        assert_eq!(
+            precomputations.setup_host.get_initialized().is_some(),
+            expected_columns,
+            "{circuit_type:?} initialized-absence state is wrong"
+        );
+    }
+    let (_, binary_image) = read_binary(&test_artifact("examples/hashed_fibonacci/app.bin"));
+    let (_, text_section) = read_binary(&test_artifact("examples/hashed_fibonacci/app.text"));
+    let handle = prover.add_binary(
+        ExecutionKind::Unrolled,
+        MachineType::FullUnsigned,
+        binary_image,
+        text_section,
+        None,
+    );
+    for (circuit_type, precomputations) in prover.binary_holders[&0].precomputations.iter() {
+        assert!(
+            precomputations
+                .setup_host
+                .get_initialized()
+                .is_some(),
+            "{circuit_type:?} family setup not initialized by add_binary"
+        );
+    }
+    let artifacts = prover.program_artifacts(&handle);
+    assert!(!artifacts.riscv_families.is_empty());
+    for (family_idx, artifact) in artifacts.riscv_families.iter() {
+        assert!(
+            !artifact.setup_cap.cap.is_empty(),
+            "family {family_idx} artifact carries an empty setup cap"
         );
     }
 }

--- a/gpu/execution_prover/src/prover/tests.rs
+++ b/gpu/execution_prover/src/prover/tests.rs
@@ -244,10 +244,7 @@ fn test_setup_hosts_initialized_by_constructor_and_add_binary() {
     );
     for (circuit_type, precomputations) in prover.binary_holders[&0].precomputations.iter() {
         assert!(
-            precomputations
-                .setup_host
-                .get_initialized()
-                .is_some(),
+            precomputations.setup_host.get_initialized().is_some(),
             "{circuit_type:?} family setup not initialized by add_binary"
         );
     }

--- a/gpu/execution_prover/src/prover/tests.rs
+++ b/gpu/execution_prover/src/prover/tests.rs
@@ -219,10 +219,6 @@ fn test_setup_hosts_initialized_by_constructor_and_add_binary() {
     let configuration = ExecutionProverConfiguration::default();
     let mut prover = ExecutionProver::with_configuration(configuration).unwrap();
     for (circuit_type, precomputations) in prover.common_precomputations.iter() {
-        assert!(
-            precomputations.setup_host.is_initialized(),
-            "{circuit_type:?} setup lock not filled by the constructor batch"
-        );
         let expected_columns = match circuit_type {
             CircuitType::Unrolled(UnrolledCircuitType::InitsAndTeardowns) => false,
             _ => true,

--- a/gpu/execution_prover/src/workers/gpu.rs
+++ b/gpu/execution_prover/src/workers/gpu.rs
@@ -47,7 +47,6 @@ pub(crate) fn get_gpu_worker_func(
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
 enum RequestKind {
     MemoryCommitment,
     Proof,
@@ -272,7 +271,7 @@ fn schedule_phase_one<'a>(
     let batch_id = state.batch_id;
     let circuit_type = state.circuit_type;
     let sequence_id = state.sequence_id;
-    let is_proof = state.kind == RequestKind::Proof;
+    let is_proof = matches!(state.kind, RequestKind::Proof);
 
     let decoder_transfer = if let Some(host) = state.precomputations.decoder_host.as_ref() {
         Some(DecoderTableTransfer::new(Arc::clone(host), context)?)

--- a/gpu/execution_prover/src/workers/gpu.rs
+++ b/gpu/execution_prover/src/workers/gpu.rs
@@ -295,10 +295,8 @@ fn schedule_phase_one<'a>(
     };
 
     let inputs = if is_proof {
-        // Setup transfer (Proof only) — lazy-init the GPU setup host on first
-        // use against this worker's context.
         let setup_transfer =
-            if let Some(setup_host) = state.precomputations.setup_host.get_or_init(context)? {
+            if let Some(setup_host) = state.precomputations.setup_host.get_initialized() {
                 Some(GpuGKRSetupTransfer::new(setup_host, context)?)
             } else {
                 None

--- a/gpu/execution_prover/src/workers/gpu.rs
+++ b/gpu/execution_prover/src/workers/gpu.rs
@@ -1,6 +1,6 @@
 use crate::messages::{
     GpuWorkRequest, GpuWorkResult, MemoryCommitmentRequest, MemoryCommitmentResult, ProofRequest,
-    ProofResult,
+    ProofResult, SetupInitializationRequest, SetupInitializationResult,
 };
 use crate::precomputations::CircuitPrecomputations;
 use crate::A;
@@ -47,6 +47,13 @@ pub(crate) fn get_gpu_worker_func(
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RequestKind {
+    MemoryCommitment,
+    Proof,
+    SetupInitialization,
+}
+
 /// Per-request bookkeeping carried across all three phases. Owns the
 /// precomputations Arc (which holds the compiled circuit, lazy-init setup
 /// host, and optional decoder host), so it outlives any Phase-2 borrow,
@@ -57,6 +64,7 @@ struct RequestState {
     circuit_type: CircuitType,
     sequence_id: usize,
     precomputations: CircuitPrecomputations,
+    kind: RequestKind,
     /// Set only for Proof requests; consumed in Phase 2 by `prove()`.
     external_challenges: Option<GKRExternalChallenges<BF, E4>>,
     /// Per-coset caps from a prior commit_memory phase; only present for
@@ -67,12 +75,6 @@ struct RequestState {
     inits_and_teardowns_result: Option<InitsAndTeardownsTraceHost>,
     tracing_data_result: Option<gpu_trace::trace::tracing_data::TracingDataHost<A>>,
     security_level: SecurityLevel,
-}
-
-impl RequestState {
-    fn is_proof(&self) -> bool {
-        self.external_challenges.is_some()
-    }
 }
 
 /// Phase-1 state: H2D transfers scheduled, no GPU job enqueued yet.
@@ -91,6 +93,7 @@ struct PhaseOne<'a> {
 enum PhaseOneInputs<'a> {
     Proof(gpu_circuit_prover::proof::inputs::GpuGKRProofTransfer<'a, A>),
     MemoryCommitment(gpu_trace::trace::memory_transfer::GpuGKRCommitMemoryTransfer<'a, A>),
+    SetupInitialization,
 }
 
 /// Phase-2 state: GPU job enqueued, awaiting `finish()`.
@@ -107,6 +110,7 @@ struct PhaseTwo<'a> {
 enum JobType<'a> {
     MemoryCommitment(MemoryCommitmentJob<'a, A>),
     Proof(GpuGKRProofJob<'a, A>),
+    SetupInitialization,
 }
 
 fn gpu_worker(
@@ -174,6 +178,35 @@ fn schedule_phase_one<'a>(
     context: &ProverContext,
     request: GpuWorkRequest<A>,
 ) -> CudaResult<PhaseOne<'a>> {
+    if let GpuWorkRequest::SetupInitialization(request) = request {
+        let SetupInitializationRequest {
+            batch_id,
+            circuit_type,
+            sequence_id,
+            precomputations,
+            security_level,
+        } = request;
+        trace!(
+            "BATCH[{batch_id}] GPU_WORKER[{device_id}] initializing setup for circuit {circuit_type:?}[{sequence_id}]"
+        );
+        precomputations.setup_host.get_or_init(context)?;
+        let state = RequestState {
+            batch_id,
+            circuit_type,
+            sequence_id,
+            precomputations,
+            kind: RequestKind::SetupInitialization,
+            external_challenges: None,
+            memory_caps: None,
+            inits_and_teardowns_result: None,
+            tracing_data_result: None,
+            security_level,
+        };
+        return Ok(PhaseOne {
+            state,
+            inputs: PhaseOneInputs::SetupInitialization,
+        });
+    }
     // Decompose the request into bookkeeping plus the host buffers that
     // become Phase 1 H2D inputs.
     let (state, inits_and_teardowns_host, tracing_data_host) = match request {
@@ -192,6 +225,7 @@ fn schedule_phase_one<'a>(
                 circuit_type,
                 sequence_id,
                 precomputations,
+                kind: RequestKind::MemoryCommitment,
                 external_challenges: None,
                 memory_caps: None,
                 inits_and_teardowns_result: inits_and_teardowns.clone(),
@@ -217,6 +251,7 @@ fn schedule_phase_one<'a>(
                 circuit_type,
                 sequence_id,
                 precomputations,
+                kind: RequestKind::Proof,
                 external_challenges: Some(external_challenges),
                 memory_caps: Some(memory_caps),
                 inits_and_teardowns_result: inits_and_teardowns.clone(),
@@ -225,11 +260,14 @@ fn schedule_phase_one<'a>(
             };
             (state, inits_and_teardowns, tracing_data)
         }
+        GpuWorkRequest::SetupInitialization(_) => {
+            unreachable!("setup initialization returns early above")
+        }
     };
     let batch_id = state.batch_id;
     let circuit_type = state.circuit_type;
     let sequence_id = state.sequence_id;
-    let is_proof = state.is_proof();
+    let is_proof = state.kind == RequestKind::Proof;
 
     let decoder_transfer = if let Some(host) = state.precomputations.decoder_host.as_ref() {
         Some(DecoderTableTransfer::new(Arc::clone(host), context)?)
@@ -378,6 +416,7 @@ fn enqueue_phase_two<'a>(
             )?;
             JobType::MemoryCommitment(job)
         }
+        PhaseOneInputs::SetupInitialization => JobType::SetupInitialization,
     };
 
     Ok(PhaseTwo { state, job })
@@ -421,6 +460,18 @@ fn finish_phase_three<'a>(device_id: i32, p2: PhaseTwo<'a>) -> CudaResult<GpuWor
                 tracing_data: tracing_data_result,
                 proof,
             }))
+        }
+        JobType::SetupInitialization => {
+            trace!(
+                "BATCH[{batch_id}] GPU_WORKER[{device_id}] initialized setup for circuit {circuit_type:?}[{sequence_id}]"
+            );
+            Ok(GpuWorkResult::SetupInitialization(
+                SetupInitializationResult {
+                    batch_id,
+                    circuit_type,
+                    sequence_id,
+                },
+            ))
         }
     }
 }

--- a/gpu/execution_prover/src/workers/gpu.rs
+++ b/gpu/execution_prover/src/workers/gpu.rs
@@ -189,7 +189,12 @@ fn schedule_phase_one<'a>(
         trace!(
             "BATCH[{batch_id}] GPU_WORKER[{device_id}] initializing setup for circuit {circuit_type:?}[{sequence_id}]"
         );
+        let timer = std::time::Instant::now();
         precomputations.setup_host.get_or_init(context)?;
+        debug!(
+            "BATCH[{batch_id}] GPU_WORKER[{device_id}] initialized setup for circuit {circuit_type:?}[{sequence_id}] in {:.3} ms",
+            timer.elapsed().as_secs_f64() * 1e3
+        );
         let state = RequestState {
             batch_id,
             circuit_type,

--- a/gpu/execution_prover/src/workers/gpu_manager.rs
+++ b/gpu/execution_prover/src/workers/gpu_manager.rs
@@ -247,6 +247,9 @@ fn handle_new_request(
                 GpuWorkRequest::Proof(_) => {
                     trace!("BATCH[{batch_id}] GPU_MANAGER received proof request for circuit {circuit_type:?}[{sequence_id}]")
                 }
+                GpuWorkRequest::SetupInitialization(_) => trace!(
+                    "BATCH[{batch_id}] GPU_MANAGER received setup initialization request for circuit {circuit_type:?}[{sequence_id}]"
+                ),
             };
             work_queue.push_back(request);
         }
@@ -285,6 +288,10 @@ fn handle_worker_result(
             GpuWorkResult::Proof(result) => {
                 assert_eq!(result.batch_id, batch_id);
                 trace!("BATCH[{batch_id}] GPU_MANAGER received proof from GPU_WORKER[{worker_id}] for circuit {circuit_type:?}[{sequence_id}]");
+            }
+            GpuWorkResult::SetupInitialization(result) => {
+                assert_eq!(result.batch_id, batch_id);
+                trace!("BATCH[{batch_id}] GPU_MANAGER received setup initialization for circuit {circuit_type:?}[{sequence_id}] from GPU_WORKER[{worker_id}]");
             }
         };
         let result = WorkerResult::GpuWorkResult(result);
@@ -343,6 +350,7 @@ fn handle_worker_ready(
             match &request {
                 GpuWorkRequest::MemoryCommitment(_) => "memory commitment",
                 GpuWorkRequest::Proof(_) => "proof",
+                GpuWorkRequest::SetupInitialization(_) => "setup initialization",
             }
         );
         (Some(request), Some(batch_id))
@@ -377,6 +385,7 @@ fn drain_eager_dispatch(
                 match &request {
                     GpuWorkRequest::MemoryCommitment(_) => trace!("BATCH[{batch_id}] GPU_MANAGER sending memory commitment request to GPU_WORKER[{worker_id}] for circuit {circuit_type:?}[{sequence_id}]"),
                     GpuWorkRequest::Proof(_) => trace!("BATCH[{batch_id}] GPU_MANAGER sending proof request to GPU_WORKER[{worker_id}] for circuit {circuit_type:?}[{sequence_id}]"),
+                    GpuWorkRequest::SetupInitialization(_) => trace!("BATCH[{batch_id}] GPU_MANAGER sending setup initialization request to GPU_WORKER[{worker_id}] for circuit {circuit_type:?}[{sequence_id}]"),
                 };
                 op.send(&worker_senders[worker_id], Some(request))
                     .expect("GPU manager failed to eagerly queue work for GPU worker");

--- a/gpu/gkr/src/setup/kernels.rs
+++ b/gpu/gkr/src/setup/kernels.rs
@@ -88,6 +88,10 @@ pub struct GpuGKRSetupHost {
 }
 
 impl GpuGKRSetupHost {
+    pub fn unified_tree_cap(&self) -> &[Digest] {
+        &self.unified_tree_cap
+    }
+
     pub fn precompute_from_cpu_setup(
         setup: &CpuGKRSetup<BF>,
         log_lde_factor: u32,

--- a/gpu/gkr/src/setup/mod.rs
+++ b/gpu/gkr/src/setup/mod.rs
@@ -92,11 +92,10 @@ impl<'a> GpuGKRSetupTransfer<'a> {
                 .expect("setup transfers require partial-tree caching");
             memory_copy_async(dst_tree, &src_tree[..], stream)?;
         }
-        // Pre-prove H2D the unified cap into the trace holder's
-        // `unified_device_cap` for test-only consumers. `prove()` ignores
-        // this buffer and reads the cap from the slab instead (it is
-        // written there directly by `prepare_stage1_and_forward_setup`'s
-        // own H2D, also from `host.unified_tree_cap`).
+        // Pre-prove H2D of the unified cap into the trace holder's
+        // `unified_device_cap`. This is the production source of the proof's
+        // setup cap: stage 1 D2Ds it from this buffer into the proof slab's
+        // whir.setup.cap range (gpu_circuit_prover stage1_forward).
         let unified_dst = self
             .trace_holder
             .unified_device_cap

--- a/gpu/gkr/src/setup/mod.rs
+++ b/gpu/gkr/src/setup/mod.rs
@@ -92,10 +92,8 @@ impl<'a> GpuGKRSetupTransfer<'a> {
                 .expect("setup transfers require partial-tree caching");
             memory_copy_async(dst_tree, &src_tree[..], stream)?;
         }
-        // Pre-prove H2D of the unified cap into the trace holder's
-        // `unified_device_cap`. This is the production source of the proof's
-        // setup cap: stage 1 D2Ds it from this buffer into the proof slab's
-        // whir.setup.cap range (gpu_circuit_prover stage1_forward).
+        // Production source of the proof's setup cap: stage 1 D2Ds it from
+        // this buffer into the proof slab (gpu_circuit_prover stage1_forward).
         let unified_dst = self
             .trace_holder
             .unified_device_cap

--- a/gpu/gkr/src/setup/tests.rs
+++ b/gpu/gkr/src/setup/tests.rs
@@ -255,6 +255,53 @@ fn setup_host_matches_flattened_cpu_setup_and_caps() {
 
 #[test]
 #[cfg(not(no_cuda))]
+fn setup_host_matches_cpu_setup_caps_at_production_cap_geometry() {
+    let trace_len = 1usize << 16;
+    let lde_factor = 2usize;
+    let tree_cap_size = 16usize;
+    let log_lde_factor = lde_factor.trailing_zeros();
+    let log_rows_per_leaf = 1u32;
+    let log_tree_cap_size = tree_cap_size.trailing_zeros();
+    let setup = make_test_cpu_setup(trace_len, 3, 64);
+    let context = make_test_context(256, 64);
+
+    let host = GpuGKRSetupHost::precompute_from_cpu_setup(
+        &setup,
+        log_lde_factor,
+        log_rows_per_leaf,
+        log_tree_cap_size,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(host.unified_tree_cap().len(), tree_cap_size);
+
+    let worker = Worker::new();
+    let twiddles: fft::Twiddles<BF, Global> = fft::Twiddles::new(trace_len, &worker);
+    let setup_commitment = setup.commit::<DefaultTreeConstructor>(
+        &twiddles,
+        lde_factor,
+        log_rows_per_leaf as usize,
+        tree_cap_size,
+        trace_len.trailing_zeros() as usize,
+        &worker,
+    );
+    let subcap_size = tree_cap_size / lde_factor;
+    let setup_caps = setup_commitment
+        .get_cap()
+        .cap
+        .chunks_exact(subcap_size)
+        .map(|chunk| MerkleTreeCapVarLength {
+            cap: chunk.to_vec(),
+        })
+        .collect_vec();
+    assert_eq!(
+        stage1_caps_from_unified_host_cap(host.unified_tree_cap(), log_lde_factor),
+        setup_caps
+    );
+}
+
+#[test]
+#[cfg(not(no_cuda))]
 fn setup_transfer_reuses_single_raw_backing_and_lazy_queries_match_fresh_commit() {
     let trace_len = 1usize << 10;
     let lde_factor = 2usize;

--- a/gpu/program_prover/Cargo.toml
+++ b/gpu/program_prover/Cargo.toml
@@ -31,7 +31,6 @@ common_constants = { workspace = true }
 riscv_transpiler = { workspace = true, features = ["jit"] }
 verifier_common = { workspace = true }
 transcript = { workspace = true }
-worker = { workspace = true }
 
 itertools = "0.14"
 log = "0.4.29"
@@ -61,6 +60,7 @@ verifiers = [
 [dev-dependencies]
 env_logger = "0.11"
 serde_json = "*"
+worker = { workspace = true }
 # CPU reference prover, used only by the GPU-vs-CPU proof-diff test.
 prover_examples = { workspace = true, default-features = false, features = [
     "timing_logs",

--- a/gpu/program_prover/src/proof_assembly.rs
+++ b/gpu/program_prover/src/proof_assembly.rs
@@ -4,9 +4,7 @@
 //! `ProgramProof` the verifiers consume additionally embeds the compiled
 //! circuit artifacts and is accompanied by the per-family setup-cap map
 //! (`Setups`) that prefixes the ND streams. Both come from
-//! `ExecutionProver::program_artifacts`; the setup caps are the ones the
-//! GPU committed (copied out of each family's `GpuGKRSetupHost`), so no
-//! CPU-side setup commitment happens here.
+//! `ExecutionProver::program_artifacts`.
 
 use std::collections::BTreeMap;
 

--- a/gpu/program_prover/src/proof_assembly.rs
+++ b/gpu/program_prover/src/proof_assembly.rs
@@ -4,23 +4,16 @@
 //! `ProgramProof` the verifiers consume additionally embeds the compiled
 //! circuit artifacts and is accompanied by the per-family setup-cap map
 //! (`Setups`) that prefixes the ND streams. Both come from
-//! `ExecutionProver::program_artifacts`. Setup caps are recomputed on the CPU
-//! via `GKRSetup::commit` — byte-identical to the caps the GPU prover
-//! committed to (validated by the gpu_circuit_prover proof-parity suite), without
-//! needing a GPU context here.
+//! `ExecutionProver::program_artifacts`; the setup caps are the ones the
+//! GPU committed (copied out of each family's `GpuGKRSetupHost`), so no
+//! CPU-side setup commitment happens here.
 
-use std::alloc::Global;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
-use gpu_core::primitives::field::BF;
 use gpu_execution_prover::{ProgramArtifacts, ProveResult};
-use worker::Worker;
 
 use crate::upstream::{compute_end_params, Setups};
-use crate::upstream::{
-    config_for_security_level_under_pessimistic_conjecture, DefaultTreeConstructor, MerkleTreeCap,
-    ProgramProof, SecurityLevel, Twiddles, UnrolledCircuitSetupParams,
-};
+use crate::upstream::{ProgramProof, UnrolledCircuitSetupParams};
 
 /// Assemble a `ProgramProof` + its `Setups` map from a GPU prove result.
 ///
@@ -36,37 +29,17 @@ use crate::upstream::{
 pub fn assemble_program_proof(
     artifacts: &ProgramArtifacts,
     result: ProveResult,
-    security_level: SecurityLevel,
-    worker: &Worker,
 ) -> (ProgramProof, Setups) {
-    let mut twiddles: HashMap<usize, Twiddles<BF, Global>> = HashMap::new();
     let mut setups: Setups = BTreeMap::new();
     for (family_idx, artifact) in artifacts.riscv_families.iter() {
         let trace_len = artifact.compiled_circuit.trace_len;
-        let prover_config = config_for_security_level_under_pessimistic_conjecture(
-            trace_len.trailing_zeros() as usize,
-            security_level,
-        );
-        let twiddles_for_size = twiddles
-            .entry(trace_len)
-            .or_insert_with(|| Twiddles::new(trace_len, worker));
-        let setup_commitment = artifact.cpu_setup.commit::<DefaultTreeConstructor>(
-            &*twiddles_for_size,
-            prover_config.lde_factor,
-            prover_config.whir_schedule.whir_steps_schedule[0],
-            prover_config.cap_size,
-            trace_len.trailing_zeros() as usize,
-            worker,
-        );
         setups.insert(
             *family_idx,
-            UnrolledCircuitSetupParams {
-                family_idx: *family_idx,
-                capacity: trace_len as u32,
-                setup_caps: MerkleTreeCap {
-                    cap: setup_commitment.get_cap().cap.try_into().unwrap(),
-                },
-            },
+            UnrolledCircuitSetupParams::from_setup_tree_cap(
+                *family_idx,
+                trace_len as u32,
+                artifact.setup_cap.clone(),
+            ),
         );
     }
 

--- a/gpu/program_prover/src/proof_assembly.rs
+++ b/gpu/program_prover/src/proof_assembly.rs
@@ -63,12 +63,12 @@ pub fn assemble_program_proof(
     let compiled_delegation_circuits = artifacts
         .delegations
         .iter()
-        .map(|(delegation_type, artifact)| (*delegation_type, (*artifact.compiled_circuit).clone()))
+        .map(|(delegation_type, artifact)| (*delegation_type, (**artifact).clone()))
         .collect();
     let inits_and_teardowns_circuit = artifacts
         .inits_and_teardowns
         .as_ref()
-        .map(|artifact| (*artifact.compiled_circuit).clone());
+        .map(|artifact| (**artifact).clone());
 
     let end_params = compute_end_params(&setups, result.final_pc);
 

--- a/gpu/program_prover/src/tests.rs
+++ b/gpu/program_prover/src/tests.rs
@@ -190,7 +190,7 @@ fn test_program_prover_unified_cpu_gpu_proof_diff() {
 
     // GPU flow.
     let mut prover = ExecutionProver::with_configuration(configuration).unwrap();
-    let (gpu_proof, _gpu_setups) = prove_on_gpu(
+    let (gpu_proof, gpu_setups) = prove_on_gpu(
         &mut prover,
         ExecutionKind::Unified,
         MachineType::Reduced,
@@ -198,6 +198,20 @@ fn test_program_prover_unified_cpu_gpu_proof_diff() {
         text_section,
         vec![50, 0xDEAD_BEEF],
     );
+
+    assert_eq!(
+        cpu_setups.keys().collect::<Vec<_>>(),
+        gpu_setups.keys().collect::<Vec<_>>(),
+        "setups family keys differ"
+    );
+    for (family_idx, cpu_params) in cpu_setups.iter() {
+        let gpu_params = &gpu_setups[family_idx];
+        assert_eq!(
+            cpu_params, gpu_params,
+            "setup params differ for family {family_idx}"
+        );
+    }
+    log::info!("setups match");
 
     serde_json::to_writer(
         std::fs::File::create("/tmp/pp_unified_cpu_proof.json").unwrap(),

--- a/gpu/program_prover/src/tests.rs
+++ b/gpu/program_prover/src/tests.rs
@@ -56,12 +56,11 @@ fn prove_on_gpu(
     binary_image: Vec<u32>,
     text_section: Vec<u32>,
     reads: Vec<u32>,
-    (security_level, worker): (crate::upstream::SecurityLevel, &worker::Worker),
 ) -> (crate::upstream::ProgramProof, crate::upstream::Setups) {
     let handle = prover.add_binary(kind, machine, binary_image, text_section, None);
     let result = prover.commit_memory_and_prove(0, &handle, QuasiUARTSource::new_with_reads(reads));
     let artifacts = prover.program_artifacts(&handle);
-    assemble_program_proof(&artifacts, result, security_level, worker)
+    assemble_program_proof(&artifacts, result)
 }
 
 /// Prove `hashed_fibonacci` (blake2_with_compression build — fires the
@@ -74,9 +73,7 @@ fn prove_on_gpu(
 fn test_program_prover_base_layer_verify() {
     init_test_logger();
     let configuration = ExecutionProverConfiguration::default();
-    let security_level = configuration.security_level;
     let mut prover = ExecutionProver::with_configuration(configuration).unwrap();
-    let worker = worker::Worker::new();
     let (binary_image, text_section) = load_workload("hashed_fibonacci");
     let (proof, setups) = prove_on_gpu(
         &mut prover,
@@ -85,7 +82,6 @@ fn test_program_prover_base_layer_verify() {
         binary_image,
         text_section,
         vec![100, 5],
-        (security_level, &worker),
     );
     log::info!(
         "assembled ProgramProof: {} cycles, {} riscv families, {} delegation types",
@@ -124,9 +120,7 @@ fn test_program_prover_base_layer_verify() {
 fn test_program_prover_unified_base_layer_verify() {
     init_test_logger();
     let configuration = ExecutionProverConfiguration::default();
-    let security_level = configuration.security_level;
     let mut prover = ExecutionProver::with_configuration(configuration).unwrap();
-    let worker = worker::Worker::new();
     let (binary_image, text_section) = load_workload("multi_family_smoke");
     let (proof, setups) = prove_on_gpu(
         &mut prover,
@@ -135,7 +129,6 @@ fn test_program_prover_unified_base_layer_verify() {
         binary_image,
         text_section,
         vec![50, 0xDEAD_BEEF],
-        (security_level, &worker),
     );
     log::info!(
         "assembled unified ProgramProof: {} cycles, {} unified circuits, num_it_circuits {:?}, {} delegation types",
@@ -204,7 +197,6 @@ fn test_program_prover_unified_cpu_gpu_proof_diff() {
         binary_image,
         text_section,
         vec![50, 0xDEAD_BEEF],
-        (security_level, &worker),
     );
 
     serde_json::to_writer(
@@ -303,7 +295,6 @@ fn test_program_prover_cpu_gpu_proof_diff() {
 
     // GPU flow.
     let configuration = ExecutionProverConfiguration::default();
-    let security_level = configuration.security_level;
     let mut prover = ExecutionProver::with_configuration(configuration).unwrap();
     let (gpu_proof, gpu_setups) = prove_on_gpu(
         &mut prover,
@@ -312,7 +303,6 @@ fn test_program_prover_cpu_gpu_proof_diff() {
         binary_image,
         text_section,
         vec![100, 5],
-        (security_level, &worker),
     );
 
     // Diff setups.
@@ -475,9 +465,7 @@ fn test_program_prover_recursion_layer_verify() {
 
     init_test_logger();
     let configuration = ExecutionProverConfiguration::default();
-    let security_level = configuration.security_level;
     let mut prover = ExecutionProver::with_configuration(configuration).unwrap();
-    let worker = worker::Worker::new();
 
     // Stage 1: base layer (identical to test_program_prover_base_layer_verify).
     let (binary_image, text_section) = load_workload("hashed_fibonacci");
@@ -488,7 +476,6 @@ fn test_program_prover_recursion_layer_verify() {
         binary_image,
         text_section,
         vec![100, 5],
-        (security_level, &worker),
     );
     native_verify_unrolled(build_unrolled_stream(&base_setups, &base_proof), true);
     log::info!(
@@ -516,7 +503,6 @@ fn test_program_prover_recursion_layer_verify() {
         fsv_binary,
         fsv_text,
         stream,
-        (security_level, &worker),
     );
     recursion_proof.set_recursion_chain(&chain);
     log::info!(
@@ -646,9 +632,7 @@ fn run_gpu_recursive_pipeline(
     let switch_cycles = unified_switch_cycles();
 
     let configuration = ExecutionProverConfiguration::default();
-    let security_level = configuration.security_level;
     let mut prover = ExecutionProver::with_configuration(configuration).unwrap();
-    let worker = worker::Worker::new();
 
     // === Stage 1: base layer. ===
     let (base_proof, base_setups) = prove_on_gpu(
@@ -658,7 +642,6 @@ fn run_gpu_recursive_pipeline(
         base_binary_image,
         base_text_section,
         base_non_determinism,
-        (security_level, &worker),
     );
     native_verify_unrolled(build_unrolled_stream(&base_setups, &base_proof), true);
     log::info!(
@@ -717,7 +700,6 @@ fn run_gpu_recursive_pipeline(
             bin.clone(),
             text.clone(),
             build_unrolled_stream(&setups, &proof),
-            (security_level, &worker),
         );
         new_proof.set_recursion_chain(&chain);
         native_verify_unrolled(build_unrolled_stream(&new_setups, &new_proof), false);
@@ -750,7 +732,6 @@ fn run_gpu_recursive_pipeline(
         bridge_bin.clone(),
         bridge_text.clone(),
         build_unrolled_stream(&setups, &proof),
-        (security_level, &worker),
     );
     bridge_proof.set_recursion_chain(&chain);
     native_verify_unified(build_unified_stream(&bridge_setups, &bridge_proof), false);
@@ -772,7 +753,6 @@ fn run_gpu_recursive_pipeline(
         final_bin.clone(),
         final_text.clone(),
         build_unified_stream(&bridge_setups, &bridge_proof),
-        (security_level, &worker),
     );
     final_proof.set_recursion_chain(&chain);
     let output = native_verify_unified(build_unified_stream(&final_setups, &final_proof), false);
@@ -800,7 +780,6 @@ fn run_gpu_recursive_pipeline(
             final_bin.clone(),
             final_text.clone(),
             build_unified_stream(&setups, &proof),
-            (security_level, &worker),
         );
         new_proof.set_recursion_chain(&chain);
         native_verify_unified(build_unified_stream(&new_setups, &new_proof), false);

--- a/gpu/program_prover/src/upstream.rs
+++ b/gpu/program_prover/src/upstream.rs
@@ -17,7 +17,7 @@ pub use full_statement_verifier::unrolled_proof_statement::{
     verify_unrolled_recursion_layer_sec_100, verify_unrolled_recursion_layer_sec_80,
 };
 
-// `prover` — definitions consumed by tests and the ND-stream contract.
+// `prover` — definitions consumed by tests only.
 pub use prover::definitions::SecurityLevel;
 
 // `setups` — the per-program setup-params entry the ND stream contract uses.

--- a/gpu/program_prover/src/upstream.rs
+++ b/gpu/program_prover/src/upstream.rs
@@ -17,12 +17,8 @@ pub use full_statement_verifier::unrolled_proof_statement::{
     verify_unrolled_recursion_layer_sec_100, verify_unrolled_recursion_layer_sec_80,
 };
 
-// `prover` — CPU-side setup commitment machinery for the per-family setup
-// caps that prefix the verifier ND streams.
-pub use prover::definitions::{MerkleTreeCap, SecurityLevel};
-pub use prover::fft::Twiddles;
-pub use prover::gkr::prover_config::example_configs::config_for_security_level_under_pessimistic_conjecture;
-pub use prover::merkle_trees::{ColumnMajorMerkleTreeConstructor, DefaultTreeConstructor};
+// `prover` — definitions consumed by tests and the ND-stream contract.
+pub use prover::definitions::SecurityLevel;
 
 // `setups` — the per-program setup-params entry the ND stream contract uses.
 pub use setups::UnrolledCircuitSetupParams;

--- a/tools/cli/src/prover_utils.rs
+++ b/tools/cli/src/prover_utils.rs
@@ -357,8 +357,6 @@ impl ProveBackend for CpuBackend {
 #[cfg(feature = "gpu")]
 pub struct GpuBackend {
     prover: gpu_execution_prover::ExecutionProver,
-    security_level: prover::definitions::SecurityLevel,
-    worker: worker::Worker,
     // Cache handles so ladder stages / batch items reuse per-binary GPU
     // precomputations instead of re-adding the same program.
     handles: std::collections::BTreeMap<(u8, u8, [u8; 32]), gpu_execution_prover::BinaryHandle>,
@@ -370,13 +368,10 @@ impl GpuBackend {
         let mut configuration = gpu_execution_prover::ExecutionProverConfiguration::default();
         configuration.replay_worker_threads_count = gpu.replay_worker_threads_count;
         configuration.security_level = COMPILED_SECURITY_LEVEL.to_prover();
-        let security_level = configuration.security_level;
         let prover = gpu_execution_prover::ExecutionProver::with_configuration(configuration)
             .map_err(|e| format!("failed to create GPU execution prover: {e:?}"))?;
         Ok(Self {
             prover,
-            security_level,
-            worker: worker::Worker::new(),
             handles: std::collections::BTreeMap::new(),
         })
     }
@@ -433,10 +428,7 @@ impl ProveBackend for GpuBackend {
         );
         let artifacts = self.prover.program_artifacts(&handle);
         Ok(gpu_program_prover::assemble_program_proof(
-            &artifacts,
-            result,
-            self.security_level,
-            &self.worker,
+            &artifacts, result,
         ))
     }
 }


### PR DESCRIPTION
## What ❔

`assemble_program_proof` now reads the per-family `Setups` caps from the GPU-computed `GpuGKRSetupHost` cache instead of recommitting every setup on the CPU. Synchronous `SetupInitialization` batches inside `ExecutionProver::with_configuration` / `add_binary` fill every setup lock (three-state: unfilled / host / no-columns) before those calls return; the proof path panics loudly on an unfilled lock. Drops the `worker`/`security_level`/Twiddles plumbing from assembly and the CLI.

## Why ❔

The GPU already computes the setup LDE, partial trees, and unified cap once per circuit; recommitting on the CPU at assembly time duplicated that work on every proof and trusted a separately-threaded security level nothing cross-checked. Detail lives in the commits.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
