### PR TITLE
fix(gpu_trace): remove stale partial-tree test argument

### DIFF
--- a/gpu/trace/src/trace/holder/tests.rs
+++ b/gpu/trace/src/trace/holder/tests.rs
@@ -1181,8 +1181,6 @@ fn partial_tree_from_physical_leaves_matches_natural_path() {
                     &stream,
                 )
                 .unwrap();
-                let mut staging =
-                    RawDeviceAllocation::<Digest>::alloc(leaves_count * cosets_in_tile).unwrap();
                 build_partial_trees_from_physical(
                     &physical_device,
                     &mut new_tree,
@@ -1192,7 +1190,6 @@ fn partial_tree_from_physical_leaves_matches_natural_path() {
                     log_tree_cap_size,
                     columns_count,
                     cosets_in_tile,
-                    &mut staging,
                     &stream,
                 )
                 .unwrap();


### PR DESCRIPTION
## What ❔

Remove the obsolete staging allocation and argument from the physical partial-tree parity test.

## Why ❔

`build_partial_trees_from_physical` no longer accepts the staging buffer. The stale test call caused `cargo check -p gpu_trace --all-targets` to fail with `E0061` even though the production library compiled.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] The affected GPU test passes, and `gpu_trace` passes all-target rustc and Clippy checks.
- [x] Documentation comments are not applicable to this test-only correction.
- [x] Code has been formatted.
