### PR TITLE
perf(gpu_hash): fuse physical partial Merkle tree

### DIFF
--- a/gpu/AGENTS.md
+++ b/gpu/AGENTS.md
@@ -218,11 +218,12 @@ from upstream library code (`full_statement_verifier::host_utils` /
   kernel). When an order conversion is required, move it to an axis where a
   permutation is free: a warp-uniform index (row slot within a leaf, coset), a
   32-byte digest slot (sector-aligned, same DRAM sectors scattered as
-  coalesced), or query/cap emission (tiny). Splitting one fused kernel into a
-  contiguous bulk pass plus a permuted digest pass is the accepted pattern
-  (`ab_blake2s_partial_tree_from_physical_digests_kernel`, the staged WHIR
-  leaf/reduce kernels). Review question for any new commitment kernel: does any
-  lane index feeding a VALUES pointer pass through `bitreverse_low_bits`?
+  coalesced), or query/cap emission (tiny). The physical partial-tree builder
+  (`ab_blake2s_partial_tree_multi_coset_physical_kernel`) enumerates boundary
+  roots in physical order and keeps the within-root leaf offset warp-uniform;
+  staged WHIR leaf/reduce kernels instead split the contiguous bulk pass from
+  the permuted digest pass. Review question for any new commitment kernel: does
+  any lane index feeding a VALUES pointer pass through `bitreverse_low_bits`?
 
 ## Profiling
 

--- a/gpu/circuit_prover/src/tests/lsb_commit_pipeline.rs
+++ b/gpu/circuit_prover/src/tests/lsb_commit_pipeline.rs
@@ -243,15 +243,8 @@ fn gpu_commit_and_query(
                 let layers_count = shape.log_leaves_count() + 1
                     - PARTIAL_TREE_REDUCTION_LAYERS
                     - shape.log_subtree_cap_size();
-                let mut staging = context
-                    .alloc::<Digest>(
-                        cosets_count << shape.log_leaves_count(),
-                        AllocationPlacement::BestFit,
-                    )
-                    .unwrap();
                 build_partial_merkle_tree_multi_coset_physical(
                     &cosets[..],
-                    &mut staging,
                     &mut backing[..],
                     shape.log_rows_per_leaf,
                     layers_count,

--- a/gpu/hash/native/hash.cu
+++ b/gpu/hash/native/hash.cu
@@ -180,14 +180,21 @@ EXTERN __launch_bounds__(256) __global__
 }
 
 DEVICE_FORCEINLINE digest hash_node(const digest &left, const digest &right) {
-  digest children[2];
-  children[0] = left;
-  children[1] = right;
+  digest children[2] = {left, right};
   digest state;
   initialize(state.words);
   u32 t = 0;
   compress<true>(state.words, t, reinterpret_cast<const u32 *>(children), BLOCK_SIZE);
   return state;
+}
+
+template <unsigned LEVEL> DEVICE_FORCEINLINE bool insert_merkle_node(digest (&pending)[LOG_WARP_SIZE], digest &node, const unsigned leaf) {
+  if ((leaf & (1u << LEVEL)) == 0) {
+    pending[LEVEL] = node;
+    return true;
+  }
+  node = hash_node(pending[LEVEL], node);
+  return false;
 }
 
 // Fused LSB partial-tree builder. One thread produces one boundary root from
@@ -215,43 +222,22 @@ EXTERN __launch_bounds__(128) __global__
   const unsigned coset = root_global >> log_roots_per_coset;
   const unsigned physical_root = root_global & (roots_per_coset - 1u);
 
-  digest level_0;
-  digest level_1;
-  digest level_2;
-  digest level_3;
-  digest level_4;
+  digest pending[LOG_WARP_SIZE];
   digest node;
 #pragma unroll 1
   for (unsigned t = 0; t < LEAVES_PER_ROOT; t++) {
     const unsigned physical_leaf = (bitreverse_low_bits(t, LOG_WARP_SIZE) << log_roots_per_coset) | physical_root;
     const unsigned leaf_global = (coset << log_per_coset_count) | physical_leaf;
     node = hash_leaf_multi_coset_physical(values, log_rows_count, cols_count, log_per_coset_count, per_coset_values_stride_bf, leaf_global);
-
-    if ((t & 1u) == 0) {
-      level_0 = node;
+    if (insert_merkle_node<0>(pending, node, t))
       continue;
-    }
-    node = hash_node(level_0, node);
-    if ((t & 3u) != 3u) {
-      level_1 = node;
+    if (insert_merkle_node<1>(pending, node, t))
       continue;
-    }
-    node = hash_node(level_1, node);
-    if ((t & 7u) != 7u) {
-      level_2 = node;
+    if (insert_merkle_node<2>(pending, node, t))
       continue;
-    }
-    node = hash_node(level_2, node);
-    if ((t & 15u) != 15u) {
-      level_3 = node;
+    if (insert_merkle_node<3>(pending, node, t))
       continue;
-    }
-    node = hash_node(level_3, node);
-    if ((t & 31u) != 31u) {
-      level_4 = node;
-      continue;
-    }
-    node = hash_node(level_4, node);
+    insert_merkle_node<4>(pending, node, t);
   }
 
   const unsigned logical_root = bitreverse_low_bits(physical_root, log_roots_per_coset);

--- a/gpu/hash/native/hash.cu
+++ b/gpu/hash/native/hash.cu
@@ -179,55 +179,84 @@ EXTERN __launch_bounds__(256) __global__
   }
 }
 
-// LSB sibling of the reduction half of `ab_blake2s_partial_tree_multi_coset_kernel`,
-// operating on leaf DIGESTS that `ab_blake2s_leaves_multi_coset_physical_kernel`
-// already hashed block-contiguously from the BITREVERSED-order codeword.
-// INVARIANT: a hashing kernel must never permute its lane->leaf axis over the
-// leaf VALUES (scattered value reads are catastrophic); the logical->physical
-// translation instead rides this 32-byte digest axis, where a scattered
-// sector-aligned load costs the same DRAM sectors as a coalesced one. Each
-// lane loads logical leaf `l` from physical digest slot `bitreverse(l)` inside
-// its own coset; the reducer and the root placement are byte-identical to the
-// natural-order builder's.
+DEVICE_FORCEINLINE digest hash_node(const digest &left, const digest &right) {
+  digest children[2];
+  children[0] = left;
+  children[1] = right;
+  digest state;
+  initialize(state.words);
+  u32 t = 0;
+  compress<true>(state.words, t, reinterpret_cast<const u32 *>(children), BLOCK_SIZE);
+  return state;
+}
+
+// Fused LSB partial-tree builder. One thread produces one boundary root from
+// 32 logical leaves without materializing their digests. Threads enumerate
+// roots in PHYSICAL order; for a warp-uniform logical offset `t`, consecutive
+// lanes therefore read consecutive physical leaf blocks at
 //
-// Valid only while a CTA's 512 leaves stay inside one coset
-// (`log_per_coset_count >= 9`), which the launcher asserts.
-EXTERN __launch_bounds__(256) __global__
-    void ab_blake2s_partial_tree_from_physical_digests_kernel(const u32 *leaf_digests, u32 *tree_backing, const unsigned log_per_coset_count,
-                                                              const unsigned per_coset_digests_stride, const unsigned per_coset_tree_stride_digests,
-                                                              const unsigned count) {
-  constexpr unsigned ROOTS_PER_BLOCK = 16;
-  constexpr unsigned LEAVES_PER_BLOCK = ROOTS_PER_BLOCK << LOG_WARP_SIZE;
-  const unsigned leaf_base = blockIdx.x * LEAVES_PER_BLOCK;
-  const unsigned valid_leaves = min(LEAVES_PER_BLOCK, count - leaf_base);
-  extern __shared__ __align__(32) uint8_t reducer_smem[];
-  auto shared_values = reinterpret_cast<digest *>(reducer_smem);
+//   bitreverse(t, 5) * roots_per_coset + physical_root.
+//
+// Only the final 32-byte root store is permuted back to logical order, so the
+// existing upper tree and query-path layout stay byte-identical to the natural
+// builder while the bulk values reads never permute the lane axis.
+EXTERN __launch_bounds__(128) __global__
+    void ab_blake2s_partial_tree_multi_coset_physical_kernel(const bf *values, u32 *tree_backing, const unsigned log_rows_count, const unsigned cols_count,
+                                                             const unsigned log_per_coset_count, const unsigned per_coset_values_stride_bf,
+                                                             const unsigned per_coset_tree_stride_digests, const unsigned count) {
+  constexpr unsigned LEAVES_PER_ROOT = 1u << LOG_WARP_SIZE;
+  const unsigned roots_count = count >> LOG_WARP_SIZE;
+  const unsigned root_global = threadIdx.x + blockIdx.x * blockDim.x;
+  if (root_global >= roots_count)
+    return;
 
-  const unsigned per_coset_count = 1u << log_per_coset_count;
-  auto load_logical = [=](const unsigned leaf_logical) {
-    const unsigned coset = leaf_logical >> log_per_coset_count;
-    const unsigned l = leaf_logical & (per_coset_count - 1u);
-    const unsigned j = bitreverse_low_bits(l, log_per_coset_count);
-    return load_cs(reinterpret_cast<const digest *>(leaf_digests) + static_cast<size_t>(coset) * per_coset_digests_stride + j);
-  };
+  const unsigned log_roots_per_coset = log_per_coset_count - LOG_WARP_SIZE;
+  const unsigned roots_per_coset = 1u << log_roots_per_coset;
+  const unsigned coset = root_global >> log_roots_per_coset;
+  const unsigned physical_root = root_global & (roots_per_coset - 1u);
 
-  const unsigned leaf = leaf_base + threadIdx.x;
-  if (threadIdx.x < valid_leaves)
-    shared_values[threadIdx.x] = load_logical(leaf);
-  if (threadIdx.x + blockDim.x < valid_leaves)
-    shared_values[threadIdx.x + blockDim.x] = load_logical(leaf + blockDim.x);
-  __syncthreads();
+  digest level_0;
+  digest level_1;
+  digest level_2;
+  digest level_3;
+  digest level_4;
+  digest node;
+#pragma unroll 1
+  for (unsigned t = 0; t < LEAVES_PER_ROOT; t++) {
+    const unsigned physical_leaf = (bitreverse_low_bits(t, LOG_WARP_SIZE) << log_roots_per_coset) | physical_root;
+    const unsigned leaf_global = (coset << log_per_coset_count) | physical_leaf;
+    node = hash_leaf_multi_coset_physical(values, log_rows_count, cols_count, log_per_coset_count, per_coset_values_stride_bf, leaf_global);
 
-  reduce_merkle_subtrees_block(shared_values, valid_leaves >> 1);
-  const unsigned valid_roots = valid_leaves >> LOG_WARP_SIZE;
-  if (threadIdx.x < valid_roots) {
-    const unsigned global_root = blockIdx.x * ROOTS_PER_BLOCK + threadIdx.x;
-    const unsigned log_roots_per_coset = log_per_coset_count - LOG_WARP_SIZE;
-    const unsigned coset = global_root >> log_roots_per_coset;
-    const unsigned root_in_coset = global_root & ((1u << log_roots_per_coset) - 1u);
-    auto roots = reinterpret_cast<digest *>(tree_backing) + static_cast<size_t>(coset) * per_coset_tree_stride_digests;
-    store_cs(roots + root_in_coset, shared_values[threadIdx.x]);
+    if ((t & 1u) == 0) {
+      level_0 = node;
+      continue;
+    }
+    node = hash_node(level_0, node);
+    if ((t & 3u) != 3u) {
+      level_1 = node;
+      continue;
+    }
+    node = hash_node(level_1, node);
+    if ((t & 7u) != 7u) {
+      level_2 = node;
+      continue;
+    }
+    node = hash_node(level_2, node);
+    if ((t & 15u) != 15u) {
+      level_3 = node;
+      continue;
+    }
+    node = hash_node(level_3, node);
+    if ((t & 31u) != 31u) {
+      level_4 = node;
+      continue;
+    }
+    node = hash_node(level_4, node);
   }
+
+  const unsigned logical_root = bitreverse_low_bits(physical_root, log_roots_per_coset);
+  auto roots = reinterpret_cast<digest *>(tree_backing) + static_cast<size_t>(coset) * per_coset_tree_stride_digests;
+  store_cs(roots + logical_root, node);
 }
 
 // Fused leaves-from-NTT kernel: reads the natural multi-coset NTT output and

--- a/gpu/hash/src/blake2s/merkle.rs
+++ b/gpu/hash/src/blake2s/merkle.rs
@@ -10,7 +10,7 @@ use era_cudart::stream::CudaStream;
 use gpu_core::primitives::field::BF;
 use gpu_core::primitives::utils::WARP_SIZE;
 
-use super::hash::{hash_leaves, hash_leaves_multi_coset, hash_leaves_multi_coset_physical};
+use super::hash::{hash_leaves, hash_leaves_multi_coset};
 use super::{checked_u32, Digest};
 
 cuda_kernel!(
@@ -330,34 +330,33 @@ pub fn build_partial_merkle_tree_multi_coset(
 }
 
 cuda_kernel!(
-    PartialTreeFromPhysicalDigests,
-    ab_blake2s_partial_tree_from_physical_digests_kernel(
-        leaf_digests: *const Digest,
+    PartialTreeMultiCosetPhysical,
+    ab_blake2s_partial_tree_multi_coset_physical_kernel(
+        values: *const BF,
         tree_backing: *mut Digest,
+        log_rows_per_hash: u32,
+        cols_count: u32,
         log_per_coset_count: u32,
-        per_coset_digests_stride: u32,
+        per_coset_values_stride_bf: u32,
         per_coset_tree_stride_digests: u32,
         count: u32,
     )
 );
 
 /// LSB sibling of [`build_partial_merkle_tree_multi_coset`]: `values` is in
-/// BITREVERSED row order. Leaf hashing reads each physically contiguous leaf
-/// block in storage order into `leaf_digests` (a transient buffer of
-/// `per_coset_leaves_count` digests per coset); the bottom reduction then pairs
-/// logical siblings by loading logical leaf `l` from physical digest slot
-/// `bitreverse(l)`, so no leaf-values read is ever permuted.
+/// BITREVERSED row order. Each thread reads the 32 physical leaf blocks for one
+/// logical boundary root, folds them in registers, and writes only that root.
+/// Threads enumerate roots in physical order, so the leaf offset permutation is
+/// warp-uniform and the lane axis feeding `values` stays contiguous.
 pub fn build_partial_merkle_tree_multi_coset_physical(
     values: &DeviceSlice<BF>,
-    leaf_digests: &mut DeviceSlice<Digest>,
     tree_backing: &mut DeviceSlice<Digest>,
     log_rows_per_hash: u32,
     layers_count: u32,
     cosets_in_tile: usize,
     stream: &CudaStream,
 ) -> CudaResult<()> {
-    const THREADS_PER_BLOCK: u32 = 256;
-    const LEAVES_PER_BLOCK: u32 = 512;
+    const THREADS_PER_BLOCK: u32 = 128;
     const REDUCTION_LAYERS: u32 = WARP_SIZE.trailing_zeros();
 
     assert_ne!(layers_count, 0);
@@ -367,12 +366,9 @@ pub fn build_partial_merkle_tree_multi_coset_physical(
     let per_coset_tree_stride_digests = tree_backing.len() / cosets_in_tile;
     assert!(per_coset_tree_stride_digests.is_power_of_two());
     let per_coset_leaves_count = per_coset_tree_stride_digests << (REDUCTION_LAYERS - 1);
-    // A CTA reduces one contiguous run of 512 LOGICAL leaves, and the physical
-    // digest-slot translation below is only coset-local for a CTA that stays
-    // inside one coset.
     assert!(
-        per_coset_leaves_count.trailing_zeros() >= LEAVES_PER_BLOCK.trailing_zeros(),
-        "each 512-leaf CTA must stay inside one coset ({per_coset_leaves_count} leaves per coset)"
+        per_coset_leaves_count.trailing_zeros() >= REDUCTION_LAYERS,
+        "a partial-tree boundary root needs {WARP_SIZE} leaves ({per_coset_leaves_count} leaves per coset)"
     );
     assert!(layers_count <= per_coset_tree_stride_digests.trailing_zeros());
     let boundary_roots_per_coset = per_coset_leaves_count >> REDUCTION_LAYERS;
@@ -387,35 +383,24 @@ pub fn build_partial_merkle_tree_multi_coset_physical(
     let total_leaves_usize = per_coset_leaves_count
         .checked_mul(cosets_in_tile)
         .expect("partial tree leaves count overflow");
-    assert_eq!(leaf_digests.len(), total_leaves_usize);
-    hash_leaves_multi_coset_physical(
-        values,
-        leaf_digests,
-        log_rows_per_hash,
-        cosets_in_tile,
-        per_coset_leaves_count,
-        per_coset_values_stride_bf,
-        per_coset_leaves_count,
-        cols_count,
-        stream,
-    )?;
-
     let total_leaves = checked_u32(total_leaves_usize);
-    let mut config = CudaLaunchConfig::basic(
-        total_leaves.div_ceil(LEAVES_PER_BLOCK),
+    let total_roots = total_leaves >> REDUCTION_LAYERS;
+    let config = CudaLaunchConfig::basic(
+        total_roots.div_ceil(THREADS_PER_BLOCK),
         THREADS_PER_BLOCK,
         stream,
     );
-    config.dynamic_smem_bytes = LEAVES_PER_BLOCK as usize * core::mem::size_of::<Digest>();
-    let args = PartialTreeFromPhysicalDigestsArguments::new(
-        leaf_digests.as_ptr(),
+    let args = PartialTreeMultiCosetPhysicalArguments::new(
+        values.as_ptr(),
         tree_backing.as_mut_ptr(),
+        log_rows_per_hash,
+        checked_u32(cols_count),
         per_coset_leaves_count.trailing_zeros(),
-        checked_u32(per_coset_leaves_count),
+        checked_u32(per_coset_values_stride_bf),
         checked_u32(per_coset_tree_stride_digests),
         total_leaves,
     );
-    PartialTreeFromPhysicalDigestsFunction::default().launch(&config, &args)?;
+    PartialTreeMultiCosetPhysicalFunction::default().launch(&config, &args)?;
     build_merkle_tree_nodes_multi_coset(
         tree_backing,
         layers_count - 1,

--- a/gpu/hash/src/blake2s/tests/physical_partial_tree_tests.rs
+++ b/gpu/hash/src/blake2s/tests/physical_partial_tree_tests.rs
@@ -9,10 +9,8 @@ use super::{bitreverse_index, random_digest};
 use crate::upstream::{Blake2sState, USE_REDUCED_BLAKE2_ROUNDS};
 use gpu_core::primitives::utils::LOG_WARP_SIZE;
 
-/// `(log_rows_per_coset, log_rows_per_hash, cosets_count)`. Every entry keeps
-/// `log_leaves_per_coset >= 9`, so a 512-leaf CTA never spans two cosets — the
-/// only regime the partial-tree kernels are valid in.
-const SHAPES: [(u32, u32, usize); 2] = [(11, 1, 2), (14, 5, 2)];
+/// `(log_rows_per_coset, log_rows_per_hash, cosets_count)`.
+const SHAPES: [(u32, u32, usize); 3] = [(8, 0, 2), (11, 1, 2), (14, 5, 2)];
 const COLS_COUNTS: [usize; 2] = [1, 3];
 const LOG_CAPS: [u32; 2] = [0, 2];
 
@@ -34,9 +32,9 @@ pub(super) fn host_layer_above(layer: &[Digest]) -> Vec<Digest> {
         .collect()
 }
 
-/// One coset's partial-tree backing as the GPU lays it out: the CTA reduction
-/// roots (`LOG_WARP_SIZE` layers above the leaves) followed by every node layer
-/// the tower writes, `layers_count` layers in total.
+/// One coset's partial-tree backing as the GPU lays it out: the fused boundary
+/// roots (`LOG_WARP_SIZE` layers above the leaves) followed by every cached node
+/// layer through the cap, `layers_count` layers in total.
 fn host_partial_tower(leaves: &[Digest], layers_count: u32) -> Vec<Digest> {
     let mut layer = leaves.to_vec();
     for _ in 0..LOG_WARP_SIZE {
@@ -59,7 +57,7 @@ fn check_partial_tree(
     log_cap: u32,
 ) {
     let log_leaves_count = log_rows_per_coset - log_rows_per_hash;
-    assert!(log_leaves_count >= 9);
+    assert!(log_leaves_count >= LOG_WARP_SIZE);
     let rows_count = 1usize << log_rows_per_coset;
     let leaves_count = 1usize << log_leaves_count;
     let values_stride = cols_count * rows_count;
@@ -95,11 +93,8 @@ fn check_partial_tree(
         stream,
     )
     .unwrap();
-    let mut staging_device =
-        DeviceAllocation::<Digest>::alloc(leaves_count * cosets_count).unwrap();
     build_partial_merkle_tree_multi_coset_physical(
         &physical_device[..physical.len()],
-        &mut staging_device,
         &mut new_device,
         log_rows_per_hash,
         layers_count,
@@ -180,29 +175,4 @@ fn physical_partial_tree_matches_old_kernel() {
             }
         }
     }
-}
-
-#[test]
-#[should_panic(expected = "one coset")]
-fn physical_partial_tree_rejects_cta_spanning_cosets() {
-    let stream = CudaStream::default();
-    let (log_rows_per_coset, log_rows_per_hash, cosets_count, cols_count) = (8u32, 0u32, 2usize, 1);
-    let rows_count = 1usize << log_rows_per_coset;
-    let leaves_count = rows_count >> log_rows_per_hash;
-    let tree_stride = (leaves_count << 1) >> LOG_WARP_SIZE;
-    let values = random_values(cols_count * rows_count * cosets_count);
-    let values_device = upload(&values, &stream);
-    let mut tree_device = DeviceAllocation::<Digest>::alloc(tree_stride * cosets_count).unwrap();
-    let mut staging_device =
-        DeviceAllocation::<Digest>::alloc(leaves_count * cosets_count).unwrap();
-    build_partial_merkle_tree_multi_coset_physical(
-        &values_device[..values.len()],
-        &mut staging_device,
-        &mut tree_device,
-        log_rows_per_hash,
-        log_rows_per_coset + 1 - LOG_WARP_SIZE,
-        cosets_count,
-        &stream,
-    )
-    .unwrap();
 }

--- a/gpu/hash/src/blake2s/tests/physical_query_gather_tests.rs
+++ b/gpu/hash/src/blake2s/tests/physical_query_gather_tests.rs
@@ -317,10 +317,8 @@ fn check_partial_path_gather(
             stream,
         )
         .unwrap();
-        let mut staging = DeviceAllocation::<Digest>::alloc(leaves_count * cosets_count).unwrap();
         build_partial_merkle_tree_multi_coset_physical(
             &physical_device[..physical.len()],
-            &mut staging,
             &mut new_tree,
             log_rows_per_hash,
             builder_layers_count,
@@ -589,10 +587,8 @@ fn check_paths_from_rows(
         stream,
     )
     .unwrap();
-    let mut staging = DeviceAllocation::<Digest>::alloc(leaves_count).unwrap();
     build_partial_merkle_tree_multi_coset_physical(
         &physical_device[..physical.len()],
-        &mut staging,
         &mut new_tree,
         log_rows_per_hash,
         builder_layers_count,

--- a/gpu/trace/src/trace/holder/mod.rs
+++ b/gpu/trace/src/trace/holder/mod.rs
@@ -568,11 +568,6 @@ impl TraceHolder<BF> {
                 )?;
             }
             TreesHolder::Partial(backing) => {
-                // Freed on scope exit, after all launches are enqueued.
-                let mut leaf_digests: DeviceAllocation<Digest> = context.alloc(
-                    lde_factor << (log_domain_size - log_rows_per_leaf),
-                    AllocationPlacement::BestFit,
-                )?;
                 build_partial_trees_from_physical(
                     evals_backing,
                     backing,
@@ -582,7 +577,6 @@ impl TraceHolder<BF> {
                     log_tree_cap_size,
                     columns_count,
                     lde_factor,
-                    &mut leaf_digests,
                     stream,
                 )?;
             }
@@ -724,10 +718,6 @@ impl TraceHolder<BF> {
             TreesHolder::Partial(backing) => backing,
             _ => panic!("build_and_cache_partial_trees requires TreesHolder::Partial"),
         };
-        let mut leaf_digests: DeviceAllocation<Digest> = context.alloc(
-            instances_count << (log_domain_size - log_rows_per_leaf),
-            AllocationPlacement::BestFit,
-        )?;
         build_partial_trees_from_physical(
             evals_backing,
             trees_backing,
@@ -737,7 +727,6 @@ impl TraceHolder<BF> {
             log_tree_cap_size,
             columns_count,
             instances_count,
-            &mut leaf_digests,
             stream,
         )?;
         Ok(())
@@ -1184,8 +1173,9 @@ pub(crate) fn commit_trace_with_partial_tree_multi_coset(
 }
 
 /// LSB sibling of [`commit_trace_with_partial_tree_multi_coset`]: each coset
-/// slab is the BITREVERSED-order codeword, so the warp-level bottom reduction
-/// reads logical leaf `l` from physical block `bitreverse(l)`. The result is
+/// slab is the BITREVERSED-order codeword. The fused bottom-five-level kernel
+/// writes logical boundary roots, then the ordinary node builder materializes
+/// every cached level through the cap. The result and cached query subtree are
 /// byte-identical to [`commit_trace_with_partial_tree_multi_coset`] over the
 /// natural-order codeword.
 #[doc(hidden)]
@@ -1198,7 +1188,6 @@ pub fn build_partial_trees_from_physical(
     log_tree_cap_size: u32,
     columns_count: usize,
     cosets_in_tile: usize,
-    leaf_digests: &mut DeviceSlice<Digest>,
     stream: &CudaStream,
 ) -> CudaResult<()> {
     assert!(log_tree_cap_size >= log_lde_factor);
@@ -1216,10 +1205,8 @@ pub fn build_partial_trees_from_physical(
         - log_rows_per_leaf
         - PARTIAL_TREE_REDUCTION_LAYERS
         - log_coset_tree_cap_size;
-    assert_eq!(leaf_digests.len(), per_coset_leaves_count * cosets_in_tile);
     build_partial_merkle_tree_multi_coset_physical(
         evals_backing,
-        leaf_digests,
         tree_backing,
         log_rows_per_leaf,
         layers_count,


### PR DESCRIPTION
## What ❔

Fuse physical-order leaf hashing with the bottom five Merkle levels. This removes the transient full leaf-digest buffer while retaining the cached subtree from level 5 through the cap and preserving byte-identical caps and query paths.

## Why ❔

The LSB migration added a global digest round trip and a second reduction launch. The fused builder reduces complete cached partial-tree construction from 4.603 ms to 4.468 ms versus the pre-migration baseline, and recovers 3.20 ms from the migrated full-proof path.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.