### PR TITLE
fix(ci): run GPU serialization guard in GPU workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
           CI: "true"
           RUST_MIN_STACK: 16777216
         run: cargo test -p prover --profile cli -- --nocapture gkr_run_basic_unrolled_test_sec_100
-      - name: GPU test serialization drift guard
-        run: cargo test -p gpu_core --profile cli cpu_nextest_config_covers_all_gpu_crates
       - name: GKR compiler feature tests
         env:
           RUST_MIN_STACK: 16777216

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -51,6 +51,9 @@ jobs:
         run: |
           nvcc --version
 
+      - name: GPU test serialization drift guard
+        run: cargo +$RUST_TOOLCHAIN test -p gpu_core --release --target x86_64-unknown-linux-gnu cpu_nextest_config_covers_all_gpu_crates
+
       - name: Build CLI and GPU tests
         shell: bash
         run: |


### PR DESCRIPTION
## What ❔

Move the GPU test serialization drift guard from generic Rust CI to the CUDA devel build in the GPU workflow.

## Why ❔

The guard compiles `gpu_core`; the generic runner has no detectable CUDA toolkit and fails before the CPU-only test runs. The GPU build job provides the required toolkit and already gates `gpu-checks`.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] The existing drift guard covers the change and passes in its relocated configuration.
- [x] Documentation comments are not applicable to this workflow-only change.
- [x] Workflow YAML parses successfully and the diff passes whitespace checks.
