### PR TITLE
fix(execution_prover): stream empty unified i&t markers during simulation

### DIFF
--- a/gpu/execution_prover/src/workers/cpu.rs
+++ b/gpu/execution_prover/src/workers/cpu.rs
@@ -2,7 +2,8 @@ use crate::messages::{InitsAndTeardownsData, SimulationResult, WorkerResult};
 use crate::tracing::{Tracer, TracingType};
 use crate::upstream::FinalRegisterValue;
 use crate::workers::simulation_runner::{
-    LockedBoxedMemoryHolder, LockedBoxedTraceChunk, SimulationRunner, Snapshot,
+    EmptyInitsAndTeardownsStreamer, LockedBoxedMemoryHolder, LockedBoxedTraceChunk,
+    SimulationRunner, Snapshot,
 };
 use crate::A;
 use common_constants::{TimestampScalar, INITIAL_TIMESTAMP, TIMESTAMP_STEP};
@@ -59,6 +60,18 @@ pub(crate) fn run_simulator<
         .lock()
         .expect("simulation worker non-determinism mutex poisoned");
     let non_determinism_source = non_determinism_guard.take().unwrap();
+    let ram_words = memory_holder.memory.len();
+    let carrier = if T::IS_SPLIT {
+        UnrolledCircuitType::InitsAndTeardowns
+    } else {
+        UnrolledCircuitType::Unified
+    };
+    let geometry = InitsAndTeardownsGeometry::new(carrier, ram_words);
+    let empty_it_streamer = (!T::IS_SPLIT).then(|| EmptyInitsAndTeardownsStreamer {
+        cycles_per_circuit: UnrolledCircuitType::Unified.get_domain_size(),
+        max_it_instances: geometry.max_instances(),
+        next_sequence_id: 0,
+    });
     let runner = SimulationRunner::<_, T>::new(
         batch_id,
         machine_type,
@@ -69,6 +82,7 @@ pub(crate) fn run_simulator<
         results,
         free_allocators.clone(),
         abort,
+        empty_it_streamer,
     );
     let runner = runner.run(
         binary_image,
@@ -84,6 +98,7 @@ pub(crate) fn run_simulator<
         abort,
         state,
         is_aborted,
+        empty_it_streamer,
         ..
     } = runner;
     *non_determinism_guard = Some(non_determinism_source);
@@ -92,33 +107,21 @@ pub(crate) fn run_simulator<
         assert!(!is_aborted);
         let results = results.unwrap();
         let instant = Instant::now();
-        let ram_words = memory_holder.memory.len();
         let inits_and_teardowns = collect_inits_and_teardowns(memory_holder, worker);
         let elapsed = instant.elapsed();
         let elapsed_ms = elapsed.as_secs_f64() * 1000.0;
         let count = inits_and_teardowns.iter().map(|v| v.len()).sum::<usize>();
         trace!("BATCH[{batch_id}] SIMULATOR collected INITS_AND_TEARDOWNS with {count} entries in {elapsed_ms:.3} ms");
         let mut instant = Instant::now();
-        let carrier = if T::IS_SPLIT {
-            UnrolledCircuitType::InitsAndTeardowns
-        } else {
-            UnrolledCircuitType::Unified
-        };
-        let geometry = InitsAndTeardownsGeometry::new(carrier, ram_words);
         let partitioning = InitsAndTeardownsPartitioning::new(inits_and_teardowns, geometry);
         let (circuit_type, sequence_id_offset) = if T::IS_SPLIT {
             (UnrolledCircuitType::InitsAndTeardowns, 0usize)
         } else {
-            // Unified mode: emit empty-circuit markers up-front so
-            // sequence_ids span the full circuit count. The orchestrator
-            // and replayer assume `sequence_id` runs `0..total_circuits`
-            // even for circuits that have no I&T data; without these
-            // prefill markers, sequence_ids would skip and the replayer's
-            // tracing results would not pair up.
-            // Under the `2^N`-row convention each unified circuit covers
-            // `domain_size` cycles (one cycle per usable row), which is also
-            // where the tracing producer slices its circuits
-            // (`cycles_per_circuit_for`), so both sides agree on the count.
+            // Unified mode: sequence_ids must span the full circuit count even
+            // for circuits with no I&T data, or the replayer's tracing results
+            // would not pair up. Each unified circuit covers `domain_size`
+            // cycles, matching where the tracing producer slices
+            // (`cycles_per_circuit_for`).
             let per_circuit_count = UnrolledCircuitType::Unified.get_domain_size();
             let timestamp_diff = state.timestamp - INITIAL_TIMESTAMP;
             assert!(timestamp_diff.is_multiple_of(TIMESTAMP_STEP));
@@ -133,7 +136,8 @@ pub(crate) fn run_simulator<
                  only spans {total_circuits} ({total_cycles} cycles)"
             );
             let empty_circuits = total_circuits - it_circuits;
-            for sequence_id in 0..empty_circuits {
+            let streamed = empty_it_streamer.map_or(0, |s| s.next_sequence_id);
+            for sequence_id in streamed..empty_circuits {
                 let data = InitsAndTeardownsData {
                     circuit_type: CircuitType::Unrolled(UnrolledCircuitType::Unified),
                     sequence_id,
@@ -341,6 +345,11 @@ struct InitsAndTeardownsGeometry {
 }
 
 impl InitsAndTeardownsGeometry {
+    /// Upper bound on `instances_count()` of any partitioning: every window touched.
+    fn max_instances(&self) -> usize {
+        (self.windows_in_ram as usize).div_ceil(self.num_sets)
+    }
+
     fn new(carrier: UnrolledCircuitType, ram_words: usize) -> Self {
         let trace_len_log2 = carrier.get_domain_size_log2();
         assert!(
@@ -591,6 +600,20 @@ mod cpu_partitioning_tests {
 
     fn windows_of(p: &InitsAndTeardownsPartitioning) -> Vec<u32> {
         p.window_schedule.iter().map(|(w, _)| *w).collect()
+    }
+
+    #[test]
+    fn cpu_unified_geometry_max_instances_bounds_any_partitioning() {
+        let geometry = unified_geometry();
+        assert_eq!(geometry.max_instances(), 16);
+        let records: Vec<_> = (0..geometry.windows_in_ram)
+            .map(|w| record_in(&geometry, w, 0))
+            .collect();
+        let all_windows_touched = partition(geometry, records);
+        assert_eq!(
+            all_windows_touched.instances_count(),
+            geometry.max_instances()
+        );
     }
 
     #[test]

--- a/gpu/execution_prover/src/workers/simulation_runner.rs
+++ b/gpu/execution_prover/src/workers/simulation_runner.rs
@@ -1,4 +1,4 @@
-use crate::messages::WorkerResult;
+use crate::messages::{InitsAndTeardownsData, WorkerResult};
 use crate::tracing::{DataTraceRanges, TracingDataProducers, TracingType};
 use crate::A;
 use common_constants::{INITIAL_TIMESTAMP, TIMESTAMP_STEP};
@@ -7,6 +7,7 @@ use era_cudart::memory::{CudaHostAllocFlags, CudaHostRegisterFlags, HostAllocati
 use era_cudart::result::CudaResultWrap;
 use era_cudart_sys::{cudaHostRegister, cudaHostUnregister};
 use gpu_core::primitives::machine_type::MachineType;
+use gpu_trace::witness::circuit_type::{CircuitType, UnrolledCircuitType};
 use itertools::Itertools;
 use log::{debug, trace};
 use riscv_transpiler::common_constants::ROM_WORD_SIZE;
@@ -128,6 +129,38 @@ pub(crate) struct Snapshot<R: DataTraceRanges> {
 // guarantee is documented on those types.
 unsafe impl<R: DataTraceRanges> Send for Snapshot<R> {}
 
+/// Streams the leading empty unified i&t markers during the run so tracing
+/// data can pair and dispatch instead of pinning host allocators until
+/// simulation ends. Sound without a guard: the i&t instances are the trailing
+/// `it_final <= max_it_instances` — an architectural bound no cycle or
+/// delegation burst can violate — so anything `max_it_instances` circuits
+/// behind the run front is provably empty.
+pub(crate) struct EmptyInitsAndTeardownsStreamer {
+    pub cycles_per_circuit: usize,
+    pub max_it_instances: usize,
+    pub next_sequence_id: usize,
+}
+
+impl EmptyInitsAndTeardownsStreamer {
+    fn release(&mut self, cycles_so_far: usize, results: &Sender<WorkerResult<A>>) {
+        let completed_circuits = cycles_so_far / self.cycles_per_circuit;
+        let frontier = completed_circuits.saturating_sub(self.max_it_instances);
+        while self.next_sequence_id < frontier {
+            let data = InitsAndTeardownsData {
+                circuit_type: CircuitType::Unrolled(UnrolledCircuitType::Unified),
+                sequence_id: self.next_sequence_id,
+                inits_and_teardowns: None,
+            };
+            results
+                .send(WorkerResult::InitsAndTeardownsData(data))
+                .expect(
+                    "simulation runner results channel closed while streaming empty init/teardown markers",
+                );
+            self.next_sequence_id += 1;
+        }
+    }
+}
+
 pub(crate) struct SimulationRunner<
     ND: NonDeterminismCSRSource + Send + 'static,
     T: TracingType + 'static,
@@ -144,6 +177,7 @@ pub(crate) struct SimulationRunner<
     pub trace: Option<LockedBoxedTraceChunk>,
     pub snapshot_index: usize,
     pub tracing_data_producers: Option<T::Producers>,
+    pub empty_it_streamer: Option<EmptyInitsAndTeardownsStreamer>,
     pub instant: Option<Instant>,
     pub total_elapsed: Duration,
     pub is_aborted: bool,
@@ -162,6 +196,7 @@ impl<ND: NonDeterminismCSRSource + Send + 'static, T: TracingType + 'static>
         results: Sender<WorkerResult<A>>,
         free_allocators: Receiver<A>,
         abort: Arc<AtomicBool>,
+        empty_it_streamer: Option<EmptyInitsAndTeardownsStreamer>,
     ) -> Self {
         let tracing_data_producers =
             T::Producers::new(machine_type, free_allocators, results.clone());
@@ -179,6 +214,7 @@ impl<ND: NonDeterminismCSRSource + Send + 'static, T: TracingType + 'static>
             trace: None,
             snapshot_index: 0,
             tracing_data_producers,
+            empty_it_streamer,
             instant: None,
             total_elapsed: Default::default(),
             is_aborted: false,
@@ -307,6 +343,12 @@ impl<ND: NonDeterminismCSRSource + Send + 'static, T: TracingType + 'static>
             self.is_aborted = true;
             return;
         }
+        if let (Some(streamer), Some(results)) =
+            (self.empty_it_streamer.as_mut(), self.results.as_ref())
+        {
+            let cycles_so_far = ((timestamp - INITIAL_TIMESTAMP) / TIMESTAMP_STEP) as usize;
+            streamer.release(cycles_so_far, results);
+        }
         let trace = self.trace.take().unwrap();
         let result = WorkerResult::SnapshotProduced;
         self.results
@@ -411,5 +453,44 @@ impl<ND: NonDeterminismCSRSource + Send + 'static, T: TracingType> ContextImpl
 
     fn final_state_ref(&'_ self) -> Option<&'_ MachineState> {
         unreachable!()
+    }
+}
+
+#[cfg(test)]
+mod cpu_streamer_tests {
+    use super::*;
+
+    #[test]
+    fn cpu_streamer_releases_only_provably_empty_markers() {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        let mut streamer = EmptyInitsAndTeardownsStreamer {
+            cycles_per_circuit: 1000,
+            max_it_instances: 3,
+            next_sequence_id: 0,
+        };
+        streamer.release(2999, &tx);
+        assert_eq!(streamer.next_sequence_id, 0);
+        streamer.release(4000, &tx);
+        assert_eq!(streamer.next_sequence_id, 1);
+        streamer.release(4000, &tx);
+        assert_eq!(streamer.next_sequence_id, 1);
+        streamer.release(10500, &tx);
+        assert_eq!(streamer.next_sequence_id, 7);
+        drop(tx);
+        let ids: Vec<usize> = rx
+            .iter()
+            .map(|result| match result {
+                WorkerResult::InitsAndTeardownsData(data) => {
+                    assert_eq!(
+                        data.circuit_type,
+                        CircuitType::Unrolled(UnrolledCircuitType::Unified)
+                    );
+                    assert!(data.inits_and_teardowns.is_none());
+                    data.sequence_id
+                }
+                _ => panic!("streamer sent an unexpected worker result"),
+            })
+            .collect();
+        assert_eq!(ids, (0..7).collect::<Vec<_>>());
     }
 }


### PR DESCRIPTION
## What ❔

Stream the leading *empty* unified inits-and-teardowns markers from the simulation loop instead of emitting all markers only after the VM run: a `sequence_id` is released once the run is `max_it = windows_in_ram / num_sets` circuits past it — the architectural bound on i&t instances, so no runtime guard is needed.

## Why ❔

Unified tracing data pins its host allocators until its i&t marker pairs it into a GPU request, and markers were only emitted post-run. Any unified layer past ~46 chunks (8 of the 384 pool allocators per 2^23-row chunk) drained the pool mid-simulation and deadlocked the pipeline. Streaming caps retention at `8 × (max_it + lag)` regardless of layer size. Proof bytes unchanged (verified byte-identical modulo `timings_ms`).

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.
