### PR TITLE
fix(recursion): recalibrate Sec100 verifier costs

### DIFF
--- a/full_statement_verifier/src/host_utils/cost_model/census.rs
+++ b/full_statement_verifier/src/host_utils/cost_model/census.rs
@@ -3,8 +3,16 @@
 //! partition total cycles. No i&t dim: always 1 on unrolled recursion layers,
 //! inline on unified.
 //!
-//! Sec80 guests only. Regenerate via `emit_census_tables` when a guest
-//! changes. blake2 g-function is unpriced → `UnpricedCircuit`.
+//! The committed table is calibrated for the Sec100 Compression verifier
+//! programs. Regenerate it locally via `emit_census_tables` when a guest
+//! changes; see that test for fixture generation. blake2 g-function is
+//! unpriced → `UnpricedCircuit`.
+//!
+//! `CENSUS_TABLES` is currently keyed by `(FsvProgram, BlakeMode)`, not
+//! `SecurityLevel`, because every active `FsvProgram` resolves to the sole
+//! Sec100 verifier set. Adding another security level requires extending the
+//! estimator key and calibrating a separate table; Sec100 coefficients must not
+//! be reused for it.
 
 use super::{proof_counts, CircuitId, EstimateError};
 use crate::program_proof::ProgramProof;
@@ -103,43 +111,43 @@ pub static CENSUS_TABLES: &[(FsvProgram, BlakeMode, CensusTable)] = &[
         FsvProgram::UnrolledBaseLayer,
         BlakeMode::Compression,
         CensusTable {
-            c0: [454009, 56003, 32149, 0, 287238, 0, 25746, 0, 0, 0],
+            c0: [565278, 70809, 42335, 0, 330374, 0, 32872, 0, 0, 0],
             v: &[
                 (
                     CircuitId::Riscv(1),
-                    [522423, 59420, 36769, 0, 218194, 0, 43645, 0, 0, 0],
+                    [637992, 77394, 48384, 0, 267897, 0, 57484, 0, 0, 0],
                 ),
                 (
                     CircuitId::Riscv(2),
-                    [536122, 60337, 37061, 0, 226872, 0, 44555, 0, 0, 0],
+                    [653666, 78524, 48657, 0, 277832, 0, 58730, 0, 0, 0],
                 ),
                 (
                     CircuitId::Riscv(3),
-                    [543888, 61141, 37396, 0, 229454, 0, 44625, 0, 0, 0],
+                    [662737, 79347, 48950, 0, 281888, 0, 58800, 0, 0, 0],
                 ),
                 (
                     CircuitId::Riscv(4),
-                    [535569, 60406, 38577, 0, 225300, 0, 44170, 0, 0, 0],
+                    [651119, 78484, 50225, 0, 274923, 0, 58177, 0, 0, 0],
                 ),
                 (
                     CircuitId::Riscv(16),
-                    [514011, 58893, 37056, 0, 218622, 0, 43652, 0, 0, 0],
+                    [626727, 76766, 48652, 0, 267016, 0, 57491, 0, 0, 0],
                 ),
                 (
                     CircuitId::Riscv(17),
-                    [524806, 59571, 37260, 0, 222573, 0, 44121, 0, 0, 0],
+                    [639292, 77496, 48985, 0, 272097, 0, 58128, 0, 0, 0],
                 ),
                 (
                     CircuitId::Delegation(1991),
-                    [1517337, 129358, 46803, 0, 635083, 0, 83475, 0, 0, 0],
+                    [1919497, 164176, 57240, 0, 799263, 0, 111489, 0, 0, 0],
                 ),
                 (
                     CircuitId::Delegation(1994),
-                    [811680, 74387, 41698, 0, 335707, 0, 51688, 0, 0, 0],
+                    [1006439, 95029, 52310, 0, 414521, 0, 68432, 0, 0, 0],
                 ),
                 (
                     CircuitId::Delegation(1995),
-                    [797932, 73985, 40196, 0, 328734, 0, 51170, 0, 0, 0],
+                    [996938, 94891, 50844, 0, 408702, 0, 67914, 0, 0, 0],
                 ),
             ],
         },
@@ -148,35 +156,35 @@ pub static CENSUS_TABLES: &[(FsvProgram, BlakeMode, CensusTable)] = &[
         FsvProgram::UnrolledRecursionLayer,
         BlakeMode::Compression,
         CensusTable {
-            c0: [451345, 55433, 31734, 0, 278849, 0, 25620, 0, 0, 0],
+            c0: [563484, 70945, 41716, 0, 322001, 0, 32746, 0, 0, 0],
             v: &[
                 (
                     CircuitId::Riscv(1),
-                    [522423, 59420, 36769, 0, 218194, 0, 43645, 0, 0, 0],
+                    [637992, 77394, 48384, 0, 267897, 0, 57484, 0, 0, 0],
                 ),
                 (
                     CircuitId::Riscv(2),
-                    [536122, 60337, 37061, 0, 226872, 0, 44555, 0, 0, 0],
+                    [653666, 78524, 48657, 0, 277832, 0, 58730, 0, 0, 0],
                 ),
                 (
                     CircuitId::Riscv(3),
-                    [543888, 61141, 37396, 0, 229454, 0, 44625, 0, 0, 0],
+                    [662737, 79347, 48950, 0, 281888, 0, 58800, 0, 0, 0],
                 ),
                 (
                     CircuitId::Riscv(16),
-                    [514011, 58893, 37056, 0, 218622, 0, 43652, 0, 0, 0],
+                    [626727, 76766, 48652, 0, 267016, 0, 57491, 0, 0, 0],
                 ),
                 (
                     CircuitId::Delegation(1991),
-                    [1517337, 129358, 46803, 0, 635083, 0, 83475, 0, 0, 0],
+                    [1919497, 164176, 57240, 0, 799263, 0, 111489, 0, 0, 0],
                 ),
                 (
                     CircuitId::Delegation(1994),
-                    [811680, 74387, 41698, 0, 335707, 0, 51688, 0, 0, 0],
+                    [1006439, 95029, 52310, 0, 414521, 0, 68432, 0, 0, 0],
                 ),
                 (
                     CircuitId::Delegation(1995),
-                    [797932, 73985, 40196, 0, 328734, 0, 51170, 0, 0, 0],
+                    [996938, 94891, 50844, 0, 408702, 0, 67914, 0, 0, 0],
                 ),
             ],
         },

--- a/full_statement_verifier/src/host_utils/cost_model/mod.rs
+++ b/full_statement_verifier/src/host_utils/cost_model/mod.rs
@@ -133,7 +133,7 @@ mod order_tests {
     #[test]
     fn base_layer_riscv_order_matches_verifier_list() {
         let actual: Vec<u32> =
-            crate::unrolled_circuit_params::unrolled_circuit_verifiers_for_base_layer_sec_80::<I, E>(
+            crate::unrolled_circuit_params::unrolled_circuit_verifiers_for_base_layer_sec_100::<I, E>(
             )
             .iter()
             .map(|(k, _)| *k)
@@ -147,7 +147,7 @@ mod order_tests {
     #[test]
     fn recursion_layer_riscv_order_matches_verifier_list() {
         let actual: Vec<u32> =
-            crate::unrolled_circuit_params::unrolled_circuit_verifiers_for_recursion_layer_sec_80::<
+            crate::unrolled_circuit_params::unrolled_circuit_verifiers_for_recursion_layer_sec_100::<
                 I,
                 E,
             >()
@@ -162,12 +162,12 @@ mod order_tests {
 
     #[test]
     fn delegation_order_matches_verifier_functions() {
-        let actual = crate::delegation_params::all_delegation_circuit_verifiers_sec_80::<I, E>();
+        let actual = crate::delegation_params::all_delegation_circuit_verifiers_sec_100::<I, E>();
         let expected: [DelegVerifier; 4] = [
-            imports::blake2_with_extended_control_sec_80::verify::<I, E>,
-            imports::bigint_with_extended_control_sec_80::verify::<I, E>,
-            imports::keccak_special5_sec_80::verify::<I, E>,
-            imports::blake2_g_function_sec_80::verify::<I, E>,
+            imports::blake2_with_extended_control_sec_100::verify::<I, E>,
+            imports::bigint_with_extended_control_sec_100::verify::<I, E>,
+            imports::keccak_special5_sec_100::verify::<I, E>,
+            imports::blake2_g_function_sec_100::verify::<I, E>,
         ];
         for (i, (a, b)) in actual.iter().zip(expected.iter()).enumerate() {
             assert_eq!(

--- a/full_statement_verifier/tests/cost_model_drift.rs
+++ b/full_statement_verifier/tests/cost_model_drift.rs
@@ -11,17 +11,17 @@ use verifier_common::prover::gkr::prover::GKRProof;
 use verifier_common::prover::merkle_trees::DefaultTreeConstructor;
 
 const EXPECTED: &[(&str, u64)] = &[
-    ("add_sub_lui_auipc_mop", 837756),
-    ("jump_branch_slt", 859309),
-    ("shift_binop", 871029),
-    ("unsigned_mul_div", 858290),
-    ("mem_word_only", 825381),
-    ("mem_subword_only", 841905),
-    ("inits_and_teardowns", 697485),
-    ("blake2_with_extended_control", 2364225),
-    ("bigint_with_extended_control", 1276430),
-    ("keccak_special5", 1258988),
-    ("blake2_g_function", 850560),
+    ("add_sub_lui_auipc_mop", 1031431),
+    ("jump_branch_slt", 1057906),
+    ("shift_binop", 1092174),
+    ("unsigned_mul_div", 1053645),
+    ("mem_word_only", 1017323),
+    ("mem_subword_only", 1036422),
+    ("inits_and_teardowns", 876826),
+    ("blake2_with_extended_control", 2976533),
+    ("bigint_with_extended_control", 1572641),
+    ("keccak_special5", 1568920),
+    ("blake2_g_function", 1068075),
 ];
 
 fn repo_root() -> String {
@@ -46,13 +46,13 @@ fn nds_for(
 fn guest_cycles(circuit: &str) -> u64 {
     let root = repo_root();
     let proof: GKRProof<BabyBearField, BabyBearExt4, DefaultTreeConstructor> = {
-        let path = format!("{root}/prover/test_proofs/{circuit}_sec_80_gkr_proof.json");
+        let path = format!("{root}/prover/test_proofs/{circuit}_sec_100_gkr_proof.json");
         let f = std::fs::File::open(&path).unwrap_or_else(|e| panic!("open {path}: {e}"));
         serde_json::from_reader(std::io::BufReader::new(f)).expect("deserialize proof")
     };
 
-    let bin_path = format!("{root}/tools/gkr_verifier/{circuit}_sec_80.bin");
-    let text_path = format!("{root}/tools/gkr_verifier/{circuit}_sec_80.text");
+    let bin_path = format!("{root}/tools/gkr_verifier/{circuit}_sec_100.bin");
+    let text_path = format!("{root}/tools/gkr_verifier/{circuit}_sec_100.text");
     for path in [&bin_path, &text_path] {
         assert!(
             std::path::Path::new(path).exists(),
@@ -78,7 +78,7 @@ fn per_circuit_verifier_cost_has_not_drifted() {
         assert_eq!(
             actual, *expected,
             "{circuit}: the generated verifier changed. Re-measure and update EXPECTED in this \
-             file; regenerating the test proof, {circuit}_sec_80.bin/.text, or the compiled \
+             file; regenerating the test proof, {circuit}_sec_100.bin/.text, or the compiled \
              circuit all move these counts. This guard is a proxy: the guest runs only verify(), \
              so it detects codegen drift but cannot validate the cost table's numbers"
         );

--- a/full_statement_verifier/tests/cost_model_trace.rs
+++ b/full_statement_verifier/tests/cost_model_trace.rs
@@ -2,26 +2,34 @@
 #![feature(generic_const_exprs)]
 #![cfg(all(feature = "host_utils", feature = "verifiers"))]
 
-//! Calibration harness for `src/cost_model/census.rs`. Every test here needs real
-//! recursion proofs, far too large to commit, so all of them are `#[ignore]`d and
-//! run by hand when the table is recalibrated. `cost_model_drift.rs` needs only
-//! committed artifacts, so it runs unignored in CI.
+//! Manual calibration harness for `src/host_utils/cost_model/census.rs`. Every
+//! test here needs freshly generated local recursion proofs, so all of them are
+//! `#[ignore]`d. CI runs only `cost_model_drift.rs`; that detects verifier
+//! codegen drift but does not validate the committed model's accuracy.
 //!
 //! Fixtures live in `$COST_MODEL_FIXTURE_DIR` as `<fixture>_proof.bin` /
 //! `<fixture>_setups.bin`: zlib-compressed bincode of `ProgramProof` and `Setups`.
-//! `circuit_defs/prover_examples`'s `test_recursive_proving_pipeline_zksync_os`
-//! (itself `#[ignore]`d — hours, large RAM) writes exactly that format via
-//! `serialize_compressed_to_file`, but under **different names**, so its output has
-//! to be renamed:
+//! Generate all four Sec100 Compression fixtures with the ignored GPU test
+//! `gpu_program_prover::tests::test_generate_sec100_cost_model_fixtures`. It
+//! proves the recursion layers explicitly instead of depending on the production
+//! scheduling threshold. From the repository root:
 //!
-//! | fixture | producer output | role |
-//! |---|---|---|
-//! | `base` | `base_proofs.bin` / `base_setups.bin` (note the plural) | RISC-V, keccak and bigint coefficients |
-//! | `base_alt` | the same two files from a second run, with the producer's hardcoded zksync_os guest swapped for one whose delegation set differs | a second base-layer delegation presence mask |
-//! | `recursion0` | `recursion_layer_0_proof_<tag>.bin` / `recursion_layer_0_setups_<tag>.bin` | recursion-layer `c0`, blake2 coefficient |
-//! | `recursion1` | `recursion_layer_1_proof_<tag>.bin` / `recursion_layer_1_setups_<tag>.bin` | steady recursion-chain path |
+//! ```text
+//! cargo nextest run -p gpu_program_prover --release --features verifiers --no-run
+//! COST_MODEL_FIXTURE_DIR="$PWD/target/cost-model-fixtures/sec100" \
+//!   .agents/bin/with_gpu_lock.sh cargo nextest run -p gpu_program_prover \
+//!   --release --features verifiers \
+//!   -E 'test(=tests::test_generate_sec100_cost_model_fixtures)' \
+//!   --run-ignored only --no-capture
+//! ```
 //!
-//! `emit_census_tables` prints the tables to paste into `src/cost_model/census.rs`;
+//! `base` is zkSync OS block 23620012; `base_alt` is hashed Fibonacci with
+//! `(n=15, h=1_200_000)`; `recursion0` and `recursion1` explicitly prove the
+//! Sec100 unrolled base and recursion verifiers. The files are non-authoritative
+//! local calibration inputs and must not be committed or consumed by CI.
+//!
+//! `emit_census_tables` prints the tables to paste into
+//! `src/host_utils/cost_model/census.rs`;
 //! `estimate_matches_measurement_on_every_fixture` and its census sibling are
 //! the acceptance gates.
 

--- a/gkr_test.sh
+++ b/gkr_test.sh
@@ -140,7 +140,7 @@ Options:
   --variant V           caches (default) | no_caches
   --encoding ENC        coeff (default) | eval (WHIR leaf encoding)
                         Forwarded as the eval_leaves feature to prover + generator.
-  --security-level L    100 (the only supported level; flag kept for compatibility)
+  --security-level L    Security level (currently: 100)
   --prove-empty         Prove every applicable circuit even if program made 0 calls.
                         Forwarded via GKR_PROVE_EMPTY.
   --no-self-checks      Disable in-prove sumcheck/cache/at-point-eval checks.
@@ -386,7 +386,7 @@ esac
 
 case "$SECURITY_LEVEL" in
   100) ;;
-  *) die "--security-level must be 100 (the 80-bit mode was removed). Got: $SECURITY_LEVEL" ;;
+  *) die "--security-level currently supports only 100. Got: $SECURITY_LEVEL" ;;
 esac
 
 if [[ ${#SELECTED_CIRCUITS[@]} -gt 0 ]]; then

--- a/gpu/circuit_prover/src/proof/orchestration/terminal.rs
+++ b/gpu/circuit_prover/src/proof/orchestration/terminal.rs
@@ -81,8 +81,8 @@ pub(in crate::proof) fn schedule_terminal_proof_assembly(
                     // The GPU prover follows the CPU Blake2sTranscript path,
                     // which does not synthesize an intermediate Keccak seed.
                     intermediate_transcript_seed: None,
-                    // Ground on device by the pow-aware challenge draws (0 at
-                    // Sec80, non-zero at Sec100) and read back from the slab.
+                    // Ground on device by the configured pow-aware challenge
+                    // draws and read back from the slab.
                     lookup_challenges_pow_nonce: proof_layout_for_parse
                         .lookup_pow_nonce_host(slab_bytes),
                     batched_proximity_check_pow_nonce: proof_layout_for_parse

--- a/gpu/circuit_prover/src/proof/orchestration/whir.rs
+++ b/gpu/circuit_prover/src/proof/orchestration/whir.rs
@@ -127,7 +127,7 @@ pub(in crate::proof) fn schedule_whir_phase<'a>(
 
     // Draw the WHIR base batching challenge on device from the rolling backward
     // seed. Pow-aware (`draw_random_field_els_with_pow(seed, 1, bits)`): grinds
-    // the batched-proximity PoW (0 bits at Sec80), advances the seed, honors the
+    // the configured batched-proximity PoW, advances the seed, and honors the
     // skip-first-word convention. The nonce lands in its slab slot.
     // SAFETY: `ProofLayout` computes a live, aligned, non-overlapping E4 region
     // inside `proof_slab`. The draw and every WHIR consumer are ordered on the

--- a/gpu/program_prover/Cargo.toml
+++ b/gpu/program_prover/Cargo.toml
@@ -47,7 +47,10 @@ verifiers = [
 ]
 
 [dev-dependencies]
+bincode = "1.3"
 env_logger = "0.11"
+flate2 = "*"
+serde = { workspace = true }
 serde_json = "*"
 worker = { workspace = true }
 # CPU reference prover, used only by the GPU-vs-CPU proof-diff test.

--- a/gpu/program_prover/src/tests.rs
+++ b/gpu/program_prover/src/tests.rs
@@ -43,6 +43,76 @@ fn load_workload(name: &str) -> (Vec<u32>, Vec<u32>) {
     (binary_image, text_section)
 }
 
+#[cfg(all(not(no_cuda), feature = "verifiers"))]
+fn load_zksync_os_workload() -> (Vec<u32>, Vec<u32>, Vec<u32>) {
+    let root = artifact_root();
+    let raw =
+        std::fs::read_to_string(root.join("riscv_transpiler/examples/zksync_os/23620012_witness"))
+            .expect("read zkSync OS block-23620012 witness");
+    let raw = raw.trim();
+    assert!(raw.len().is_multiple_of(8));
+    let witness = raw
+        .as_bytes()
+        .chunks(8)
+        .map(|chunk| {
+            u32::from_str_radix(std::str::from_utf8(chunk).unwrap(), 16)
+                .expect("invalid zkSync OS witness word")
+        })
+        .collect();
+    let (_, binary_image) = read_binary(&root.join("riscv_transpiler/examples/zksync_os/app.bin"));
+    let (_, text_section) = read_binary(&root.join("riscv_transpiler/examples/zksync_os/app.text"));
+    (binary_image, text_section, witness)
+}
+
+#[cfg(all(not(no_cuda), feature = "verifiers", feature = "deterministic_pow"))]
+fn write_compressed<T: serde::Serialize>(value: &T, path: &std::path::Path) {
+    assert!(!path.exists(), "refusing to overwrite {}", path.display());
+    let file_name = path.file_name().unwrap().to_string_lossy();
+    let temporary = path.with_file_name(format!(".{file_name}.tmp"));
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)
+        .unwrap_or_else(|err| panic!("create {}: {err}", temporary.display()));
+    let mut encoder = flate2::write::ZlibEncoder::new(file, flate2::Compression::default());
+    bincode::serialize_into(&mut encoder, value).expect("serialize calibration fixture");
+    let file = encoder.finish().expect("finish fixture compression");
+    file.sync_all().expect("sync calibration fixture");
+    std::fs::rename(&temporary, path).unwrap_or_else(|err| {
+        panic!(
+            "rename {} to {}: {err}",
+            temporary.display(),
+            path.display()
+        )
+    });
+}
+
+#[cfg(all(not(no_cuda), feature = "verifiers", feature = "deterministic_pow"))]
+fn write_cost_model_fixture(
+    directory: &std::path::Path,
+    name: &str,
+    proof: &crate::upstream::ProgramProof,
+    setups: &crate::upstream::Setups,
+) {
+    write_compressed(proof, &directory.join(format!("{name}_proof.bin")));
+    write_compressed(setups, &directory.join(format!("{name}_setups.bin")));
+
+    let riscv_counts: Vec<_> = proof
+        .riscv_proofs
+        .iter()
+        .map(|(family, proofs)| (*family, proofs.len()))
+        .collect();
+    let delegation_counts: Vec<_> = proof
+        .delegation_proofs
+        .iter()
+        .map(|(delegation, proofs)| (*delegation, proofs.len()))
+        .collect();
+    log::info!(
+        "wrote {name}: {} cycles, RISC-V {riscv_counts:?}, delegations {delegation_counts:?}",
+        proof.executed_cycles()
+    );
+}
+
 /// Prove `(binary_image, text_section)` with the given non-determinism reads on
 /// the GPU `ExecutionProver` and assemble the `(ProgramProof, Setups)`. The
 /// shared prove tail of every e2e below and of each `run_gpu_recursive_pipeline`
@@ -574,23 +644,122 @@ fn test_program_prover_recursive_pipeline() {
 #[ignore]
 fn test_program_prover_recursive_pipeline_zksync_os() {
     init_test_logger();
-    // Mirrors prover_examples::recursion::read_hex_witness.
-    let raw = std::fs::read_to_string(
-        artifact_root().join("riscv_transpiler/examples/zksync_os/23620012_witness"),
-    )
-    .expect("read witness file");
-    let raw = raw.trim();
-    assert!(raw.len().is_multiple_of(8));
-    let witness: Vec<u32> = raw
-        .as_bytes()
-        .chunks(8)
-        .map(|c| u32::from_str_radix(std::str::from_utf8(c).unwrap(), 16).expect("invalid hex"))
-        .collect();
-    let (_, binary_image) =
-        read_binary(&artifact_root().join("riscv_transpiler/examples/zksync_os/app.bin"));
-    let (_, text_section) =
-        read_binary(&artifact_root().join("riscv_transpiler/examples/zksync_os/app.text"));
+    let (binary_image, text_section, witness) = load_zksync_os_workload();
     run_gpu_recursive_pipeline(binary_image, text_section, witness, false);
+}
+
+/// Generate the local, non-authoritative proof/setup inputs used to calibrate
+/// the Sec100 Compression verifier cost model. This deliberately proves two
+/// recursion layers instead of consulting the production scheduling threshold.
+#[test]
+#[cfg(all(not(no_cuda), feature = "verifiers", feature = "deterministic_pow"))]
+#[ignore = "manual Sec100 cost-model fixture generation (large GPU run)"]
+fn test_generate_sec100_cost_model_fixtures() {
+    use crate::upstream::{
+        compute_end_params, load_fsv_program, native_verify_unrolled, BlakeMode, FsvProgram,
+        FsvRecursionChain, SecurityLevel,
+    };
+
+    init_test_logger();
+
+    let fixture_dir = std::env::var_os("COST_MODEL_FIXTURE_DIR")
+        .map(std::path::PathBuf::from)
+        .expect("set COST_MODEL_FIXTURE_DIR to an empty local output directory");
+    std::fs::create_dir_all(&fixture_dir).expect("create cost-model fixture directory");
+    for name in ["base", "base_alt", "recursion0", "recursion1"] {
+        for suffix in ["proof", "setups"] {
+            let path = fixture_dir.join(format!("{name}_{suffix}.bin"));
+            assert!(!path.exists(), "refusing to overwrite {}", path.display());
+        }
+    }
+
+    let configuration = ExecutionProverConfiguration {
+        security_level: SecurityLevel::Sec100,
+        ..Default::default()
+    };
+    let mut prover = ExecutionProver::with_configuration(configuration).unwrap();
+
+    let (base_binary, base_text, base_witness) = load_zksync_os_workload();
+    let (base_proof, base_setups) = prove_on_gpu(
+        &mut prover,
+        ExecutionKind::Unrolled,
+        MachineType::FullUnsigned,
+        base_binary,
+        base_text,
+        base_witness,
+    );
+    native_verify_unrolled(build_unrolled_stream(&base_setups, &base_proof), true);
+    write_cost_model_fixture(&fixture_dir, "base", &base_proof, &base_setups);
+
+    let base_end_params = compute_end_params(&base_setups, base_proof.final_pc);
+    let mut chain = FsvRecursionChain::begin(&base_end_params);
+    let fsv_dir = artifact_root().join("tools/gkr_verifier");
+    let (base_verifier_bin, base_verifier_text) = load_fsv_program(
+        &fsv_dir,
+        FsvProgram::UnrolledBaseLayer,
+        BlakeMode::Compression,
+    );
+    let (mut recursion0_proof, recursion0_setups) = prove_on_gpu(
+        &mut prover,
+        ExecutionKind::Unrolled,
+        MachineType::Reduced,
+        base_verifier_bin,
+        base_verifier_text,
+        build_unrolled_stream(&base_setups, &base_proof),
+    );
+    recursion0_proof.set_recursion_chain(&chain);
+    native_verify_unrolled(
+        build_unrolled_stream(&recursion0_setups, &recursion0_proof),
+        false,
+    );
+    write_cost_model_fixture(
+        &fixture_dir,
+        "recursion0",
+        &recursion0_proof,
+        &recursion0_setups,
+    );
+
+    let recursion0_end_params = compute_end_params(&recursion0_setups, recursion0_proof.final_pc);
+    chain.extend(&recursion0_end_params);
+    let (recursion_verifier_bin, recursion_verifier_text) = load_fsv_program(
+        &fsv_dir,
+        FsvProgram::UnrolledRecursionLayer,
+        BlakeMode::Compression,
+    );
+    let (mut recursion1_proof, recursion1_setups) = prove_on_gpu(
+        &mut prover,
+        ExecutionKind::Unrolled,
+        MachineType::Reduced,
+        recursion_verifier_bin,
+        recursion_verifier_text,
+        build_unrolled_stream(&recursion0_setups, &recursion0_proof),
+    );
+    recursion1_proof.set_recursion_chain(&chain);
+    native_verify_unrolled(
+        build_unrolled_stream(&recursion1_setups, &recursion1_proof),
+        false,
+    );
+    write_cost_model_fixture(
+        &fixture_dir,
+        "recursion1",
+        &recursion1_proof,
+        &recursion1_setups,
+    );
+
+    let (base_alt_binary, base_alt_text) = load_workload("hashed_fibonacci");
+    let (base_alt_proof, base_alt_setups) = prove_on_gpu(
+        &mut prover,
+        ExecutionKind::Unrolled,
+        MachineType::FullUnsigned,
+        base_alt_binary,
+        base_alt_text,
+        vec![15, 1_200_000],
+    );
+    native_verify_unrolled(
+        build_unrolled_stream(&base_alt_setups, &base_alt_proof),
+        true,
+    );
+    write_cost_model_fixture(&fixture_dir, "base_alt", &base_alt_proof, &base_alt_setups);
 }
 
 #[cfg(all(not(no_cuda), feature = "verifiers"))]

--- a/gpu/program_prover/src/upstream.rs
+++ b/gpu/program_prover/src/upstream.rs
@@ -31,4 +31,4 @@ pub use full_statement_verifier::host_utils::{
 #[cfg(feature = "verifiers")]
 pub use full_statement_verifier::host_utils::{native_verify_unified, native_verify_unrolled};
 pub use setups::Setups;
-pub use verifier_common::fsv_binaries::FsvProgram;
+pub use verifier_common::fsv_binaries::{BlakeMode, FsvProgram};

--- a/riscv_transpiler/src/vm/mod.rs
+++ b/riscv_transpiler/src/vm/mod.rs
@@ -599,7 +599,7 @@ pub(crate) mod test {
     fn test_pretty_show_assembly() {
         // let (_, binary) = read_binary(&Path::new("examples/fibonacci/app.bin"));
         let (_, text) = read_binary(&Path::new(
-            "../tools/gkr_verifier/add_sub_lui_auipc_mop_sec_80.text",
+            "../tools/gkr_verifier/add_sub_lui_auipc_mop_sec_100.text",
         ));
         for opcode in text.iter().take(16) {
             println!("0x{:08x}", opcode);

--- a/tools/gkr_verifier/dump_bin.sh
+++ b/tools/gkr_verifier/dump_bin.sh
@@ -50,7 +50,7 @@ done
 
 case "$SEC" in
     100) ;;
-    *) echo "ERROR: --sec must be 100 (the 80-bit mode was removed; got '$SEC')" >&2; exit 1 ;;
+    *) echo "ERROR: --sec currently supports only 100 (got '$SEC')" >&2; exit 1 ;;
 esac
 
 # Remaining args are circuits, or default to all (filtered by --sec).

--- a/tools/gkr_verifier/dump_recursive_verifiers.sh
+++ b/tools/gkr_verifier/dump_recursive_verifiers.sh
@@ -8,7 +8,7 @@
 #   fsv_unrolled_recursion_layer_sec_100 : blake2_with_compression, blake2_g_function
 #   fsv_unified_recursion_layer_sec_100  : blake2_with_compression, blake2_g_function, special_opcodes_extension
 #
-# `--sec 100` is the only (and default) security level — the 80-bit mode was removed.
+# `--sec` defaults to 100, the currently supported security level.
 #
 # `special_opcodes_extension` does blake inline with the reduced machine's
 # tri-add / xor-rotate opcodes — the correct mop-style path for the reduced ISA
@@ -42,7 +42,7 @@ done
 
 case "$SEC" in
     100)  SEC_LEVELS="100" ;;
-    *) echo "ERROR: --sec must be 100 (the 80-bit mode was removed; got '$SEC')" >&2; exit 1 ;;
+    *) echo "ERROR: --sec currently supports only 100 (got '$SEC')" >&2; exit 1 ;;
 esac
 
 build_variant() {


### PR DESCRIPTION
## What ❔

- Remove Sec80-specific dependencies from the GPU-adjacent verifier stack.
- Recalibrate the recursion cost model against fresh local Sec100 fixtures.
- Add an ignored GPU fixture generator while keeping CI fixture-free and drift-only.

## Why ❔

Sec80 was removed, but the cost-model guards and coefficients still depended on its verifier artifacts. This updates the active Sec100 path without changing generic multi-level infrastructure.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
