### PR TITLE
chore(agents): whitelist tracked entries, ignore all other agent artifacts

### DIFF
--- a/.agents/.gitignore
+++ b/.agents/.gitignore
@@ -1,6 +1,7 @@
-# Agent-generated artifacts (plans, specs, audits, reviews) — see ../AGENTS.md "Agent Artifact Locations".
-# Paths are relative to this .agents/ directory.
-.bus/
-/plans/
-/specs/
-/audits/
+# Agent-generated artifacts (plans, specs, audits, sdd ledgers, bus) are never committed —
+# see ../AGENTS.md "Agent Artifact Locations". Everything here is ignored except the
+# explicitly tracked entries below. Paths are relative to this .agents/ directory.
+/*
+!/bin
+!/.gitignore
+!/gpu_work.md


### PR DESCRIPTION
## What ❔

Replace `.agents/.gitignore`'s ignore-list (plans/specs/audits/.bus) with an allowlist: everything under `.agents/` is ignored except `bin/`, `gpu_work.md`, and the ignore file itself.

## Why ❔

The ignore-list missed `logs/` and `sdd/`, which let 1003 agent-scratch files (including a 28 MB proof artifact) reach a PR via a careless `git add -A`. The allowlist makes that structurally impossible. Cherry-picked from `rr/gkr_uniskip_bench`, where it was authored but never merged.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.