### PR TITLE
fix(gpu): regenerate witness CUDA with verifiers

### DIFF
--- a/recreate_verifiers.sh
+++ b/recreate_verifiers.sh
@@ -26,17 +26,16 @@ for CIRCUIT_NAME in "${circuit_names[@]}"; do
     echo $CIRCUIT_NAME
 
     (cd circuit_defs/${CIRCUIT_NAME} && RUST_MIN_STACK=100000000 cargo test generate)
-    cd -
 done
 
 for CIRCUIT_NAME in "${unrolled_circuit_names[@]}"; do
     echo $CIRCUIT_NAME
 
     (cd circuit_defs/unrolled_circuits/${CIRCUIT_NAME} && RUST_MIN_STACK=100000000 cargo test generate)
-    cd -
 done
 
 (cd circuit_defs/setups && RUST_MIN_STACK=100000000 cargo test --release generate_delegation_circuits_artifacts)
-cd -
+
+cargo run -p gpu_witness_eval_generator --bin regenerate_committed
 
 (cargo test -p verifier_generator --no-default-features --test generate_verifiers)


### PR DESCRIPTION
## What ❔

Run `gpu_witness_eval_generator` from `recreate_verifiers.sh` and remove redundant `cd -` calls after subshells.

## Why ❔

Include committed GPU witness CUDA in the existing generated-artifact freshness workflow and allow the script to run from outside the repository.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Existing generation tests cover this change; no new test code is needed.
- [x] Documentation comments are not applicable to this script-only change.