### PR TITLE
fix(full_statement_verifier): tolerate proof cycle jitter

### DIFF
--- a/full_statement_verifier/tests/cost_model_drift.rs
+++ b/full_statement_verifier/tests/cost_model_drift.rs
@@ -75,12 +75,13 @@ fn guest_cycles(circuit: &str) -> u64 {
 fn per_circuit_verifier_cost_has_not_drifted() {
     for (circuit, expected) in EXPECTED {
         let actual = guest_cycles(circuit);
-        assert_eq!(
-            actual, *expected,
-            "{circuit}: the generated verifier changed. Re-measure and update EXPECTED in this \
-             file; regenerating the test proof, {circuit}_sec_100.bin/.text, or the compiled \
-             circuit all move these counts. This guard is a proxy: the guest runs only verify(), \
-             so it detects codegen drift but cannot validate the cost table's numbers"
+        let tolerance = expected / 1000;
+        assert!(
+            actual.abs_diff(*expected) <= tolerance,
+            "{circuit}: {actual} vs expected {expected} (tolerance {tolerance}). The generated \
+             verifier changed; recalibrate the cost tables. This guard is a proxy: the guest \
+             runs only verify(), so it detects codegen drift but cannot validate the cost \
+             table's numbers"
         );
     }
 }


### PR DESCRIPTION
## What ❔

Restore the verifier cost-model drift guard's original 0.1% tolerance.

## Why ❔

The preceding prover smoke test regenerates proof fixtures. Proof-dependent verifier execution can shift the exact cycle count without verifier codegen drift; CI observed a 72-cycle (0.0046%) difference for `keccak_special5`. The tolerance still rejects material drift.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.