### PR TITLE
perf(ntt): accelerate LSB commitment LDE

### DIFF
--- a/gpu/circuit_prover/src/tests/lsb_commit_pipeline.rs
+++ b/gpu/circuit_prover/src/tests/lsb_commit_pipeline.rs
@@ -5,9 +5,9 @@ use super::*;
 
 use era_cudart::slice::DeviceSlice;
 use gpu_hash::blake2s::{
-    Digest, OracleGatherDesc, OraclePartialPathDesc, STATE_SIZE,
     gather_leaves_for_queries_physical, gather_merkle_paths_full_for_queries,
-    gather_merkle_paths_partial_for_queries_physical,
+    gather_merkle_paths_partial_for_queries_physical, Digest, OracleGatherDesc,
+    OraclePartialPathDesc, STATE_SIZE,
 };
 use gpu_trace::trace::holder::{TraceHolder, TreesCacheMode};
 use prover::gkr::whir::ColumnMajorBaseOracleForLDE;

--- a/gpu/circuit_prover/src/tests/lsb_commit_pipeline.rs
+++ b/gpu/circuit_prover/src/tests/lsb_commit_pipeline.rs
@@ -4,19 +4,12 @@
 use super::*;
 
 use era_cudart::slice::DeviceSlice;
-use gpu_core::primitives::device_structures::{DeviceMatrix, DeviceMatrixMut};
 use gpu_hash::blake2s::{
-    build_partial_merkle_tree_multi_coset_physical, gather_leaves_for_queries_physical,
-    gather_merkle_paths_full_for_queries, gather_merkle_paths_partial_for_queries_physical,
-    gather_tree_caps_inline, Digest, OracleGatherDesc, OraclePartialPathDesc, STATE_SIZE,
+    Digest, OracleGatherDesc, OraclePartialPathDesc, STATE_SIZE,
+    gather_leaves_for_queries_physical, gather_merkle_paths_full_for_queries,
+    gather_merkle_paths_partial_for_queries_physical,
 };
-use gpu_ntt::ntt::{
-    hypercube_evals_to_monomials, natural_monomials_to_bitreversed_evals_multi_coset,
-};
-use gpu_trace::trace::holder::{
-    build_full_trees_from_physical, TraceHolder, TreesCacheMode, TreesHolder,
-    PARTIAL_TREE_REDUCTION_LAYERS,
-};
+use gpu_trace::trace::holder::{TraceHolder, TreesCacheMode};
 use prover::gkr::whir::ColumnMajorBaseOracleForLDE;
 
 const DEVICE_ALLOCATOR_ARENA_BYTES: usize = 8usize << 30;
@@ -162,7 +155,6 @@ struct GpuResult {
     leaf_values: Vec<BF>,
     path_nodes: Vec<Digest>,
 }
-
 fn gpu_commit_and_query(
     context: &ProverContext,
     shape: &Shape,
@@ -171,9 +163,7 @@ fn gpu_commit_and_query(
     trees_cache_mode: TreesCacheMode,
 ) -> GpuResult {
     let stream = context.get_exec_stream();
-    let device_properties = context.get_device_properties();
     let log_n = shape.log_domain_size;
-    let rows = shape.rows();
     let cosets_count = shape.cosets_count();
     let columns_count = shape.columns_count;
 
@@ -194,108 +184,7 @@ fn gpu_commit_and_query(
     )
     .unwrap();
 
-    let mut monomials = context
-        .alloc::<BF>(columns_count * rows, AllocationPlacement::BestFit)
-        .unwrap();
-    {
-        let source = DeviceMatrix::new(holder.get_hypercube_evals(), rows);
-        let mut destination = DeviceMatrixMut::new(&mut monomials, rows);
-        hypercube_evals_to_monomials(
-            &source,
-            &mut destination,
-            log_n as usize,
-            false,
-            stream,
-            device_properties,
-        )
-        .unwrap();
-    }
-    {
-        let (cosets, trees) = holder.get_uninit_cosets_and_tree_mut();
-        let source = DeviceMatrix::new(&monomials[..], rows);
-        natural_monomials_to_bitreversed_evals_multi_coset(
-            &source,
-            &mut cosets[..],
-            log_n as usize,
-            shape.log_lde_factor as usize,
-            columns_count,
-            false,
-            context.ntt_device_context(),
-            None,
-            stream,
-            device_properties,
-        )
-        .unwrap();
-        match trees {
-            TreesHolder::Full(backing) => build_full_trees_from_physical(
-                &cosets[..],
-                &mut backing[..],
-                log_n,
-                shape.log_lde_factor,
-                shape.log_rows_per_leaf,
-                shape.log_tree_cap_size(),
-                columns_count,
-                cosets_count,
-                stream,
-            )
-            .unwrap(),
-            TreesHolder::Partial(backing) => {
-                let layers_count = shape.log_leaves_count() + 1
-                    - PARTIAL_TREE_REDUCTION_LAYERS
-                    - shape.log_subtree_cap_size();
-                build_partial_merkle_tree_multi_coset_physical(
-                    &cosets[..],
-                    &mut backing[..],
-                    shape.log_rows_per_leaf,
-                    layers_count,
-                    cosets_count,
-                    stream,
-                )
-                .unwrap()
-            }
-            TreesHolder::None => panic!("composed pipeline needs a cached tree"),
-        }
-    }
-    holder.mark_cosets_materialized();
-
-    let per_coset_segment_len = match trees_cache_mode {
-        TreesCacheMode::CacheFull => 1usize << (shape.log_leaves_count() + 1),
-        TreesCacheMode::CachePartial => {
-            1usize << (shape.log_leaves_count() + 1 - PARTIAL_TREE_REDUCTION_LAYERS)
-        }
-        TreesCacheMode::CacheNone => unreachable!(),
-    };
-    let cap_size = 1usize << shape.log_tree_cap_size();
-    let cap_words_per_coset = ((1usize << shape.log_subtree_cap_size()) * STATE_SIZE) as u32;
-    let cap_offset_in_u32_words =
-        (per_coset_segment_len - (1usize << (shape.log_subtree_cap_size() + 1))) * STATE_SIZE;
-    let stride_in_u32_words = (per_coset_segment_len * STATE_SIZE) as u32;
-    let tree_base_u32 = holder.get_consolidated_tree().unwrap().as_ptr() as *const u32;
-    let mut device_cap: DeviceAllocation<Digest> = context
-        .alloc(cap_size, AllocationPlacement::BestFit)
-        .unwrap();
-    {
-        // SAFETY: `device_cap` owns `cap_size` digests; `Digest == [u32; 8]` so
-        // the same bytes are a `cap_size * STATE_SIZE` u32 slice.
-        let dst_u32 = unsafe {
-            DeviceSlice::from_raw_parts_mut(
-                device_cap.as_mut_ptr() as *mut u32,
-                cap_size * STATE_SIZE,
-            )
-        };
-        // SAFETY: the offset stays inside the first per-coset segment.
-        let cap_base = unsafe { tree_base_u32.add(cap_offset_in_u32_words) };
-        gather_tree_caps_inline(
-            cap_base,
-            cap_words_per_coset,
-            stride_in_u32_words,
-            shape.log_lde_factor,
-            dst_u32,
-            stream,
-        )
-        .unwrap();
-    }
-    holder.install_unified_device_cap(device_cap);
+    holder.commit_all(context).unwrap();
     let cap = holder.read_full_cap_synchronously(context).unwrap().cap;
 
     let queries_device = upload_slice_to_device_for_test(queries, context);
@@ -443,11 +332,21 @@ fn assert_composed_pipeline_matches_cpu(shape: Shape) {
 }
 
 #[test]
-fn composed_lsb_commit_pipeline_matches_cpu_log21() {
+fn composed_lsb_trace_holder_fused_pipeline_matches_cpu_log21() {
     assert_composed_pipeline_matches_cpu(Shape {
         log_domain_size: 21,
         log_rows_per_leaf: 1,
         log_lde_factor: 1,
-        columns_count: 1,
+        columns_count: 4,
+    });
+}
+
+#[test]
+fn composed_lsb_trace_holder_fused_pipeline_matches_cpu_log20() {
+    assert_composed_pipeline_matches_cpu(Shape {
+        log_domain_size: 20,
+        log_rows_per_leaf: 1,
+        log_lde_factor: 1,
+        columns_count: 4,
     });
 }

--- a/gpu/core/native_headers/primitives/ptx.cuh
+++ b/gpu/core/native_headers/primitives/ptx.cuh
@@ -273,4 +273,11 @@ AB_PTX_ST_ALL(st_wt, "wt")
 #undef AB_PTX_ST_V2
 #undef AB_PTX_ST_V1
 
+// Non-binding L2 prefetch hint for a 128-byte line.
+DEVICE_FORCEINLINE void prefetch_l2(const void *p) { asm volatile("prefetch.global.L2 [%0];" ::"l"(p)); }
+
+// L2 prefetch with last-evict priority: the line survives intervening
+// streaming traffic until its consumer reads it.
+DEVICE_FORCEINLINE void prefetch_l2_evict_last(const void *p) { asm volatile("prefetch.global.L2::evict_last [%0];" ::"l"(p)); }
+
 } // namespace airbender::primitives::ptx

--- a/gpu/ntt/native/CMakeLists.txt
+++ b/gpu/ntt/native/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(gpu_ntt_native STATIC
         hypercube.cu
         hypercube_evals_to_monomials_three_pass.cu
         hypercube_evals_to_monomials_two_pass.cu
+        hypercube_evals_to_monomials_two_pass_compact.cu
         lde_intermediate_first_pass.cu
         monomials_to_evals_compact.cu
         monomials_to_evals_smem_packed.cu

--- a/gpu/ntt/native/hypercube_evals_to_monomials_three_pass.cu
+++ b/gpu/ntt/native/hypercube_evals_to_monomials_three_pass.cu
@@ -115,7 +115,9 @@ EXTERN __launch_bounds__(256, 3) __global__
 EXTERN __launch_bounds__(256, 3) __global__
     void ab_hypercube_evals_to_monomials_8_stages_pdl_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
                                                              const int log_n, const int start_stage) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
   cudaGridDependencySynchronize();
+#endif
   __shared__ bf smem_block[8192];
   hypercube_evals_to_monomials_8_stages<2>(gmem_in, gmem_out, log_n, start_stage, smem_block);
 }

--- a/gpu/ntt/native/hypercube_evals_to_monomials_three_pass.cu
+++ b/gpu/ntt/native/hypercube_evals_to_monomials_three_pass.cu
@@ -3,20 +3,23 @@
 
 namespace airbender::ntt {
 
-// Two tile roles per thread at 256 threads / 3 blocks-per-SM (see the forward
-// noninitial body for the shape rationale).
-EXTERN __launch_bounds__(256, 3) __global__
-    void ab_hypercube_evals_to_monomials_nonfinal_8_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
-                                                                  const int log_n, const int start_stage) {
+// One or two tile roles per thread at 256 threads / 3 blocks-per-SM. The
+// ordinary body covers an 8192-value exchange region with two roles; the
+// log_n=20 middle body covers its 4096-value exchange region with one role.
+template <int ROLES>
+DEVICE_FORCEINLINE void hypercube_evals_to_monomials_8_stages(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
+                                                              const int log_n, const int start_stage, bf *smem_block) {
   using namespace pass_config::three_pass_phase_a;
-  constexpr int ROLES = 2;
-  constexpr int ROLE_TILE_STRIDE = THREAD_TILES_PER_BLOCK / ROLES;
+  static_assert(ROLES == 1 || ROLES == 2);
+  constexpr int ROLE_TILE_STRIDE = THREAD_TILES_PER_BLOCK / 2;
+  constexpr int ACTIVE_THREAD_TILES = ROLE_TILE_STRIDE * ROLES;
+  constexpr int LOG_ACTIVE_DATA_TILES_PER_BLOCK = ROLES == 1 ? LOG_DATA_TILES_PER_BLOCK - 1 : LOG_DATA_TILES_PER_BLOCK;
 
   const int lane_in_tile = threadIdx.x & 31;
 
   const int exchg_region_size = 1 << (log_n - start_stage);
-  const int tile_gmem_stride = exchg_region_size >> LOG_DATA_TILES_PER_BLOCK;
-  const int interleaved_gmem_stride = tile_gmem_stride * THREAD_TILES_PER_BLOCK;
+  const int tile_gmem_stride = exchg_region_size >> LOG_ACTIVE_DATA_TILES_PER_BLOCK;
+  const int interleaved_gmem_stride = tile_gmem_stride * ACTIVE_THREAD_TILES;
 
   // Reversed block indexing for the middle kernel, to help L2 hits
   const int alternating_block_idx_x = (start_stage == 0) ? blockIdx.x : (gridDim.x - 1 - blockIdx.x);
@@ -24,8 +27,6 @@ EXTERN __launch_bounds__(256, 3) __global__
   const int gmem_block_offset = alternating_block_idx_y * exchg_region_size + (alternating_block_idx_x << LOG_DATA_TILE_SIZE);
   gmem_in.add_row(gmem_block_offset);
   gmem_out.add_row(gmem_block_offset);
-
-  __shared__ bf smem_block[8192];
 
 #pragma unroll
   for (int role = 0; role < ROLES; role++) {
@@ -45,23 +46,24 @@ EXTERN __launch_bounds__(256, 3) __global__
     reg_exchg_hypercube_inv<1, 2, 8>(vals);
 
 #pragma unroll
-    for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
+    for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * ACTIVE_THREAD_TILES)
       smem_block[addr] = vals[i]; // write interleaved smem tiles
   }
 
   __syncthreads();
 
-#pragma unroll
-  for (int role = 0; role < ROLES; role++) {
-    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
-    const int thread_ct_gmem_start = lane_in_tile + tile_id * interleaved_gmem_stride;
-    const int thread_ct_smem_start = lane_in_tile + tile_id * TILE_SIZE * THREAD_TILES_PER_BLOCK;
-
+  if (ROLES == 1) {
+    // The 4096-value log_n=20 middle has only eight physical warp tiles. Its
+    // first phase above covers region bits 11..8. Read 16-value groups at
+    // stride 16 here so the second phase covers bits 7..4 rather than
+    // repeating bit 8 and omitting bit 4 as the ordinary 16-tile transpose
+    // would when naively halved.
+    const int thread_ct_start = (threadIdx.x & 15) + (threadIdx.x >> 4) * 256;
     bf vals[VALS_PER_THREAD];
 
 #pragma unroll
-    for (int i{0}, addr{thread_ct_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE)
-      vals[i] = smem_block[addr]; // read consecutive smem tiles
+    for (int i{0}, addr{thread_ct_start}; i < VALS_PER_THREAD; i++, addr += 16)
+      vals[i] = smem_block[addr];
 
     reg_exchg_hypercube_inv<8, 16, 1>(vals);
     reg_exchg_hypercube_inv<4, 8, 2>(vals);
@@ -69,9 +71,53 @@ EXTERN __launch_bounds__(256, 3) __global__
     reg_exchg_hypercube_inv<1, 2, 8>(vals);
 
 #pragma unroll
-    for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
-      gmem_out.set_at_row(row, vals[i]); // write consecutive gmem tiles
+    for (int i{0}, row{thread_ct_start}; i < VALS_PER_THREAD; i++, row += 16)
+      gmem_out.set_at_row(row, vals[i]);
+  } else {
+#pragma unroll
+    for (int role = 0; role < ROLES; role++) {
+      const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+      const int thread_ct_gmem_start = lane_in_tile + tile_id * interleaved_gmem_stride;
+      const int thread_ct_smem_start = lane_in_tile + tile_id * TILE_SIZE * ACTIVE_THREAD_TILES;
+
+      bf vals[VALS_PER_THREAD];
+
+#pragma unroll
+      for (int i{0}, addr{thread_ct_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE)
+        vals[i] = smem_block[addr]; // read consecutive smem tiles
+
+      reg_exchg_hypercube_inv<8, 16, 1>(vals);
+      reg_exchg_hypercube_inv<4, 8, 2>(vals);
+      reg_exchg_hypercube_inv<2, 4, 4>(vals);
+      reg_exchg_hypercube_inv<1, 2, 8>(vals);
+
+#pragma unroll
+      for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
+        gmem_out.set_at_row(row, vals[i]); // write consecutive gmem tiles
+    }
   }
+}
+
+EXTERN __launch_bounds__(256, 3) __global__
+    void ab_hypercube_evals_to_monomials_8_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out, const int log_n,
+                                                         const int start_stage) {
+  __shared__ bf smem_block[8192];
+  hypercube_evals_to_monomials_8_stages<2>(gmem_in, gmem_out, log_n, start_stage, smem_block);
+}
+
+EXTERN __launch_bounds__(256, 3) __global__
+    void ab_hypercube_evals_to_monomials_8_stages_1_role_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
+                                                                const int log_n, const int start_stage) {
+  __shared__ bf smem_block[4096];
+  hypercube_evals_to_monomials_8_stages<1>(gmem_in, gmem_out, log_n, start_stage, smem_block);
+}
+
+EXTERN __launch_bounds__(256, 3) __global__
+    void ab_hypercube_evals_to_monomials_8_stages_pdl_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
+                                                             const int log_n, const int start_stage) {
+  cudaGridDependencySynchronize();
+  __shared__ bf smem_block[8192];
+  hypercube_evals_to_monomials_8_stages<2>(gmem_in, gmem_out, log_n, start_stage, smem_block);
 }
 
 // Fused LDE boundary for a column's FIRST coset (transposed layout only):
@@ -234,10 +280,187 @@ DEFINE_LDE_FUSED_WRITEBACK_KERNEL(8)
 
 #undef DEFINE_LDE_FUSED_WRITEBACK_KERNEL
 
+// Complete the coarse hypercube tail, preserve natural monomials in place,
+// and stream one coset's initial forward output. Each block rewrites exactly
+// the scratch window it read.
+DEVICE_FORCEINLINE void natural_lde_fused_boundary_writeback_out_cs_impl(bf_matrix_getter_setter<ld_modifier::cg, st_modifier::cg> gmem_scratch,
+                                                                         bf_matrix_setter<st_modifier::cs> gmem_out, const int log_n,
+                                                                         const int coset_index_base, const int coset_factor_shift, const int num_cols_per_coset,
+                                                                         const int log_cosets_in_tile) {
+  using namespace pass_config::three_pass_phase_a;
+  constexpr int ROLES = 2;
+  constexpr int ROLE_TILE_STRIDE = THREAD_TILES_PER_BLOCK / ROLES;
+
+  const int lane_in_tile = threadIdx.x & 31;
+
+  const int exchg_region_size = 1 << log_n; // coarse-8 tail: one exchange region
+  const int tile_gmem_stride = exchg_region_size >> LOG_DATA_TILES_PER_BLOCK;
+  const int interleaved_gmem_stride = tile_gmem_stride * THREAD_TILES_PER_BLOCK;
+
+  const unsigned log_blocks_per_ntt = static_cast<unsigned>(log_n) - 13u;
+  const FlatBlockIndex fi = decompose_flat_1d(log_blocks_per_ntt, static_cast<unsigned>(log_cosets_in_tile));
+  gmem_scratch.add_col(static_cast<int>(fi.col));
+  gmem_out.add_col(static_cast<int>(fi.coset) * num_cols_per_coset + static_cast<int>(fi.col));
+  const unsigned coset_factor_power = static_cast<unsigned>((coset_index_base + static_cast<int>(fi.coset)) << coset_factor_shift);
+
+  const int gmem_block_offset = static_cast<int>(fi.intra_x) << LOG_DATA_TILE_SIZE;
+
+  __shared__ bf smem_block[8192];
+
+  // Phase 1 (interleaved tiles): load the pre-tail scratch, top-4-bit
+  // hypercube stages.
+#pragma unroll
+  for (int role = 0; role < ROLES; role++) {
+    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    const int thread_il_gmem_start = gmem_block_offset + lane_in_tile + tile_id * tile_gmem_stride;
+    const int thread_il_smem_start = lane_in_tile + tile_id * TILE_SIZE;
+
+    bf vals[VALS_PER_THREAD];
+
+#pragma unroll
+    for (int i{0}, row{thread_il_gmem_start}; i < VALS_PER_THREAD; i++, row += interleaved_gmem_stride)
+      vals[i] = gmem_scratch.get_at_row(row);
+
+    reg_exchg_hypercube_inv<8, 16, 1>(vals);
+    reg_exchg_hypercube_inv<4, 8, 2>(vals);
+    reg_exchg_hypercube_inv<2, 4, 4>(vals);
+    reg_exchg_hypercube_inv<1, 2, 8>(vals);
+
+#pragma unroll
+    for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
+      smem_block[addr] = vals[i]; // write interleaved smem tiles
+  }
+
+  __syncthreads();
+
+  // Phase 2 (consecutive tiles): the remaining hypercube stages complete the
+  // monomials. Write them back (pre-scale) for the later cosets' initial
+  // passes and republish to smem so phase 3 can read the interleaved view.
+#pragma unroll
+  for (int role = 0; role < ROLES; role++) {
+    int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    asm volatile("mov.u32 %0, %0;" : "+r"(tile_id));
+    const int thread_ct_gmem_start = gmem_block_offset + lane_in_tile + tile_id * interleaved_gmem_stride;
+    const int thread_ct_smem_start = lane_in_tile + tile_id * TILE_SIZE * THREAD_TILES_PER_BLOCK;
+
+    bf vals[VALS_PER_THREAD];
+
+#pragma unroll
+    for (int i{0}, addr{thread_ct_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE)
+      vals[i] = smem_block[addr]; // read consecutive smem tiles
+
+    reg_exchg_hypercube_inv<8, 16, 1>(vals);
+    reg_exchg_hypercube_inv<4, 8, 2>(vals);
+    reg_exchg_hypercube_inv<2, 4, 4>(vals);
+    reg_exchg_hypercube_inv<1, 2, 8>(vals);
+
+#pragma unroll
+    for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
+      gmem_scratch.set_at_row(row, vals[i]);
+
+#pragma unroll
+    for (int i{0}, addr{thread_ct_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE)
+      smem_block[addr] = vals[i]; // republish consecutive smem tiles
+  }
+
+  __syncthreads();
+
+  // Phase 3 (interleaved tiles): coset scale on the natural rows (the
+  // natural labeling IS the exponent), then DIT stages 0..3 (mirrors the
+  // natural initial kernel's first half).
+#pragma unroll
+  for (int role = 0; role < ROLES; role++) {
+    int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    asm volatile("mov.u32 %0, %0;" : "+r"(tile_id));
+    const int thread_il_gmem_start = gmem_block_offset + lane_in_tile + tile_id * tile_gmem_stride;
+    const int thread_il_smem_start = lane_in_tile + tile_id * TILE_SIZE;
+
+    bf vals[VALS_PER_THREAD];
+
+#pragma unroll
+    for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
+      vals[i] = smem_block[addr]; // read interleaved smem tiles
+
+    if (coset_factor_power != 0) {
+      const bf power_delta = get_forward_twiddle_power(static_cast<unsigned>(interleaved_gmem_stride) * coset_factor_power);
+      bf power = get_forward_twiddle_power(static_cast<unsigned>(thread_il_gmem_start) * coset_factor_power);
+#pragma unroll
+      for (int i = 0; i < VALS_PER_THREAD - 1; i++) {
+        vals[i] = bf::mul(vals[i], power);
+        power = bf::mul(power, power_delta);
+      }
+      vals[VALS_PER_THREAD - 1] = bf::mul(vals[VALS_PER_THREAD - 1], power);
+    }
+
+    // This half always starts at exchange-region zero. Region zero's twiddle
+    // is the identity at every stage, so skip its 15 field multiplications.
+    reg_exchg_fwd_dit_offset_0<8, 16, 1>(vals);
+    reg_exchg_fwd_dit_offset_0<4, 8, 2>(vals);
+    reg_exchg_fwd_dit_offset_0<2, 4, 4>(vals);
+    reg_exchg_fwd_dit_offset_0<1, 2, 8>(vals);
+
+#pragma unroll
+    for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
+      smem_block[addr] = vals[i]; // write interleaved smem tiles
+  }
+
+  __syncthreads();
+
+  // Phase 4 (consecutive tiles): DIT stages 4..7, store the first coset's
+  // evals (mirrors the natural initial kernel's second half).
+#pragma unroll
+  for (int role = 0; role < ROLES; role++) {
+    int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    asm volatile("mov.u32 %0, %0;" : "+r"(tile_id));
+    const int thread_ct_gmem_start = gmem_block_offset + lane_in_tile + tile_id * interleaved_gmem_stride;
+    const int thread_ct_smem_start = lane_in_tile + tile_id * TILE_SIZE * THREAD_TILES_PER_BLOCK;
+
+    bf vals[VALS_PER_THREAD];
+
+#pragma unroll
+    for (int i{0}, addr{thread_ct_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE)
+      vals[i] = smem_block[addr]; // read consecutive smem tiles
+
+    int tile_exchg_region_offset = tile_id;
+    reg_exchg_fwd_dit<8, 16, 1>(vals, tile_exchg_region_offset);
+    tile_exchg_region_offset <<= 1;
+    reg_exchg_fwd_dit<4, 8, 2>(vals, tile_exchg_region_offset);
+    tile_exchg_region_offset <<= 1;
+    reg_exchg_fwd_dit<2, 4, 4>(vals, tile_exchg_region_offset);
+    tile_exchg_region_offset <<= 1;
+    reg_exchg_fwd_dit<1, 2, 8>(vals, tile_exchg_region_offset);
+
+#pragma unroll
+    for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
+      gmem_out.set_at_row(row, vals[i]);
+  }
+}
+
+EXTERN __launch_bounds__(256, 3) __global__
+    void ab_natural_lde_fused_boundary_writeback_out_cs_kernel(bf_matrix_getter_setter<ld_modifier::cg, st_modifier::cg> gmem_scratch,
+                                                               bf_matrix_setter<st_modifier::cs> gmem_out, const int log_n, const int coset_index_base,
+                                                               const int coset_factor_shift, const int num_cols_per_coset, const int log_cosets_in_tile) {
+  natural_lde_fused_boundary_writeback_out_cs_impl(gmem_scratch, gmem_out, log_n, coset_index_base, coset_factor_shift, num_cols_per_coset, log_cosets_in_tile);
+}
+
+#define DEFINE_FIXED_NATURAL_FUSED_OUT_CS(LOG_N, COSET_SHIFT)                                                                                                  \
+  EXTERN __launch_bounds__(256, 3) __global__ void ab_natural_lde_fused_boundary_writeback_out_cs_log_n_##LOG_N##_c1_kernel(                                   \
+      bf_matrix_getter_setter<ld_modifier::cg, st_modifier::cg> gmem_scratch, bf_matrix_setter<st_modifier::cs> gmem_out) {                                    \
+    natural_lde_fused_boundary_writeback_out_cs_impl(gmem_scratch, gmem_out, LOG_N, 1, COSET_SHIFT, 1, 0);                                                     \
+  }
+
+DEFINE_FIXED_NATURAL_FUSED_OUT_CS(21, 5)
+DEFINE_FIXED_NATURAL_FUSED_OUT_CS(22, 4)
+DEFINE_FIXED_NATURAL_FUSED_OUT_CS(23, 3)
+DEFINE_FIXED_NATURAL_FUSED_OUT_CS(24, 2)
+
+#undef DEFINE_FIXED_NATURAL_FUSED_OUT_CS
+
 template <int STAGES>
 DEVICE_FORCEINLINE void hypercube_evals_to_monomials_final_up_to_8_stages(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
                                                                           const bool transposed_monomials, const int log_n) {
   using namespace pass_config::three_pass_phase_b;
+  static_assert(STAGES >= 4 && STAGES <= 8);
   constexpr int INITIAL_EXCHG_REGIONS_PER_WARP = 1 << (10 - STAGES);
 
   const int lane_id = threadIdx.x & 31;
@@ -279,7 +502,8 @@ DEVICE_FORCEINLINE void hypercube_evals_to_monomials_final_up_to_8_stages(bf_mat
 
   warp_transpose_swizzled<VALS_PER_THREAD>(smem_warp, vals, lane_id);
 
-  reg_exchg_hypercube_inv<16, 32, 1>(vals);
+  if (STAGES >= 5)
+    reg_exchg_hypercube_inv<16, 32, 1>(vals);
   reg_exchg_hypercube_inv<8, 16, 2>(vals);
   reg_exchg_hypercube_inv<4, 8, 4>(vals);
   reg_exchg_hypercube_inv<2, 4, 8>(vals);
@@ -305,8 +529,14 @@ DEVICE_FORCEINLINE void hypercube_evals_to_monomials_final_up_to_8_stages(bf_mat
 }
 
 EXTERN __launch_bounds__(256, 3) __global__
-    void ab_hypercube_evals_to_monomials_final_8_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
+    void ab_hypercube_evals_to_monomials_final_4_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
                                                                const bool transposed_monomials, const int log_n) {
+  hypercube_evals_to_monomials_final_up_to_8_stages<4>(gmem_in, gmem_out, transposed_monomials, log_n);
+}
+
+EXTERN __launch_bounds__(256, 3) __global__
+    void ab_hypercube_evals_to_monomials_finest_8_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
+                                                                const bool transposed_monomials, const int log_n) {
   hypercube_evals_to_monomials_final_up_to_8_stages<8>(gmem_in, gmem_out, transposed_monomials, log_n);
 }
 

--- a/gpu/ntt/native/hypercube_evals_to_monomials_two_pass_compact.cu
+++ b/gpu/ntt/native/hypercube_evals_to_monomials_two_pass_compact.cu
@@ -1,0 +1,63 @@
+#include "ntt.cuh"
+
+namespace airbender::ntt {
+
+// Compact-range hypercube tail for log_n in [13, 20]. The preceding
+// nonfinal8 pass owns bits log_n-1 .. log_n-8; each block here owns one
+// consecutive 2^LOG_K-row chunk and applies the remaining bits LOG_K-1 .. 0.
+// There are exactly 2^8 disjoint chunks for LOG_K = log_n - 8. The family
+// uses LOG_K=5..11; log_n=20 keeps the faster 8+8+4 three-pass shape.
+constexpr int HYPERCUBE_COMPACT_THREADS = 256;
+
+template <int LOG_K>
+DEVICE_FORCEINLINE void hypercube_evals_to_monomials_last_stages_compact(bf_matrix_getter<ld_modifier::cg> gmem_in,
+                                                                         bf_matrix_setter<st_modifier::cg> gmem_out) {
+  static_assert(LOG_K >= 5 && LOG_K <= 11);
+  constexpr int K_VALS = 1 << LOG_K;
+  constexpr int HALF_K = K_VALS >> 1;
+
+  const int gmem_block_offset = static_cast<int>(blockIdx.x) << LOG_K;
+  gmem_in.add_row(gmem_block_offset);
+  gmem_out.add_row(gmem_block_offset);
+
+  extern __shared__ bf smem[];
+
+  for (int idx = threadIdx.x; idx < K_VALS; idx += HYPERCUBE_COMPACT_THREADS)
+    smem[idx] = gmem_in.get_at_row(idx);
+  __syncthreads();
+
+#pragma unroll
+  for (int stage = 0; stage < LOG_K; stage++) {
+    const int log_distance = LOG_K - 1 - stage;
+    const int distance = 1 << log_distance;
+    for (int gid = threadIdx.x; gid < HALF_K; gid += HYPERCUBE_COMPACT_THREADS) {
+      const int region = gid >> log_distance;
+      const int pair = gid & (distance - 1);
+      const int left_idx = (region << (log_distance + 1)) + pair;
+      const int right_idx = left_idx + distance;
+      smem[right_idx] = bf::sub(smem[right_idx], smem[left_idx]);
+    }
+    __syncthreads();
+  }
+
+  for (int idx = threadIdx.x; idx < K_VALS; idx += HYPERCUBE_COMPACT_THREADS)
+    gmem_out.set_at_row(idx, smem[idx]);
+}
+
+#define DEFINE_HYPERCUBE_LAST_COMPACT_KERNEL(LOG_K)                                                                                                            \
+  EXTERN __launch_bounds__(HYPERCUBE_COMPACT_THREADS, 2) __global__ void ab_hypercube_evals_to_monomials_last_##LOG_K##_stages_compact_kernel(                 \
+      bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out) {                                                                 \
+    hypercube_evals_to_monomials_last_stages_compact<LOG_K>(gmem_in, gmem_out);                                                                                \
+  }
+
+DEFINE_HYPERCUBE_LAST_COMPACT_KERNEL(5)
+DEFINE_HYPERCUBE_LAST_COMPACT_KERNEL(6)
+DEFINE_HYPERCUBE_LAST_COMPACT_KERNEL(7)
+DEFINE_HYPERCUBE_LAST_COMPACT_KERNEL(8)
+DEFINE_HYPERCUBE_LAST_COMPACT_KERNEL(9)
+DEFINE_HYPERCUBE_LAST_COMPACT_KERNEL(10)
+DEFINE_HYPERCUBE_LAST_COMPACT_KERNEL(11)
+
+#undef DEFINE_HYPERCUBE_LAST_COMPACT_KERNEL
+
+} // namespace airbender::ntt

--- a/gpu/ntt/native/natural_monomials_to_bitrev_evals_three_pass.cu
+++ b/gpu/ntt/native/natural_monomials_to_bitrev_evals_three_pass.cu
@@ -6,39 +6,6 @@
 
 namespace airbender::ntt {
 
-// Encode the rank-2 view used by the non-cross terminal TMA egress. The
-// global buffer is viewed as N/32 consecutive rows of 32 bf values, and each
-// warp writes one 32x32 box. Resolve the driver entry point through cudart so
-// the Rust final link does not acquire a direct libcuda dependency.
-EXTERN cudaError_t ab_encode_natural_final_output_tensor_map(CUtensorMap *tensor_map, bf *output, const unsigned long long n) {
-  struct Encoder {
-    decltype(&cuTensorMapEncodeTiled) function;
-    cudaError_t status;
-  };
-  static const Encoder encoder = [] {
-    void *raw_function = nullptr;
-    cudaDriverEntryPointQueryResult query_result{};
-    cudaError_t status = cudaGetDriverEntryPointByVersion("cuTensorMapEncodeTiled", &raw_function, 12000, cudaEnableDefault, &query_result);
-    if (status == cudaSuccess && (raw_function == nullptr || query_result != cudaDriverEntryPointSuccess))
-      status = cudaErrorNotSupported;
-    return Encoder{reinterpret_cast<decltype(&cuTensorMapEncodeTiled)>(raw_function), status};
-  }();
-  if (encoder.status != cudaSuccess)
-    return encoder.status;
-  if ((reinterpret_cast<uintptr_t>(tensor_map) & 127u) != 0 || (reinterpret_cast<uintptr_t>(output) & 127u) != 0 || n < 1024 || (n & 1023u) != 0)
-    return cudaErrorInvalidValue;
-
-  constexpr unsigned RANK = 2;
-  const cuuint64_t global_dims[RANK] = {32, static_cast<cuuint64_t>(n / 32)};
-  const cuuint64_t global_strides[RANK - 1] = {32 * sizeof(bf)};
-  const cuuint32_t box_dims[RANK] = {32, 32};
-  const cuuint32_t element_strides[RANK] = {1, 1};
-  const CUresult result =
-      encoder.function(tensor_map, CU_TENSOR_MAP_DATA_TYPE_UINT32, RANK, output, global_dims, global_strides, box_dims, element_strides,
-                       CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B, CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
-  return result == CUDA_SUCCESS ? cudaSuccess : cudaErrorInvalidValue;
-}
-
 // Natural-order monomials -> bitreversed-order evaluations, three-pass regime
 // (log_n in [21, 24]): out_k[p] = f(g_k * omega^rev_n(p)). Descending-stride
 // DIT network (pass structure cloned from evals_to_monomials_three_pass.cu)
@@ -776,6 +743,7 @@ DEVICE_FORCEINLINE void natural_monomials_to_bitrev_evals_final_up_to_8_stages_w
   __syncthreads();
 
   smem_warp = smem_block + warp_id * VALS_PER_WARP;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
   if constexpr (TMA_EGRESS) {
     // CU_TENSOR_MAP_SWIZZLE_128B XORs 16-byte chunks, not individual bf
     // values. A lane owns one logical 128-byte row. Its eight STS.128
@@ -806,7 +774,9 @@ DEVICE_FORCEINLINE void natural_monomials_to_bitrev_evals_final_up_to_8_stages_w
       asm volatile("cp.async.bulk.commit_group;" : : : "memory");
       asm volatile("cp.async.bulk.wait_group.read 0;" : : : "memory");
     }
-  } else {
+  } else
+#endif
+  {
     if constexpr (PACKED_SMEM_TRANSPOSE)
       warp_transpose_swizzled_v4<VALS_PER_THREAD>(smem_warp, vals, lane_id);
     else
@@ -1005,8 +975,10 @@ DEVICE_FORCEINLINE void natural_final_cross_column(bf_matrix_getter<ld_modifier:
       gmem_in, gmem_out, log_n, 1, 0, smem_block, nullptr, nullptr, next_hypercube_in.ptr);
   __syncthreads();
   if constexpr (PDL) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
     if (threadIdx.x == 0)
       cudaTriggerProgrammaticLaunchCompletion();
+#endif
   }
   cross_column_hypercube_finest<STAGES>(next_hypercube_in, next_pre_tail_out, smem_block);
 }

--- a/gpu/ntt/native/natural_monomials_to_bitrev_evals_three_pass.cu
+++ b/gpu/ntt/native/natural_monomials_to_bitrev_evals_three_pass.cu
@@ -1,7 +1,43 @@
+#include <cuda.h>
+
+#include "dit_memory.cuh"
 #include "ntt.cuh"
 #include "pass_config.cuh"
 
 namespace airbender::ntt {
+
+// Encode the rank-2 view used by the non-cross terminal TMA egress. The
+// global buffer is viewed as N/32 consecutive rows of 32 bf values, and each
+// warp writes one 32x32 box. Resolve the driver entry point through cudart so
+// the Rust final link does not acquire a direct libcuda dependency.
+EXTERN cudaError_t ab_encode_natural_final_output_tensor_map(CUtensorMap *tensor_map, bf *output, const unsigned long long n) {
+  struct Encoder {
+    decltype(&cuTensorMapEncodeTiled) function;
+    cudaError_t status;
+  };
+  static const Encoder encoder = [] {
+    void *raw_function = nullptr;
+    cudaDriverEntryPointQueryResult query_result{};
+    cudaError_t status = cudaGetDriverEntryPointByVersion("cuTensorMapEncodeTiled", &raw_function, 12000, cudaEnableDefault, &query_result);
+    if (status == cudaSuccess && (raw_function == nullptr || query_result != cudaDriverEntryPointSuccess))
+      status = cudaErrorNotSupported;
+    return Encoder{reinterpret_cast<decltype(&cuTensorMapEncodeTiled)>(raw_function), status};
+  }();
+  if (encoder.status != cudaSuccess)
+    return encoder.status;
+  if ((reinterpret_cast<uintptr_t>(tensor_map) & 127u) != 0 || (reinterpret_cast<uintptr_t>(output) & 127u) != 0 || n < 1024 || (n & 1023u) != 0)
+    return cudaErrorInvalidValue;
+
+  constexpr unsigned RANK = 2;
+  const cuuint64_t global_dims[RANK] = {32, static_cast<cuuint64_t>(n / 32)};
+  const cuuint64_t global_strides[RANK - 1] = {32 * sizeof(bf)};
+  const cuuint32_t box_dims[RANK] = {32, 32};
+  const cuuint32_t element_strides[RANK] = {1, 1};
+  const CUresult result =
+      encoder.function(tensor_map, CU_TENSOR_MAP_DATA_TYPE_UINT32, RANK, output, global_dims, global_strides, box_dims, element_strides,
+                       CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B, CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  return result == CUDA_SUCCESS ? cudaSuccess : cudaErrorInvalidValue;
+}
 
 // Natural-order monomials -> bitreversed-order evaluations, three-pass regime
 // (log_n in [21, 24]): out_k[p] = f(g_k * omega^rev_n(p)). Descending-stride
@@ -10,12 +46,11 @@ namespace airbender::ntt {
 // multi-coset shape: one shared input column feeds every coset's output slab,
 // with the coset pre-scale g_k^row fused into the load.
 
-// Pass 1: stages 0..7 (exchange region = the whole NTT).
-EXTERN __launch_bounds__(256, 3) __global__
-    void ab_natural_monomials_to_bitrev_evals_initial_8_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
-                                                                      const bool transposed_monomials, const int log_n, const int coset_index_base,
-                                                                      const int coset_factor_shift, const int num_cols_per_coset,
-                                                                      const int log_cosets_in_tile) {
+template <bool HYPERCUBE_FINAL4>
+DEVICE_FORCEINLINE void natural_monomials_to_bitrev_evals_initial_8_stages(bf_matrix_getter<ld_modifier::cg> gmem_in,
+                                                                           bf_matrix_setter<st_modifier::cg> gmem_out, const bool transposed_monomials,
+                                                                           const int log_n, const int coset_index_base, const int coset_factor_shift,
+                                                                           const int num_cols_per_coset, const int log_cosets_in_tile) {
   using namespace pass_config::three_pass_phase_a;
   constexpr int ROLES = 2;
   constexpr int ROLE_TILE_STRIDE = THREAD_TILES_PER_BLOCK / ROLES;
@@ -44,7 +79,8 @@ EXTERN __launch_bounds__(256, 3) __global__
 
 #pragma unroll
   for (int role = 0; role < ROLES; role++) {
-    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    asm volatile("mov.u32 %0, %0;" : "+r"(tile_id));
     const int thread_il_gmem_start = gmem_block_offset + lane_in_tile + tile_id * tile_gmem_stride;
     const int thread_il_smem_start = lane_in_tile + tile_id * TILE_SIZE;
 
@@ -54,26 +90,64 @@ EXTERN __launch_bounds__(256, 3) __global__
     for (int i{0}, row{thread_il_gmem_start}; i < VALS_PER_THREAD; i++, row += interleaved_gmem_stride)
       vals[i] = gmem_in.get_at_row(row);
 
+    // The log_n=20 hypercube pre-tail has exactly bits 3..0 left. In this
+    // load layout, threads in a warp hold consecutive physical rows for each
+    // fixed register index, so those four Mobius stages are XOR-lane
+    // exchanges. Every lane executes every shuffle; only the upper endpoint
+    // of each pair applies y -= x. The input stays read-only, allowing all
+    // cosets to share it in the existing flat tiled launch.
+    if (HYPERCUBE_FINAL4) {
+      constexpr unsigned WARP_MASK = 0xffffffff;
+#pragma unroll
+      for (int i{0}; i < VALS_PER_THREAD; i++) {
+#pragma unroll
+        for (int partner_mask = 8; partner_mask > 0; partner_mask >>= 1) {
+          const unsigned partner_bits = __shfl_xor_sync(WARP_MASK, bf::into_raw_u32(vals[i]), partner_mask);
+          if (lane_in_tile & partner_mask)
+            vals[i] = bf::sub(vals[i], bf::from_reduced_raw_repr(partner_bits));
+        }
+      }
+    }
+
     // A separate coset adjustment loop performs better than interleaving
     // adjustments with loads. The natural labeling IS the exponent, so no
     // bitrev here; `transposed_row_to_effective_row` resolves the physical
     // row of the transposed-monomial layout to its logical row.
+    // Branch (grid-uniform) instead of a per-element ternary: the ternary
+    // makes the compiler compute the transposed-layout row math and discard
+    // it on the natural path.
     if (coset_factor_power != 0) {
+      if (transposed_monomials) {
 #pragma unroll
-      for (int i{0}, row{thread_il_gmem_start}; i < VALS_PER_THREAD; i++, row += interleaved_gmem_stride) {
-        const int effective_row = transposed_monomials ? transposed_row_to_effective_row(row) : row;
-        vals[i] = bf::mul(vals[i], get_forward_twiddle_power(static_cast<unsigned>(effective_row) * coset_factor_power));
+        for (int i{0}, row{thread_il_gmem_start}; i < VALS_PER_THREAD; i++, row += interleaved_gmem_stride)
+          vals[i] = bf::mul(vals[i], get_forward_twiddle_power(static_cast<unsigned>(transposed_row_to_effective_row(row)) * coset_factor_power));
+      } else {
+        if constexpr (HYPERCUBE_FINAL4) {
+          // The log_n=20 fused boundary reads natural rows in an arithmetic
+          // progression. Seed its geometric power progression once per role
+          // instead of reconstructing all 16 powers independently.
+          const bf power_delta = get_forward_twiddle_power(static_cast<unsigned>(interleaved_gmem_stride) * coset_factor_power);
+          bf power = get_forward_twiddle_power(static_cast<unsigned>(thread_il_gmem_start) * coset_factor_power);
+#pragma unroll
+          for (int i = 0; i < VALS_PER_THREAD - 1; i++) {
+            vals[i] = bf::mul(vals[i], power);
+            power = bf::mul(power, power_delta);
+          }
+          vals[VALS_PER_THREAD - 1] = bf::mul(vals[VALS_PER_THREAD - 1], power);
+        } else {
+#pragma unroll
+          for (int i{0}, row{thread_il_gmem_start}; i < VALS_PER_THREAD; i++, row += interleaved_gmem_stride)
+            vals[i] = bf::mul(vals[i], get_forward_twiddle_power(static_cast<unsigned>(row) * coset_factor_power));
+        }
       }
     }
 
-    int block_exchg_region_offset = 0; // start_stage == 0: one exchange region
-    reg_exchg_fwd_dit<8, 16, 1>(vals, block_exchg_region_offset);
-    block_exchg_region_offset <<= 1;
-    reg_exchg_fwd_dit<4, 8, 2>(vals, block_exchg_region_offset);
-    block_exchg_region_offset <<= 1;
-    reg_exchg_fwd_dit<2, 4, 4>(vals, block_exchg_region_offset);
-    block_exchg_region_offset <<= 1;
-    reg_exchg_fwd_dit<1, 2, 8>(vals, block_exchg_region_offset);
+    // This half always starts at exchange-region zero. Region zero's twiddle
+    // is the identity at every stage, so skip its 15 field multiplications.
+    reg_exchg_fwd_dit_offset_0<8, 16, 1>(vals);
+    reg_exchg_fwd_dit_offset_0<4, 8, 2>(vals);
+    reg_exchg_fwd_dit_offset_0<2, 4, 4>(vals);
+    reg_exchg_fwd_dit_offset_0<1, 2, 8>(vals);
 
 #pragma unroll
     for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
@@ -84,7 +158,10 @@ EXTERN __launch_bounds__(256, 3) __global__
 
 #pragma unroll
   for (int role = 0; role < ROLES; role++) {
-    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    // Keep the second role's address/twiddle seed local to its unrolled body.
+    // Otherwise ptxas hoists it across the first role and spills one word.
+    asm volatile("mov.u32 %0, %0;" : "+r"(tile_id));
     const int thread_ct_gmem_start = gmem_block_offset + lane_in_tile + tile_id * interleaved_gmem_stride;
     const int thread_ct_smem_start = lane_in_tile + tile_id * TILE_SIZE * THREAD_TILES_PER_BLOCK;
 
@@ -107,15 +184,93 @@ EXTERN __launch_bounds__(256, 3) __global__
     // 1024-row transposition chunk (so the layout does not disturb its
     // butterflies or twiddle groups), but passes 2 and 3 exchange rows WITHIN
     // a chunk and require natural row order.
+    if (transposed_monomials) {
 #pragma unroll
-    for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
-      gmem_out.set_at_row(transposed_monomials ? transposed_row_to_effective_row(row) : row, vals[i]);
+      for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
+        gmem_out.set_at_row(transposed_row_to_effective_row(row), vals[i]);
+    } else {
+#pragma unroll
+      for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
+        gmem_out.set_at_row(row, vals[i]);
+    }
+  }
+}
+
+// Pass 1: stages 0..7 (exchange region = the whole NTT).
+EXTERN __launch_bounds__(256, 3) __global__
+    void ab_natural_monomials_to_bitrev_evals_initial_8_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
+                                                                      const bool transposed_monomials, const int log_n, const int coset_index_base,
+                                                                      const int coset_factor_shift, const int num_cols_per_coset,
+                                                                      const int log_cosets_in_tile) {
+  natural_monomials_to_bitrev_evals_initial_8_stages<false>(gmem_in, gmem_out, transposed_monomials, log_n, coset_index_base, coset_factor_shift,
+                                                            num_cols_per_coset, log_cosets_in_tile);
+}
+
+// Commitment-only log_n=20 boundary: hypercube final4 plus the unchanged
+// natural-to-bitrev initial8. The pre-tail scratch is deliberately read-only.
+EXTERN __launch_bounds__(256, 1) __global__ void ab_natural_monomials_to_bitrev_evals_initial_8_stages_from_hypercube_final_4_kernel(
+    bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out, const bool transposed_monomials, const int log_n,
+    const int coset_index_base, const int coset_factor_shift, const int num_cols_per_coset, const int log_cosets_in_tile) {
+  natural_monomials_to_bitrev_evals_initial_8_stages<true>(gmem_in, gmem_out, transposed_monomials, log_n, coset_index_base, coset_factor_shift,
+                                                           num_cols_per_coset, log_cosets_in_tile);
+}
+
+template <int STRIDE, int REGION_SIZE, int NUM_REGIONS>
+DEVICE_FORCEINLINE void reg_exchg_precomputed_twiddles_fwd_dit(bf *vals, const int exchg_region_offset) {
+#pragma unroll
+  for (int region = 0; region < NUM_REGIONS; region++) {
+    const bf twiddle = mem::load_ca(ab_fully_precomputed_bitrev_twiddles + exchg_region_offset + region);
+    const int region_offset = region * REGION_SIZE;
+#pragma unroll
+    for (int lane_in_region = 0; lane_in_region < STRIDE; lane_in_region++) {
+      const int i = region_offset + lane_in_region;
+      exchg_dit(vals[i], vals[i + STRIDE], twiddle);
+    }
+  }
+}
+
+template <int STRIDE, int REGION_SIZE, int NUM_REGIONS>
+DEVICE_FORCEINLINE void reg_exchg_packed_precomputed_twiddles_fwd_dit(bf *vals, const int exchg_region_offset) {
+  static_assert(NUM_REGIONS == 1 || NUM_REGIONS == 2 || NUM_REGIONS == 4 || NUM_REGIONS == 8);
+
+  // Every caller doubles the exchange-region offset before doubling the
+  // region count, so the table run is naturally aligned to its packed width.
+  // All lanes in a warp use the same address: unlike strided value egress,
+  // these vector loads remain one coalesced/broadcast global transaction.
+  const bf *src = ab_fully_precomputed_bitrev_twiddles + exchg_region_offset;
+  bf twiddles[NUM_REGIONS];
+  if constexpr (NUM_REGIONS == 1) {
+    twiddles[0] = mem::load_ca(src);
+  } else if constexpr (NUM_REGIONS == 2) {
+    const bf2_wide packed = mem::load_ca(reinterpret_cast<const bf2_wide *>(src));
+    twiddles[0] = packed.v[0];
+    twiddles[1] = packed.v[1];
+  } else if constexpr (NUM_REGIONS == 4) {
+    const bf4_wide packed = mem::load_ca(reinterpret_cast<const bf4_wide *>(src));
+#pragma unroll
+    for (int i = 0; i < NUM_REGIONS; i++)
+      twiddles[i] = packed.v[i];
+  } else {
+    const bf8_wide packed = mem::load_ca(reinterpret_cast<const bf8_wide *>(src));
+#pragma unroll
+    for (int i = 0; i < NUM_REGIONS; i++)
+      twiddles[i] = packed.v[i];
+  }
+
+#pragma unroll
+  for (int region = 0; region < NUM_REGIONS; region++) {
+    const int region_offset = region * REGION_SIZE;
+#pragma unroll
+    for (int lane_in_region = 0; lane_in_region < STRIDE; lane_in_region++) {
+      const int i = region_offset + lane_in_region;
+      exchg_dit(vals[i], vals[i + STRIDE], twiddles[region]);
+    }
   }
 }
 
 // Pass 2: 8 in-place stages per coset starting at `start_stage` (8 in the
-// three-pass plan). Same tile exchange as the inverse nonfinal kernel, always
-// on the two-level cmem twiddle lookup (correct for any start_stage).
+// three-pass plan). Its largest twiddle index is below 2^15, so the existing
+// fully-precomputed order-2^18 table contains this order-2^16 prefix exactly.
 EXTERN __launch_bounds__(256, 3) __global__
     void ab_natural_monomials_to_bitrev_evals_middle_8_stages_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out,
                                                                      const int log_n, const int start_stage, const int num_cols_per_coset,
@@ -123,17 +278,18 @@ EXTERN __launch_bounds__(256, 3) __global__
   using namespace pass_config::three_pass_phase_a;
   constexpr int ROLES = 2;
   constexpr int ROLE_TILE_STRIDE = THREAD_TILES_PER_BLOCK / ROLES;
+  constexpr int START_STAGE = 8;
 
   const int lane_in_tile = threadIdx.x & 31;
 
-  const int exchg_region_size = 1 << (log_n - start_stage);
+  const int exchg_region_size = 1 << (log_n - START_STAGE);
   const int tile_gmem_stride = exchg_region_size >> LOG_DATA_TILES_PER_BLOCK;
   const int interleaved_gmem_stride = tile_gmem_stride * THREAD_TILES_PER_BLOCK;
 
   //   log_blocks_x = log_n - start_stage - 13 (blocks per exchg region)
   //   log_blocks_y = start_stage              (num exchg regions)
-  const unsigned log_blocks_x = static_cast<unsigned>(log_n - start_stage - 13);
-  const unsigned log_blocks_y = static_cast<unsigned>(start_stage);
+  const unsigned log_blocks_x = static_cast<unsigned>(log_n - START_STAGE - 13);
+  constexpr unsigned log_blocks_y = START_STAGE;
   const FlatBlockIndex fi = decompose_flat_2d(log_blocks_x, log_blocks_y, static_cast<unsigned>(log_cosets_in_tile));
   apply_flat_col_offset(fi, num_cols_per_coset, gmem_in, gmem_out);
   const unsigned blocks_per_exchg_region = 1u << log_blocks_x;
@@ -161,13 +317,13 @@ EXTERN __launch_bounds__(256, 3) __global__
       vals[i] = gmem_in.get_at_row(addr);
 
     int block_exchg_region_offset = alternating_block_idx_y;
-    reg_exchg_cmem_twiddles_fwd_dit<8, 16, 1>(vals, block_exchg_region_offset);
+    reg_exchg_precomputed_twiddles_fwd_dit<8, 16, 1>(vals, block_exchg_region_offset);
     block_exchg_region_offset <<= 1;
-    reg_exchg_cmem_twiddles_fwd_dit<4, 8, 2>(vals, block_exchg_region_offset);
+    reg_exchg_precomputed_twiddles_fwd_dit<4, 8, 2>(vals, block_exchg_region_offset);
     block_exchg_region_offset <<= 1;
-    reg_exchg_cmem_twiddles_fwd_dit<2, 4, 4>(vals, block_exchg_region_offset);
+    reg_exchg_precomputed_twiddles_fwd_dit<2, 4, 4>(vals, block_exchg_region_offset);
     block_exchg_region_offset <<= 1;
-    reg_exchg_cmem_twiddles_fwd_dit<1, 2, 8>(vals, block_exchg_region_offset);
+    reg_exchg_precomputed_twiddles_fwd_dit<1, 2, 8>(vals, block_exchg_region_offset);
 
 #pragma unroll
     for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
@@ -189,13 +345,13 @@ EXTERN __launch_bounds__(256, 3) __global__
       vals[i] = smem_block[addr]; // read consecutive smem tiles
 
     int tile_exchg_region_offset = (alternating_block_idx_y << 4) + tile_id;
-    reg_exchg_cmem_twiddles_fwd_dit<8, 16, 1>(vals, tile_exchg_region_offset);
+    reg_exchg_precomputed_twiddles_fwd_dit<8, 16, 1>(vals, tile_exchg_region_offset);
     tile_exchg_region_offset <<= 1;
-    reg_exchg_cmem_twiddles_fwd_dit<4, 8, 2>(vals, tile_exchg_region_offset);
+    reg_exchg_precomputed_twiddles_fwd_dit<4, 8, 2>(vals, tile_exchg_region_offset);
     tile_exchg_region_offset <<= 1;
-    reg_exchg_cmem_twiddles_fwd_dit<2, 4, 4>(vals, tile_exchg_region_offset);
+    reg_exchg_precomputed_twiddles_fwd_dit<2, 4, 4>(vals, tile_exchg_region_offset);
     tile_exchg_region_offset <<= 1;
-    reg_exchg_cmem_twiddles_fwd_dit<1, 2, 8>(vals, tile_exchg_region_offset);
+    reg_exchg_precomputed_twiddles_fwd_dit<1, 2, 8>(vals, tile_exchg_region_offset);
 
 #pragma unroll
     for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += tile_gmem_stride)
@@ -203,44 +359,328 @@ EXTERN __launch_bounds__(256, 3) __global__
   }
 }
 
+// Fixed one-NTT, one-coset production shape.
+template <int LOG_N>
+DEVICE_FORCEINLINE void natural_monomials_to_bitrev_evals_middle_8_stages_fixed_packed(bf_matrix_getter<ld_modifier::cg> gmem_in,
+                                                                                       bf_matrix_setter<st_modifier::cg> gmem_out, bf *smem_block) {
+  using namespace pass_config::three_pass_phase_a;
+  static_assert(LOG_N >= 22 && LOG_N <= 24);
+  constexpr int ROLES = 2;
+  constexpr int ROLE_TILE_STRIDE = THREAD_TILES_PER_BLOCK / ROLES;
+  constexpr int EXCHG_REGION_SIZE = 1 << (LOG_N - 8);
+  constexpr int TILE_GMEM_STRIDE = EXCHG_REGION_SIZE >> LOG_DATA_TILES_PER_BLOCK;
+  constexpr int INTERLEAVED_GMEM_STRIDE = TILE_GMEM_STRIDE * THREAD_TILES_PER_BLOCK;
+  constexpr int LOG_BLOCKS_PER_EXCHG_REGION = LOG_N - 21;
+  constexpr int BLOCKS_PER_EXCHG_REGION = 1 << LOG_BLOCKS_PER_EXCHG_REGION;
+  constexpr int NUM_EXCHG_REGIONS = 256;
+
+  const int lane_in_tile = threadIdx.x & 31;
+  const unsigned intra_x = blockIdx.x & (BLOCKS_PER_EXCHG_REGION - 1);
+  const unsigned intra_y = blockIdx.x >> LOG_BLOCKS_PER_EXCHG_REGION;
+
+  const int alternating_block_idx_x = BLOCKS_PER_EXCHG_REGION - 1 - static_cast<int>(intra_x);
+  const int alternating_block_idx_y = NUM_EXCHG_REGIONS - 1 - static_cast<int>(intra_y);
+  const int gmem_block_offset = alternating_block_idx_y * EXCHG_REGION_SIZE + (alternating_block_idx_x << LOG_DATA_TILE_SIZE);
+  gmem_in.add_row(gmem_block_offset);
+  gmem_out.add_row(gmem_block_offset);
+
+#pragma unroll
+  for (int role = 0; role < ROLES; role++) {
+    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    const int thread_il_gmem_start = lane_in_tile + tile_id * TILE_GMEM_STRIDE;
+    const int thread_il_smem_start = lane_in_tile + tile_id * TILE_SIZE;
+
+    bf vals[VALS_PER_THREAD];
+
+#pragma unroll
+    for (int i{0}, addr{thread_il_gmem_start}; i < VALS_PER_THREAD; i++, addr += INTERLEAVED_GMEM_STRIDE)
+      vals[i] = gmem_in.get_at_row(addr);
+
+    int block_exchg_region_offset = alternating_block_idx_y;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<8, 16, 1>(vals, block_exchg_region_offset);
+    block_exchg_region_offset <<= 1;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<4, 8, 2>(vals, block_exchg_region_offset);
+    block_exchg_region_offset <<= 1;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<2, 4, 4>(vals, block_exchg_region_offset);
+    block_exchg_region_offset <<= 1;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<1, 2, 8>(vals, block_exchg_region_offset);
+
+#pragma unroll
+    for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
+      smem_block[addr] = vals[i];
+  }
+
+  __syncthreads();
+
+#pragma unroll
+  for (int role = 0; role < ROLES; role++) {
+    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    const int thread_ct_gmem_start = lane_in_tile + tile_id * INTERLEAVED_GMEM_STRIDE;
+    const int thread_ct_smem_start = lane_in_tile + tile_id * TILE_SIZE * THREAD_TILES_PER_BLOCK;
+
+    bf vals[VALS_PER_THREAD];
+
+#pragma unroll
+    for (int i{0}, addr{thread_ct_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE)
+      vals[i] = smem_block[addr];
+
+    int tile_exchg_region_offset = (alternating_block_idx_y << 4) + tile_id;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<8, 16, 1>(vals, tile_exchg_region_offset);
+    tile_exchg_region_offset <<= 1;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<4, 8, 2>(vals, tile_exchg_region_offset);
+    tile_exchg_region_offset <<= 1;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<2, 4, 4>(vals, tile_exchg_region_offset);
+    tile_exchg_region_offset <<= 1;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<1, 2, 8>(vals, tile_exchg_region_offset);
+
+#pragma unroll
+    for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += TILE_GMEM_STRIDE)
+      gmem_out.set_at_row(row, vals[i]);
+  }
+}
+
+#define DEFINE_NATURAL_MIDDLE_FIXED_PACKED(LOG_N)                                                                                                              \
+  EXTERN __launch_bounds__(256, 3) __global__ void ab_natural_monomials_to_bitrev_evals_middle_8_stages_log_n_##LOG_N##_packed_twiddles_kernel(                \
+      bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out) {                                                                 \
+    __shared__ bf smem_block[8192];                                                                                                                            \
+    natural_monomials_to_bitrev_evals_middle_8_stages_fixed_packed<LOG_N>(gmem_in, gmem_out, smem_block);                                                      \
+  }
+
+DEFINE_NATURAL_MIDDLE_FIXED_PACKED(22)
+DEFINE_NATURAL_MIDDLE_FIXED_PACKED(23)
+DEFINE_NATURAL_MIDDLE_FIXED_PACKED(24)
+
+#undef DEFINE_NATURAL_MIDDLE_FIXED_PACKED
+
+// At log_n=21 the 128 MiB L2 strategy keeps both LDE cosets in one launch and
+// may also batch several columns. Specialize the fixed block/coset geometry
+// while retaining the runtime column stride needed by that batching.
+EXTERN __launch_bounds__(256, 3) __global__
+    void ab_natural_monomials_to_bitrev_evals_middle_8_stages_log_n_21_two_cosets_packed_twiddles_kernel(bf_matrix_getter<ld_modifier::cg> gmem_in,
+                                                                                                         bf_matrix_setter<st_modifier::cg> gmem_out,
+                                                                                                         const int num_cols_per_coset) {
+  using namespace pass_config::three_pass_phase_a;
+  constexpr int ROLES = 2;
+  constexpr int ROLE_TILE_STRIDE = THREAD_TILES_PER_BLOCK / ROLES;
+  constexpr int EXCHG_REGION_SIZE = 1 << 13;
+  constexpr int TILE_GMEM_STRIDE = EXCHG_REGION_SIZE >> LOG_DATA_TILES_PER_BLOCK;
+  constexpr int INTERLEAVED_GMEM_STRIDE = TILE_GMEM_STRIDE * THREAD_TILES_PER_BLOCK;
+  constexpr int NUM_EXCHG_REGIONS = 256;
+
+  const int lane_in_tile = threadIdx.x & 31;
+  const unsigned intra_y = blockIdx.x & (NUM_EXCHG_REGIONS - 1);
+  const unsigned ntt_idx = blockIdx.x >> 8;
+  const unsigned coset = ntt_idx & 1;
+  const unsigned col = ntt_idx >> 1;
+  const int col_offset = static_cast<int>(coset) * num_cols_per_coset + static_cast<int>(col);
+  gmem_in.add_col(col_offset);
+  gmem_out.add_col(col_offset);
+
+  const int alternating_block_idx_y = NUM_EXCHG_REGIONS - 1 - static_cast<int>(intra_y);
+  const int gmem_block_offset = alternating_block_idx_y * EXCHG_REGION_SIZE;
+  gmem_in.add_row(gmem_block_offset);
+  gmem_out.add_row(gmem_block_offset);
+
+  __shared__ bf smem_block[8192];
+
+#pragma unroll
+  for (int role = 0; role < ROLES; role++) {
+    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    const int thread_il_gmem_start = lane_in_tile + tile_id * TILE_GMEM_STRIDE;
+    const int thread_il_smem_start = lane_in_tile + tile_id * TILE_SIZE;
+
+    bf vals[VALS_PER_THREAD];
+
+#pragma unroll
+    for (int i{0}, addr{thread_il_gmem_start}; i < VALS_PER_THREAD; i++, addr += INTERLEAVED_GMEM_STRIDE)
+      vals[i] = gmem_in.get_at_row(addr);
+
+    int block_exchg_region_offset = alternating_block_idx_y;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<8, 16, 1>(vals, block_exchg_region_offset);
+    block_exchg_region_offset <<= 1;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<4, 8, 2>(vals, block_exchg_region_offset);
+    block_exchg_region_offset <<= 1;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<2, 4, 4>(vals, block_exchg_region_offset);
+    block_exchg_region_offset <<= 1;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<1, 2, 8>(vals, block_exchg_region_offset);
+
+#pragma unroll
+    for (int i{0}, addr{thread_il_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE * THREAD_TILES_PER_BLOCK)
+      smem_block[addr] = vals[i];
+  }
+
+  __syncthreads();
+
+#pragma unroll
+  for (int role = 0; role < ROLES; role++) {
+    const int tile_id = (threadIdx.x >> LOG_DATA_TILE_SIZE) + role * ROLE_TILE_STRIDE;
+    const int thread_ct_gmem_start = lane_in_tile + tile_id * INTERLEAVED_GMEM_STRIDE;
+    const int thread_ct_smem_start = lane_in_tile + tile_id * TILE_SIZE * THREAD_TILES_PER_BLOCK;
+
+    bf vals[VALS_PER_THREAD];
+
+#pragma unroll
+    for (int i{0}, addr{thread_ct_smem_start}; i < VALS_PER_THREAD; i++, addr += TILE_SIZE)
+      vals[i] = smem_block[addr];
+
+    int tile_exchg_region_offset = (alternating_block_idx_y << 4) + tile_id;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<8, 16, 1>(vals, tile_exchg_region_offset);
+    tile_exchg_region_offset <<= 1;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<4, 8, 2>(vals, tile_exchg_region_offset);
+    tile_exchg_region_offset <<= 1;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<2, 4, 4>(vals, tile_exchg_region_offset);
+    tile_exchg_region_offset <<= 1;
+    reg_exchg_packed_precomputed_twiddles_fwd_dit<1, 2, 8>(vals, tile_exchg_region_offset);
+
+#pragma unroll
+    for (int i{0}, row{thread_ct_gmem_start}; i < VALS_PER_THREAD; i++, row += TILE_GMEM_STRIDE)
+      gmem_out.set_at_row(row, vals[i]);
+  }
+}
+
 // Pass 3: the final STAGES (= log_n - 16) finest stages, in place per coset.
 // Outputs are always written in plain (non-transposed) row order: the
 // bitreversed codeword is what the tree layer consumes.
-template <int STAGES>
-DEVICE_FORCEINLINE void natural_monomials_to_bitrev_evals_final_up_to_8_stages(bf_matrix_getter<ld_modifier::cg> gmem_in,
-                                                                               bf_matrix_setter<st_modifier::cg> gmem_out, const int log_n,
-                                                                               const int num_cols_per_coset, const int log_cosets_in_tile) {
+template <int STRIDE, int REGION_SIZE, int NUM_REGIONS>
+DEVICE_FORCEINLINE void reg_exchg_aligned_cmem_smem_twiddles_fwd_dit(bf *vals, const int exchg_region_offset, const bf *smem_twiddles) {
+  static_assert(NUM_REGIONS > 0 && NUM_REGIONS <= 16);
+  static_assert((NUM_REGIONS & (NUM_REGIONS - 1)) == 0);
+  static_assert((32 % NUM_REGIONS) == 0);
+
+  // Every terminal call aligns the exchange-region offset to NUM_REGIONS.
+  // Since NUM_REGIONS divides both a 32-entry swizzle row and the 4096-entry
+  // coarse table, the unrolled run crosses neither boundary. Swizzling the
+  // aligned base once and XORing the region is therefore identical to
+  // swizzling every coarse index independently.
+  const int fine_idx = (exchg_region_offset >> EightStages::COARSE_LOG_COUNT) & EightStages::FINE_MASK;
+  const int coarse_base = exchg_region_offset & EightStages::COARSE_MASK;
+  const int swizzled_coarse_base = linear_to_swizzled(coarse_base);
+  // Entry zero is BF::ONE by construction in generate_fwd_inv_arrays. The
+  // zero-fine regions are rare here, so exact identity multiplications are
+  // cheaper than duplicating the fully unrolled butterfly body around a branch.
+  const bf fine = ab_fwd_cmem_twiddles_finest_11[fine_idx];
+#pragma unroll
+  for (int region = 0; region < NUM_REGIONS; region++) {
+    const bf coarse = smem_twiddles[swizzled_coarse_base ^ region];
+    const bf twiddle = bf::mul(fine, coarse);
+    const int region_offset = region * REGION_SIZE;
+#pragma unroll
+    for (int lane_in_region = 0; lane_in_region < STRIDE; lane_in_region++) {
+      const int i = region_offset + lane_in_region;
+      exchg_dit(vals[i], vals[i + STRIDE], twiddle);
+    }
+  }
+}
+
+// A 16-byte-chunk XOR swizzle for the packed half of a 32x32 warp
+// transpose. Four consecutive logical x coordinates stay physically
+// consecutive and aligned, while the chunk index retains the bank-rotation
+// property of xy_to_swizzled.
+DEVICE_FORCEINLINE int xy_to_swizzled_v4(const int x, const int y) { return y * 32 + 4 * ((y & 7) ^ (x >> 2)) + (x & 3); }
+
+template <unsigned N> DEVICE_FORCEINLINE void warp_transpose_swizzled_v4(bf *smem_warp, bf *vals, const int lane) {
+  static_assert(N == 32, "warp_transpose_swizzled_v4 assumes a 32-wide warp tile");
+#pragma unroll
+  for (int y = 0; y < static_cast<int>(N); y++)
+    smem_warp[xy_to_swizzled_v4(lane, y)] = vals[y];
+  __syncwarp();
+#pragma unroll
+  for (int chunk = 0; chunk < static_cast<int>(N) / 4; chunk++) {
+    const int x = 4 * chunk;
+    ld_shared_v4(smem_warp + xy_to_swizzled_v4(x, lane), vals[x], vals[x + 1], vals[x + 2], vals[x + 3]);
+  }
+}
+
+template <unsigned N> DEVICE_FORCEINLINE void warp_transpose_swizzled_v4_mirror(bf *smem_warp, bf *vals, const int lane) {
+  static_assert(N == 32, "warp_transpose_swizzled_v4_mirror assumes a 32-wide warp tile");
+#pragma unroll
+  for (int chunk = 0; chunk < static_cast<int>(N) / 4; chunk++) {
+    const int x = 4 * chunk;
+    st_shared_v4(smem_warp + xy_to_swizzled_v4(x, lane), vals[x], vals[x + 1], vals[x + 2], vals[x + 3]);
+  }
+  __syncwarp();
+#pragma unroll
+  for (int y = 0; y < static_cast<int>(N); y++)
+    vals[y] = smem_warp[xy_to_swizzled_v4(lane, y)];
+}
+
+template <int STAGES, ld_modifier LD, st_modifier ST, bool HOIST_FINE, bool BULK_TWIDDLES, bool TMA_EGRESS = false, bool DELAYED_NEXT_PREFETCH = false,
+          bool PACKED_SMEM_TRANSPOSE = false, bool PACKED_PRECOMPUTED_NUM2 = false>
+DEVICE_FORCEINLINE void natural_monomials_to_bitrev_evals_final_up_to_8_stages_with_smem(
+    bf_matrix_getter<LD> gmem_in, bf_matrix_setter<ST> gmem_out, const int log_n, const int num_cols_per_coset, const int log_cosets_in_tile, bf *smem_block,
+    unsigned long long *twiddle_copy_barrier, const CUtensorMap *output_tensor_map = nullptr, const bf *delayed_prefetch_src = nullptr) {
   using namespace pass_config::three_pass_phase_b;
   constexpr int INITIAL_EXCHG_REGIONS_PER_WARP = 1 << (10 - STAGES);
 
   const unsigned log_blocks_per_ntt = static_cast<unsigned>(log_n) - 13u;
   const FlatBlockIndex fi = decompose_flat_1d(log_blocks_per_ntt, static_cast<unsigned>(log_cosets_in_tile));
-  apply_flat_col_offset(fi, num_cols_per_coset, gmem_in, gmem_out);
+  // apply_flat_col_offset is pinned to cg accessors; inline it for the
+  // modifier-templated body.
+  const int col_offset = static_cast<int>(fi.coset) * num_cols_per_coset + static_cast<int>(fi.col);
+  gmem_in.add_col(col_offset);
+  gmem_out.add_col(col_offset);
 
   const int lane_id = threadIdx.x & 31;
   const int warp_id = threadIdx.x >> 5;
-  const int pipeline_memcpy_start = 4 * threadIdx.x;
-  const int pipeline_memcpy_stride = 4 * blockDim.x;
   const int gmem_block_offset = static_cast<int>(fi.intra_x) * VALS_PER_BLOCK;
   gmem_in.add_row(gmem_block_offset + warp_id * VALS_PER_WARP);
   gmem_out.add_row(gmem_block_offset + warp_id * VALS_PER_WARP);
 
-  __shared__ bf smem_block[8192]; // 4096 vals, 4096 coarse twiddles
   bf *smem_warp = smem_block + (warp_id & 3) * VALS_PER_WARP;
   bf *smem_twiddles = smem_block + (VALS_PER_BLOCK >> 1);
 
   bf vals[VALS_PER_THREAD];
 
-  // Cooperatively fetch the coarse gmem twiddle powers used by the last 5
-  // stages. The gmem layout is already swizzled, so it's a linear copy.
+  if constexpr (BULK_TWIDDLES) {
+#if __CUDA_ARCH__ >= 900
+    // One CTA-owned bulk transaction stages the 16 KiB coarse table while the
+    // block loads its values and executes the cmem-only stages. Thread 0 is the
+    // sole barrier participant; after it observes transaction completion, the
+    // existing CTA barrier below publishes the table to every thread.
+    if (threadIdx.x == 0) {
+      const unsigned mbar_s = static_cast<unsigned>(__cvta_generic_to_shared(twiddle_copy_barrier));
+      const unsigned dst_s = static_cast<unsigned>(__cvta_generic_to_shared(smem_twiddles));
+      constexpr unsigned COPY_BYTES = 4096 * sizeof(bf);
+      asm volatile("mbarrier.init.shared::cta.b64 [%0], 1;" : : "r"(mbar_s));
+      asm volatile("fence.mbarrier_init.release.cluster;" : : : "memory");
+      asm volatile("mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;" : : "r"(mbar_s), "r"(COPY_BYTES));
+      asm volatile("cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];"
+                   :
+                   : "r"(dst_s), "l"(ab_fwd_gmem_twiddles_coarse), "r"(COPY_BYTES), "r"(mbar_s)
+                   : "memory");
+    }
+#else
+    const int pipeline_memcpy_start = 4 * threadIdx.x;
+    const int pipeline_memcpy_stride = 4 * blockDim.x;
+    const bf *twiddle_src = ab_fwd_gmem_twiddles_coarse;
 #pragma unroll
-  for (int i{0}, addr{pipeline_memcpy_start}; i < 4; i++, addr += pipeline_memcpy_stride)
-    __pipeline_memcpy_async(smem_twiddles + addr, ab_fwd_gmem_twiddles_coarse + addr, 4 * sizeof(bf));
-  __pipeline_commit();
+    for (int i{0}, addr{pipeline_memcpy_start}; i < 4; i++, addr += pipeline_memcpy_stride)
+      __pipeline_memcpy_async(smem_twiddles + addr, twiddle_src + addr, 4 * sizeof(bf));
+    __pipeline_commit();
+#endif
+  } else {
+    // Keep the cross body under its 128-register budget.
+    const int pipeline_memcpy_start = 4 * threadIdx.x;
+    const int pipeline_memcpy_stride = 4 * blockDim.x;
+    const bf *twiddle_src = ab_fwd_gmem_twiddles_coarse;
+#pragma unroll
+    for (int i{0}, addr{pipeline_memcpy_start}; i < 4; i++, addr += pipeline_memcpy_stride)
+      __pipeline_memcpy_async(smem_twiddles + addr, twiddle_src + addr, 4 * sizeof(bf));
+    __pipeline_commit();
+  }
 
 #pragma unroll
   for (int i{0}, row{lane_id}; i < VALS_PER_THREAD; i++, row += WARP_SIZE)
     vals[i] = gmem_in.get_at_row(row);
+
+  if constexpr (DELAYED_NEXT_PREFETCH) {
+    // The cross kernel consumes this exact line set in its second phase. Issue
+    // after the current terminal's global-load queue instead of at kernel
+    // entry, leaving the rest of the terminal as overlap distance without
+    // parking B values in registers.
+    const size_t global_thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    ::airbender::primitives::ptx::prefetch_l2(delayed_prefetch_src + global_thread * WARP_SIZE);
+  }
 
   // Use pure cmem for warp-uniform twiddles
   if (STAGES >= 5) {
@@ -250,9 +690,12 @@ DEVICE_FORCEINLINE void natural_monomials_to_bitrev_evals_final_up_to_8_stages(b
       int exchg_region_offset = warp_exchg_region_offset + i;
       if (STAGES == 8) {
         bf *vals_this_region = vals + 8 * i;
-        reg_exchg_cmem_twiddles_fwd_dit<4, 8, 1>(vals_this_region, exchg_region_offset);
+        reg_exchg_precomputed_twiddles_fwd_dit<4, 8, 1>(vals_this_region, exchg_region_offset);
         exchg_region_offset <<= 1;
-        reg_exchg_cmem_twiddles_fwd_dit<2, 4, 2>(vals_this_region, exchg_region_offset);
+        if constexpr (PACKED_PRECOMPUTED_NUM2)
+          reg_exchg_packed_precomputed_twiddles_fwd_dit<2, 4, 2>(vals_this_region, exchg_region_offset);
+        else
+          reg_exchg_precomputed_twiddles_fwd_dit<2, 4, 2>(vals_this_region, exchg_region_offset);
         exchg_region_offset <<= 1;
         reg_exchg_cmem_twiddles_fwd_dit<1, 2, 4>(vals_this_region, exchg_region_offset);
       }
@@ -270,45 +713,139 @@ DEVICE_FORCEINLINE void natural_monomials_to_bitrev_evals_final_up_to_8_stages(b
   }
 
   if (warp_id & 4) {
-    warp_transpose_swizzled<VALS_PER_THREAD>(smem_warp, vals, lane_id);
+    if constexpr (PACKED_SMEM_TRANSPOSE)
+      warp_transpose_swizzled_v4<VALS_PER_THREAD>(smem_warp, vals, lane_id);
+    else
+      warp_transpose_swizzled<VALS_PER_THREAD>(smem_warp, vals, lane_id);
   }
 
-  __pipeline_wait_prior(0);
+  if constexpr (BULK_TWIDDLES) {
+#if __CUDA_ARCH__ >= 900
+    if (threadIdx.x == 0)
+      asm volatile("{\n\t"
+                   ".reg .pred p;\n"
+                   "WAIT:\n\t"
+                   "mbarrier.try_wait.parity.shared::cta.b64 p, [%0], 0;\n\t"
+                   "@!p bra WAIT;\n\t"
+                   "}"
+                   :
+                   : "r"(static_cast<unsigned>(__cvta_generic_to_shared(twiddle_copy_barrier)))
+                   : "memory");
+#else
+    __pipeline_wait_prior(0);
+#endif
+  } else {
+    __pipeline_wait_prior(0);
+  }
 
   __syncthreads();
 
   if (!(warp_id & 4)) {
-    warp_transpose_swizzled<VALS_PER_THREAD>(smem_warp, vals, lane_id);
+    if constexpr (PACKED_SMEM_TRANSPOSE)
+      warp_transpose_swizzled_v4<VALS_PER_THREAD>(smem_warp, vals, lane_id);
+    else
+      warp_transpose_swizzled<VALS_PER_THREAD>(smem_warp, vals, lane_id);
   }
 
   int thread_exchg_region_offset = threadIdx.x + static_cast<int>(fi.intra_x) * blockDim.x;
-  constexpr bf *cmem_twiddles = ab_fwd_cmem_twiddles_finest_11;
-  reg_exchg_cmem_smem_twiddles_fwd_dit<EightStages, 16, 32, 1, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
-  thread_exchg_region_offset <<= 1;
-  reg_exchg_cmem_smem_twiddles_fwd_dit<EightStages, 8, 16, 2, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
-  thread_exchg_region_offset <<= 1;
-  reg_exchg_cmem_smem_twiddles_fwd_dit<EightStages, 4, 8, 4, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
-  thread_exchg_region_offset <<= 1;
-  reg_exchg_cmem_smem_twiddles_fwd_dit<EightStages, 2, 4, 8, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
-  thread_exchg_region_offset <<= 1;
-  reg_exchg_cmem_smem_twiddles_fwd_dit<EightStages, 1, 2, 16, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
+  if constexpr (HOIST_FINE) {
+    reg_exchg_aligned_cmem_smem_twiddles_fwd_dit<16, 32, 1>(vals, thread_exchg_region_offset, smem_twiddles);
+    thread_exchg_region_offset <<= 1;
+    reg_exchg_aligned_cmem_smem_twiddles_fwd_dit<8, 16, 2>(vals, thread_exchg_region_offset, smem_twiddles);
+    thread_exchg_region_offset <<= 1;
+    reg_exchg_aligned_cmem_smem_twiddles_fwd_dit<4, 8, 4>(vals, thread_exchg_region_offset, smem_twiddles);
+    thread_exchg_region_offset <<= 1;
+    reg_exchg_aligned_cmem_smem_twiddles_fwd_dit<2, 4, 8>(vals, thread_exchg_region_offset, smem_twiddles);
+    thread_exchg_region_offset <<= 1;
+    reg_exchg_aligned_cmem_smem_twiddles_fwd_dit<1, 2, 16>(vals, thread_exchg_region_offset, smem_twiddles);
+  } else {
+    constexpr bf *cmem_twiddles = ab_fwd_cmem_twiddles_finest_11;
+    reg_exchg_cmem_smem_twiddles_fwd_dit<EightStages, 16, 32, 1, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
+    thread_exchg_region_offset <<= 1;
+    reg_exchg_cmem_smem_twiddles_fwd_dit<EightStages, 8, 16, 2, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
+    thread_exchg_region_offset <<= 1;
+    reg_exchg_cmem_smem_twiddles_fwd_dit<EightStages, 4, 8, 4, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
+    thread_exchg_region_offset <<= 1;
+    reg_exchg_cmem_smem_twiddles_fwd_dit<EightStages, 2, 4, 8, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
+    thread_exchg_region_offset <<= 1;
+    reg_exchg_cmem_smem_twiddles_fwd_dit<EightStages, 1, 2, 16, cmem_twiddles>(vals, thread_exchg_region_offset, smem_twiddles);
+  }
 
-  // Un-swizzle and store with coalescing.
+  // Un-swizzle and store with coalescing, or publish each warp's canonical
+  // 32x32 tile in the 128-byte TMA swizzle and let one tensor store write it.
   __syncthreads();
 
   smem_warp = smem_block + warp_id * VALS_PER_WARP;
-  warp_transpose_swizzled<VALS_PER_THREAD>(smem_warp, vals, lane_id);
+  if constexpr (TMA_EGRESS) {
+    // CU_TENSOR_MAP_SWIZZLE_128B XORs 16-byte chunks, not individual bf
+    // values. A lane owns one logical 128-byte row. Its eight STS.128
+    // operations therefore incur four shared wavefronts apiece (32 total),
+    // while the TMA engine unswizzles the tile into canonical global order.
+#pragma unroll
+    for (int chunk = 0; chunk < VALS_PER_THREAD / 4; chunk++) {
+      const int swizzled_chunk = chunk ^ (lane_id & 7);
+      bf *dst = smem_warp + lane_id * VALS_PER_THREAD + 4 * swizzled_chunk;
+      st_shared_v4(dst, vals[4 * chunk], vals[4 * chunk + 1], vals[4 * chunk + 2], vals[4 * chunk + 3]);
+    }
+
+    // Every producer orders its shared writes into the async proxy. The warp
+    // barrier then makes those fences precede lane 0's TMA read of this warp's
+    // disjoint 4 KiB slab.
+    asm volatile("fence.proxy.async.shared::cta;" : : : "memory");
+    __syncwarp();
+    if (lane_id == 0) {
+      const int tensor_coords_0 = 0;
+      const int tensor_coords_1 = (gmem_block_offset + warp_id * VALS_PER_WARP) / VALS_PER_THREAD;
+      const unsigned src_s = static_cast<unsigned>(__cvta_generic_to_shared(smem_warp));
+      unsigned long long cache_policy;
+      asm volatile("createpolicy.fractional.L2::evict_first.b64 %0, 1.0;" : "=l"(cache_policy));
+      asm volatile("cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group.L2::cache_hint [%0, {%1, %2}], [%3], %4;"
+                   :
+                   : "l"(output_tensor_map), "r"(tensor_coords_0), "r"(tensor_coords_1), "r"(src_s), "l"(cache_policy)
+                   : "memory");
+      asm volatile("cp.async.bulk.commit_group;" : : : "memory");
+      asm volatile("cp.async.bulk.wait_group.read 0;" : : : "memory");
+    }
+  } else {
+    if constexpr (PACKED_SMEM_TRANSPOSE)
+      warp_transpose_swizzled_v4<VALS_PER_THREAD>(smem_warp, vals, lane_id);
+    else
+      warp_transpose_swizzled<VALS_PER_THREAD>(smem_warp, vals, lane_id);
 
 #pragma unroll
-  for (int i{0}, row{lane_id}; i < VALS_PER_THREAD; i++, row += WARP_SIZE)
-    gmem_out.set_at_row(row, vals[i]);
+    for (int i{0}, row{lane_id}; i < VALS_PER_THREAD; i++, row += WARP_SIZE)
+      gmem_out.set_at_row(row, vals[i]);
+  }
+}
+
+template <int STAGES, ld_modifier LD, st_modifier ST>
+DEVICE_FORCEINLINE void natural_monomials_to_bitrev_evals_final_up_to_8_stages(bf_matrix_getter<LD> gmem_in, bf_matrix_setter<ST> gmem_out, const int log_n,
+                                                                               const int num_cols_per_coset, const int log_cosets_in_tile) {
+  __shared__ __align__(16) bf smem_block[8192]; // 4096 vals, 4096 coarse twiddles
+  __shared__ __align__(8) unsigned long long twiddle_copy_barrier;
+  natural_monomials_to_bitrev_evals_final_up_to_8_stages_with_smem<STAGES, LD, ST, true, true>(gmem_in, gmem_out, log_n, num_cols_per_coset, log_cosets_in_tile,
+                                                                                               smem_block, &twiddle_copy_barrier);
+}
+
+template <int STAGES, bool PACKED_SMEM_TRANSPOSE = false, bool PACKED_PRECOMPUTED_NUM2 = false>
+DEVICE_FORCEINLINE void natural_monomials_to_bitrev_evals_final_up_to_8_stages_tma(bf_matrix_getter<ld_modifier::cs> gmem_in,
+                                                                                   bf_matrix_setter<st_modifier::cs> gmem_out, const int log_n,
+                                                                                   const CUtensorMap *output_tensor_map) {
+  // The 128-byte TMA swizzle repeats after 1024 bytes. Every warp slab starts
+  // at a 4096-byte multiple of this base.
+  __shared__ __align__(1024) bf smem_block[8192];
+  __shared__ __align__(8) unsigned long long twiddle_copy_barrier;
+  natural_monomials_to_bitrev_evals_final_up_to_8_stages_with_smem<STAGES, ld_modifier::cs, st_modifier::cs, true, true, true, false, PACKED_SMEM_TRANSPOSE,
+                                                                   PACKED_PRECOMPUTED_NUM2>(gmem_in, gmem_out, log_n, 1, 0, smem_block, &twiddle_copy_barrier,
+                                                                                            output_tensor_map);
 }
 
 #define DEFINE_FINAL_KERNEL(STAGES)                                                                                                                            \
   EXTERN __launch_bounds__(256, 3) __global__ void ab_natural_monomials_to_bitrev_evals_final_##STAGES##_stages_kernel(                                        \
       bf_matrix_getter<ld_modifier::cg> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out, const int log_n, const int num_cols_per_coset,                    \
       const int log_cosets_in_tile) {                                                                                                                          \
-    natural_monomials_to_bitrev_evals_final_up_to_8_stages<STAGES>(gmem_in, gmem_out, log_n, num_cols_per_coset, log_cosets_in_tile);                          \
+    natural_monomials_to_bitrev_evals_final_up_to_8_stages<STAGES, ld_modifier::cg, st_modifier::cg>(gmem_in, gmem_out, log_n, num_cols_per_coset,             \
+                                                                                                     log_cosets_in_tile);                                      \
   }
 
 DEFINE_FINAL_KERNEL(5)
@@ -317,5 +854,175 @@ DEFINE_FINAL_KERNEL(7)
 DEFINE_FINAL_KERNEL(8)
 
 #undef DEFINE_FINAL_KERNEL
+
+// Evict variant for the LDE's terminal pass: its input lines are dead after
+// this read and its output (the committed codeword) is not re-read within the
+// LDE phase (next consumer is the Merkle leaf hash), so evict-first keeps
+// these dead lines from evicting the monomials that later cosets' initials
+// still need.
+#define DEFINE_FINAL_EVICT_KERNEL(STAGES)                                                                                                                      \
+  EXTERN __launch_bounds__(256, 3) __global__ void ab_natural_monomials_to_bitrev_evals_final_##STAGES##_stages_evict_kernel(                                  \
+      bf_matrix_getter<ld_modifier::cs> gmem_in, bf_matrix_setter<st_modifier::cs> gmem_out, const int log_n, const int num_cols_per_coset,                    \
+      const int log_cosets_in_tile) {                                                                                                                          \
+    natural_monomials_to_bitrev_evals_final_up_to_8_stages<STAGES, ld_modifier::cs, st_modifier::cs>(gmem_in, gmem_out, log_n, num_cols_per_coset,             \
+                                                                                                     log_cosets_in_tile);                                      \
+  }
+
+DEFINE_FINAL_EVICT_KERNEL(5)
+DEFINE_FINAL_EVICT_KERNEL(6)
+DEFINE_FINAL_EVICT_KERNEL(7)
+DEFINE_FINAL_EVICT_KERNEL(8)
+
+#undef DEFINE_FINAL_EVICT_KERNEL
+
+#define DEFINE_FINAL_EVICT_TMA_KERNEL(STAGES)                                                                                                                  \
+  EXTERN __launch_bounds__(256, 3) __global__ void ab_natural_monomials_to_bitrev_evals_final_##STAGES##_stages_evict_tma_kernel(                              \
+      bf_matrix_getter<ld_modifier::cs> gmem_in, bf_matrix_setter<st_modifier::cs> gmem_out, const int log_n,                                                  \
+      const __grid_constant__ CUtensorMap output_tensor_map) {                                                                                                 \
+    natural_monomials_to_bitrev_evals_final_up_to_8_stages_tma<STAGES>(gmem_in, gmem_out, log_n, &output_tensor_map);                                          \
+  }
+
+DEFINE_FINAL_EVICT_TMA_KERNEL(5)
+DEFINE_FINAL_EVICT_TMA_KERNEL(6)
+DEFINE_FINAL_EVICT_TMA_KERNEL(7)
+DEFINE_FINAL_EVICT_TMA_KERNEL(8)
+
+#undef DEFINE_FINAL_EVICT_TMA_KERNEL
+
+// Evict + L2-prefetch variant of the terminal pass: while this codeword
+// streams out, prefetch the next NTT slab (the launch has exactly n/32
+// threads and the source is exactly n/32 128-byte lines:
+// one prefetch per thread, issued at each block's tail so the DRAM fetches
+// stagger through this kernel's drain). Single-column launches only: the
+// prefetch indexing assumes gridDim.x covers one NTT.
+#define DEFINE_FINAL_EVICT_PREFETCH_KERNEL(STAGES)                                                                                                             \
+  EXTERN __launch_bounds__(256, 3) __global__ void ab_natural_monomials_to_bitrev_evals_final_##STAGES##_stages_evict_prefetch_kernel(                         \
+      bf_matrix_getter<ld_modifier::cs> gmem_in, bf_matrix_setter<st_modifier::cs> gmem_out, const int log_n, const int num_cols_per_coset,                    \
+      const int log_cosets_in_tile, const bf *prefetch_src) {                                                                                                  \
+    natural_monomials_to_bitrev_evals_final_up_to_8_stages<STAGES, ld_modifier::cs, st_modifier::cs>(gmem_in, gmem_out, log_n, num_cols_per_coset,             \
+                                                                                                     log_cosets_in_tile);                                      \
+    /* Last instruction per block: the grid drains over several waves, so                                                                                      \
+       the fetches stagger into the tail of this launch, trailing its own                                                                                      \
+       traffic with minimal eviction lead before the next consumer. */                                                                                         \
+    if (prefetch_src != nullptr)                                                                                                                               \
+      ::airbender::primitives::ptx::prefetch_l2(prefetch_src + (static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x) * 32u);                            \
+  }
+
+DEFINE_FINAL_EVICT_PREFETCH_KERNEL(5)
+DEFINE_FINAL_EVICT_PREFETCH_KERNEL(6)
+DEFINE_FINAL_EVICT_PREFETCH_KERNEL(7)
+DEFINE_FINAL_EVICT_PREFETCH_KERNEL(8)
+
+#undef DEFINE_FINAL_EVICT_PREFETCH_KERNEL
+
+#define DEFINE_FINAL_EVICT_PREFETCH_PACKED_TMA_KERNEL(STAGES)                                                                                                  \
+  EXTERN __launch_bounds__(256, 3) __global__ void ab_natural_monomials_to_bitrev_evals_final_##STAGES##_stages_evict_prefetch_packed_smem_tma_kernel(         \
+      bf_matrix_getter<ld_modifier::cs> gmem_in, bf_matrix_setter<st_modifier::cs> gmem_out, const int log_n, const bf *prefetch_src,                          \
+      const __grid_constant__ CUtensorMap output_tensor_map) {                                                                                                 \
+    natural_monomials_to_bitrev_evals_final_up_to_8_stages_tma<STAGES, true>(gmem_in, gmem_out, log_n, &output_tensor_map);                                    \
+    if (prefetch_src != nullptr)                                                                                                                               \
+      ::airbender::primitives::ptx::prefetch_l2(prefetch_src + (static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x) * 32u);                            \
+  }
+
+DEFINE_FINAL_EVICT_PREFETCH_PACKED_TMA_KERNEL(5)
+DEFINE_FINAL_EVICT_PREFETCH_PACKED_TMA_KERNEL(6)
+DEFINE_FINAL_EVICT_PREFETCH_PACKED_TMA_KERNEL(7)
+
+#undef DEFINE_FINAL_EVICT_PREFETCH_PACKED_TMA_KERNEL
+
+EXTERN __launch_bounds__(256, 3) __global__ void ab_natural_monomials_to_bitrev_evals_final_8_stages_evict_prefetch_packed_smem_packed_num2_tma_kernel(
+    bf_matrix_getter<ld_modifier::cs> gmem_in, bf_matrix_setter<st_modifier::cs> gmem_out, const int log_n, const bf *prefetch_src,
+    const __grid_constant__ CUtensorMap output_tensor_map) {
+  natural_monomials_to_bitrev_evals_final_up_to_8_stages_tma<8, true, true>(gmem_in, gmem_out, log_n, &output_tensor_map);
+  if (prefetch_src != nullptr)
+    ::airbender::primitives::ptx::prefetch_l2(prefetch_src + (static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x) * 32u);
+}
+
+// Finish the next column's fine-first hypercube pass in the same block/window
+// as the current column's last-coset terminal pass. Both phase-B bodies use
+// identical 8192-row ownership, and the natural terminal's shared state is
+// dead before this body starts, so they can reuse one shared slab.
+template <int STAGES>
+DEVICE_FORCEINLINE void cross_column_hypercube_finest(bf_matrix_getter<ld_modifier::cs> gmem_in, bf_matrix_setter<st_modifier::cg> gmem_out, bf *smem_block) {
+  using namespace pass_config::three_pass_phase_b;
+  constexpr int INITIAL_EXCHG_REGIONS_PER_WARP = 1 << (10 - STAGES);
+
+  const int lane_id = threadIdx.x & 31;
+  const int warp_id = threadIdx.x >> 5;
+  const int gmem_block_offset = blockIdx.x * VALS_PER_BLOCK;
+  gmem_in.add_row(gmem_block_offset + warp_id * VALS_PER_WARP);
+  gmem_out.add_row(gmem_block_offset + warp_id * VALS_PER_WARP);
+
+  bf *smem_warp = smem_block + warp_id * VALS_PER_WARP;
+  bf vals[VALS_PER_THREAD];
+
+#pragma unroll
+  for (int i{0}, row{lane_id}; i < VALS_PER_THREAD; i++, row += WARP_SIZE)
+    vals[i] = gmem_in.get_at_row(row);
+
+  if (STAGES >= 5) {
+#pragma unroll
+    for (int i{0}; i < INITIAL_EXCHG_REGIONS_PER_WARP; i++) {
+      if (STAGES == 8) {
+        bf *vals_this_region = vals + 8 * i;
+        reg_exchg_hypercube_inv<4, 8, 1>(vals_this_region);
+        reg_exchg_hypercube_inv<2, 4, 2>(vals_this_region);
+        reg_exchg_hypercube_inv<1, 2, 4>(vals_this_region);
+      }
+      if (STAGES == 7) {
+        bf *vals_this_region = vals + 4 * i;
+        reg_exchg_hypercube_inv<2, 4, 1>(vals_this_region);
+        reg_exchg_hypercube_inv<1, 2, 2>(vals_this_region);
+      }
+      if (STAGES == 6) {
+        bf *vals_this_region = vals + 2 * i;
+        reg_exchg_hypercube_inv<1, 2, 1>(vals_this_region);
+      }
+    }
+  }
+
+  warp_transpose_swizzled_v4<VALS_PER_THREAD>(smem_warp, vals, lane_id);
+
+  reg_exchg_hypercube_inv<16, 32, 1>(vals);
+  reg_exchg_hypercube_inv<8, 16, 2>(vals);
+  reg_exchg_hypercube_inv<4, 8, 4>(vals);
+  reg_exchg_hypercube_inv<2, 4, 8>(vals);
+  reg_exchg_hypercube_inv<1, 2, 16>(vals);
+
+  warp_transpose_swizzled_v4_mirror<VALS_PER_THREAD>(smem_warp, vals, lane_id);
+
+#pragma unroll
+  for (int i{0}, row{lane_id}; i < VALS_PER_THREAD; i++, row += WARP_SIZE)
+    gmem_out.set_at_row(row, vals[i]);
+}
+
+template <int STAGES, bool PDL>
+DEVICE_FORCEINLINE void natural_final_cross_column(bf_matrix_getter<ld_modifier::cs> gmem_in, bf_matrix_setter<st_modifier::cs> gmem_out,
+                                                   bf_matrix_getter<ld_modifier::cs> next_hypercube_in, bf_matrix_setter<st_modifier::cg> next_pre_tail_out,
+                                                   const int log_n) {
+  __shared__ __align__(16) bf smem_block[8192];
+  natural_monomials_to_bitrev_evals_final_up_to_8_stages_with_smem<STAGES, ld_modifier::cs, st_modifier::cs, false, false, false, true, true>(
+      gmem_in, gmem_out, log_n, 1, 0, smem_block, nullptr, nullptr, next_hypercube_in.ptr);
+  __syncthreads();
+  if constexpr (PDL) {
+    if (threadIdx.x == 0)
+      cudaTriggerProgrammaticLaunchCompletion();
+  }
+  cross_column_hypercube_finest<STAGES>(next_hypercube_in, next_pre_tail_out, smem_block);
+}
+
+#define DEFINE_RETAINED_CROSS_COLUMN_FINAL_KERNEL(STAGES, SUFFIX, PDL)                                                                                         \
+  EXTERN __launch_bounds__(256, 2) __global__ void ab_natural_monomials_to_bitrev_evals_final_##STAGES##_stages_evict_##SUFFIX##_kernel(                       \
+      bf_matrix_getter<ld_modifier::cs> gmem_in, bf_matrix_setter<st_modifier::cs> gmem_out, bf_matrix_getter<ld_modifier::cs> next_hypercube_in,              \
+      bf_matrix_setter<st_modifier::cg> next_pre_tail_out, const int log_n) {                                                                                  \
+    natural_final_cross_column<STAGES, PDL>(gmem_in, gmem_out, next_hypercube_in, next_pre_tail_out, log_n);                                                   \
+  }
+
+DEFINE_RETAINED_CROSS_COLUMN_FINAL_KERNEL(5, delayed_prefetch_packed_smem_cross_column, false)
+DEFINE_RETAINED_CROSS_COLUMN_FINAL_KERNEL(6, delayed_prefetch_packed_smem_cross_column_pdl, true)
+DEFINE_RETAINED_CROSS_COLUMN_FINAL_KERNEL(7, delayed_prefetch_packed_smem_cross_column_pdl, true)
+DEFINE_RETAINED_CROSS_COLUMN_FINAL_KERNEL(8, delayed_prefetch_packed_smem_cross_column_pdl, true)
+
+#undef DEFINE_RETAINED_CROSS_COLUMN_FINAL_KERNEL
 
 } // namespace airbender::ntt

--- a/gpu/ntt/native/ntt.cuh
+++ b/gpu/ntt/native/ntt.cuh
@@ -250,6 +250,26 @@ template <int STRIDE, int REGION_SIZE, int NUM_REGIONS> DEVICE_FORCEINLINE void 
   }
 }
 
+// Specialization for a known-zero exchange-region offset. The first region's
+// twiddle is the identity at every stage, so use the no-multiply butterfly
+// there and load twiddles only for the remaining regions.
+template <int STRIDE, int REGION_SIZE, int NUM_REGIONS> DEVICE_FORCEINLINE void reg_exchg_fwd_dit_offset_0(bf *vals) {
+#pragma unroll
+  for (int lane_in_region = 0; lane_in_region < STRIDE; lane_in_region++)
+    exchg_dit_0(vals[lane_in_region], vals[lane_in_region + STRIDE]);
+
+#pragma unroll
+  for (int region = 1; region < NUM_REGIONS; region++) {
+    const bf twiddle = ab_fwd_cmem_twiddles_coarse[region];
+    const int region_offset = region * REGION_SIZE;
+#pragma unroll
+    for (int lane_in_region = 0; lane_in_region < STRIDE; lane_in_region++) {
+      const int i = region_offset + lane_in_region;
+      exchg_dit(vals[i], vals[i + STRIDE], twiddle);
+    }
+  }
+}
+
 template <int GROUP> DEVICE_FORCEINLINE void exchg_pipeline_group(bf *vals, const bf twiddle) {
   exchg_dit_0(vals[GROUP], vals[GROUP + 16]);
   exchg_dit_0(vals[GROUP + 8], vals[GROUP + 24]);

--- a/gpu/ntt/src/ntt/forward.rs
+++ b/gpu/ntt/src/ntt/forward.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use era_cudart::execution::{CudaLaunchConfig, Dim3, KernelFunction};
-use era_cudart::result::CudaResult;
+use era_cudart::result::{CudaResult, CudaResultWrap};
 use era_cudart::slice::DeviceSlice;
 use era_cudart::stream::CudaStream;
 
@@ -14,9 +14,24 @@ use gpu_core::primitives::device_structures::{
 use gpu_core::primitives::field::BaseField;
 use gpu_core::primitives::utils::GetChunksCount;
 
-use std::mem::size_of;
+use std::mem::{MaybeUninit, size_of};
 
 type BF = BaseField;
+
+fn encode_natural_final_output_tensor_map(
+    output: MutPtrAndStride<BF>,
+    n: usize,
+) -> CudaResult<NaturalFinalOutputTensorMap> {
+    let tensor_map = MaybeUninit::<NaturalFinalOutputTensorMap>::uninit();
+    unsafe {
+        ab_encode_natural_final_output_tensor_map(
+            tensor_map.as_ptr() as *mut NaturalFinalOutputTensorMap,
+            output.ptr,
+            n as u64,
+        )
+        .wrap_maybe_uninit(tensor_map)
+    }
+}
 
 /// The two forward noninitial passes for one (column-chunk, coset-tile). The
 /// LAST pass uses the evict variant: its inputs are dead after the read and
@@ -198,6 +213,8 @@ fn launch_natural_to_bitrev_tail(
     ntts_in_launch: usize,
     num_cols_per_coset: usize,
     log_cosets_in_tile: i32,
+    prefetch_src: Option<*const BF>,
+    cross_column_finest: Option<(PtrAndStride<BF>, MutPtrAndStride<BF>)>,
     stream: &CudaStream,
 ) -> CudaResult<()> {
     let n = 1usize << log_n;
@@ -214,29 +231,63 @@ fn launch_natural_to_bitrev_tail(
     let grid_dim_middle: Dim3 =
         (blocks_per_exchg_region as u32 * num_exchg_regions as u32 * ntts_in_launch as u32).into();
     let config = CudaLaunchConfig::basic(grid_dim_middle, 256, stream);
-    let args = StridedTilesStagesArguments::new(
-        output_matrix_const,
-        output_matrix_mut,
-        log_n as i32,
-        start_stage as i32,
-        num_cols_arg,
-        log_cosets_in_tile,
-    );
-    StridedTilesStagesFunction(ab_natural_monomials_to_bitrev_evals_middle_8_stages_kernel)
+    if log_n == 21 && log_cosets_in_tile == 1 {
+        debug_assert_eq!(ntts_in_launch & 1, 0);
+        let args = NaturalMiddleLogN21TwoCosetsArguments::new(
+            output_matrix_const,
+            output_matrix_mut,
+            num_cols_arg,
+        );
+        NaturalMiddleLogN21TwoCosetsFunction(
+            ab_natural_monomials_to_bitrev_evals_middle_8_stages_log_n_21_two_cosets_packed_twiddles_kernel,
+        )
         .launch(&config, &args)?;
+    } else if log_n == 22 && ntts_in_launch == 1 && log_cosets_in_tile == 0 {
+        let args = NaturalMiddleFixedArguments::new(output_matrix_const, output_matrix_mut);
+        NaturalMiddleFixedFunction(
+            ab_natural_monomials_to_bitrev_evals_middle_8_stages_log_n_22_packed_twiddles_kernel,
+        )
+        .launch(&config, &args)?;
+    } else if log_n == 23 && ntts_in_launch == 1 && log_cosets_in_tile == 0 {
+        let args = NaturalMiddleFixedArguments::new(output_matrix_const, output_matrix_mut);
+        NaturalMiddleFixedFunction(
+            ab_natural_monomials_to_bitrev_evals_middle_8_stages_log_n_23_packed_twiddles_kernel,
+        )
+        .launch(&config, &args)?;
+    } else if log_n == 24 && ntts_in_launch == 1 && log_cosets_in_tile == 0 {
+        let args = NaturalMiddleFixedArguments::new(output_matrix_const, output_matrix_mut);
+        NaturalMiddleFixedFunction(
+            ab_natural_monomials_to_bitrev_evals_middle_8_stages_log_n_24_packed_twiddles_kernel,
+        )
+        .launch(&config, &args)?;
+    } else {
+        let args = StridedTilesStagesArguments::new(
+            output_matrix_const,
+            output_matrix_mut,
+            log_n as i32,
+            start_stage as i32,
+            num_cols_arg,
+            log_cosets_in_tile,
+        );
+        StridedTilesStagesFunction(ab_natural_monomials_to_bitrev_evals_middle_8_stages_kernel)
+            .launch(&config, &args)?;
+    }
+    // The terminal pass uses the evict variant: its inputs are dead after the
+    // read and the codeword is next consumed by the Merkle leaf hash, outside
+    // the LDE phase.
     let final_function = match log_n {
-        21 => {
-            NaturalToBitrevFinalFunction(ab_natural_monomials_to_bitrev_evals_final_5_stages_kernel)
-        }
-        22 => {
-            NaturalToBitrevFinalFunction(ab_natural_monomials_to_bitrev_evals_final_6_stages_kernel)
-        }
-        23 => {
-            NaturalToBitrevFinalFunction(ab_natural_monomials_to_bitrev_evals_final_7_stages_kernel)
-        }
-        24 => {
-            NaturalToBitrevFinalFunction(ab_natural_monomials_to_bitrev_evals_final_8_stages_kernel)
-        }
+        21 => NaturalToBitrevFinalFunction(
+            ab_natural_monomials_to_bitrev_evals_final_5_stages_evict_kernel,
+        ),
+        22 => NaturalToBitrevFinalFunction(
+            ab_natural_monomials_to_bitrev_evals_final_6_stages_evict_kernel,
+        ),
+        23 => NaturalToBitrevFinalFunction(
+            ab_natural_monomials_to_bitrev_evals_final_7_stages_evict_kernel,
+        ),
+        24 => NaturalToBitrevFinalFunction(
+            ab_natural_monomials_to_bitrev_evals_final_8_stages_evict_kernel,
+        ),
         _ => unreachable!(
             "NTT 3-pass natural->bitrev kernels are only generated for log_n in 21..=24"
         ),
@@ -244,6 +295,117 @@ fn launch_natural_to_bitrev_tail(
     let blocks = n.get_chunks_count(bf_vals_per_block);
     let grid_dim_final: Dim3 = (blocks as u32 * ntts_in_launch as u32).into();
     let config = CudaLaunchConfig::basic(grid_dim_final, 256, stream);
+    assert!(prefetch_src.is_none() || cross_column_finest.is_none());
+    if let Some((next_hypercube_inputs, next_pre_tail_outputs)) = cross_column_finest {
+        // Cross-column variant: the current last-coset terminal and the next
+        // column's hypercube finest pass have identical block ownership. The
+        // combined kernel writes the next column's coset-0 pre-tail slab, so
+        // that column will start at its middle hypercube pass.
+        assert_eq!(ntts_in_launch, 1);
+        assert_eq!(log_cosets_in_tile, 0);
+        let cross_column_function = match log_n {
+            21 => NaturalToBitrevFinalCrossColumnFunction(
+                ab_natural_monomials_to_bitrev_evals_final_5_stages_evict_delayed_prefetch_packed_smem_cross_column_kernel,
+            ),
+            22 => NaturalToBitrevFinalCrossColumnFunction(
+                ab_natural_monomials_to_bitrev_evals_final_6_stages_evict_delayed_prefetch_packed_smem_cross_column_pdl_kernel,
+            ),
+            23 => NaturalToBitrevFinalCrossColumnFunction(
+                ab_natural_monomials_to_bitrev_evals_final_7_stages_evict_delayed_prefetch_packed_smem_cross_column_pdl_kernel,
+            ),
+            24 => NaturalToBitrevFinalCrossColumnFunction(
+                ab_natural_monomials_to_bitrev_evals_final_8_stages_evict_delayed_prefetch_packed_smem_cross_column_pdl_kernel,
+            ),
+            _ => unreachable!(
+                "NTT 3-pass natural->bitrev kernels are only generated for log_n in 21..=24"
+            ),
+        };
+        let args = NaturalToBitrevFinalCrossColumnArguments::new(
+            output_matrix_const,
+            output_matrix_mut,
+            next_hypercube_inputs,
+            next_pre_tail_outputs,
+            log_n as i32,
+        );
+        return cross_column_function.launch(&config, &args);
+    }
+    if let Some(prefetch_src) = prefetch_src {
+        // One trailing L2 prefetch per thread for the slab consumed by the
+        // immediately following tail. Its indexing assumes one NTT.
+        assert_eq!(ntts_in_launch, 1);
+        if matches!(log_n, 21..=24)
+            && log_cosets_in_tile == 0
+            && (output_matrix_mut.ptr as usize & 127) == 0
+        {
+            let output_tensor_map = encode_natural_final_output_tensor_map(output_matrix_mut, n)?;
+            let args = NaturalToBitrevFinalPrefetchTmaArguments::new(
+                output_matrix_const,
+                output_matrix_mut,
+                log_n as i32,
+                prefetch_src,
+                output_tensor_map,
+            );
+            let tma_function = if log_n == 21 {
+                ab_natural_monomials_to_bitrev_evals_final_5_stages_evict_prefetch_packed_smem_tma_kernel
+            } else if log_n == 22 {
+                ab_natural_monomials_to_bitrev_evals_final_6_stages_evict_prefetch_packed_smem_tma_kernel
+            } else if log_n == 23 {
+                ab_natural_monomials_to_bitrev_evals_final_7_stages_evict_prefetch_packed_smem_tma_kernel
+            } else {
+                ab_natural_monomials_to_bitrev_evals_final_8_stages_evict_prefetch_packed_smem_packed_num2_tma_kernel
+            };
+            return NaturalToBitrevFinalPrefetchTmaFunction(tma_function).launch(&config, &args);
+        }
+        let prefetch_function = match log_n {
+            21 => NaturalToBitrevFinalPrefetchFunction(
+                ab_natural_monomials_to_bitrev_evals_final_5_stages_evict_prefetch_kernel,
+            ),
+            22 => NaturalToBitrevFinalPrefetchFunction(
+                ab_natural_monomials_to_bitrev_evals_final_6_stages_evict_prefetch_kernel,
+            ),
+            23 => NaturalToBitrevFinalPrefetchFunction(
+                ab_natural_monomials_to_bitrev_evals_final_7_stages_evict_prefetch_kernel,
+            ),
+            24 => NaturalToBitrevFinalPrefetchFunction(
+                ab_natural_monomials_to_bitrev_evals_final_8_stages_evict_prefetch_kernel,
+            ),
+            _ => unreachable!(
+                "NTT 3-pass natural->bitrev kernels are only generated for log_n in 21..=24"
+            ),
+        };
+        let args = NaturalToBitrevFinalPrefetchArguments::new(
+            output_matrix_const,
+            output_matrix_mut,
+            log_n as i32,
+            num_cols_arg,
+            log_cosets_in_tile,
+            prefetch_src,
+        );
+        return prefetch_function.launch(&config, &args);
+    }
+    if matches!(log_n, 21..=24)
+        && ntts_in_launch == 1
+        && log_cosets_in_tile == 0
+        && (output_matrix_mut.ptr as usize & 127) == 0
+    {
+        let output_tensor_map = encode_natural_final_output_tensor_map(output_matrix_mut, n)?;
+        let args = NaturalToBitrevFinalTmaArguments::new(
+            output_matrix_const,
+            output_matrix_mut,
+            log_n as i32,
+            output_tensor_map,
+        );
+        let tma_function = if log_n == 21 {
+            ab_natural_monomials_to_bitrev_evals_final_5_stages_evict_tma_kernel
+        } else if log_n == 22 {
+            ab_natural_monomials_to_bitrev_evals_final_6_stages_evict_tma_kernel
+        } else if log_n == 23 {
+            ab_natural_monomials_to_bitrev_evals_final_7_stages_evict_tma_kernel
+        } else {
+            ab_natural_monomials_to_bitrev_evals_final_8_stages_evict_tma_kernel
+        };
+        return NaturalToBitrevFinalTmaFunction(tma_function).launch(&config, &args);
+    }
     let args = NaturalToBitrevFinalArguments::new(
         output_matrix_const,
         output_matrix_mut,
@@ -352,6 +514,8 @@ pub(crate) fn natural_monomials_to_bitrev_evals_3_pass(
                 cosets_in_tile * cols_in_chunk,
                 num_cols_per_coset,
                 log_cosets_in_tile,
+                None,
+                None,
                 stream,
             )?;
             coset_tile_start += cosets_in_tile;
@@ -504,6 +668,79 @@ pub(crate) fn natural_monomials_to_bitrev_evals_2_pass_compact(
     transposed_monomials: bool,
     stream: &CudaStream,
 ) -> CudaResult<()> {
+    let initial_function = MonomialsToEvalsCompactFunction(
+        ab_natural_monomials_to_bitrev_evals_initial_8_stages_kernel,
+    );
+    natural_monomials_to_bitrev_evals_2_pass_compact_with_initial(
+        inputs_matrix,
+        outputs_matrix,
+        log_n,
+        coset_index_base,
+        coset_factor_shift,
+        num_cosets,
+        num_cols_per_coset,
+        cosets_per_launch,
+        columns_per_launch,
+        transposed_monomials,
+        stream,
+        initial_function,
+    )
+}
+
+/// Commitment-only log_n=20 path whose initial launch consumes the hypercube
+/// pre-final4 intermediate. The CUDA body applies final4 from warp lanes, then
+/// executes the same natural-to-bitrev initial8 exchange as the ordinary path.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn natural_monomials_to_bitrev_evals_2_pass_compact_from_hypercube_final4(
+    inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
+    log_n: usize,
+    coset_index_base: usize,
+    coset_factor_shift: u32,
+    num_cosets: usize,
+    num_cols_per_coset: usize,
+    cosets_per_launch: usize,
+    columns_per_launch: usize,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    assert_eq!(
+        log_n, 20,
+        "hypercube-final4 fusion is generated only for log_n=20"
+    );
+    let initial_function = MonomialsToEvalsCompactFunction(
+        ab_natural_monomials_to_bitrev_evals_initial_8_stages_from_hypercube_final_4_kernel,
+    );
+    natural_monomials_to_bitrev_evals_2_pass_compact_with_initial(
+        inputs_matrix,
+        outputs_matrix,
+        log_n,
+        coset_index_base,
+        coset_factor_shift,
+        num_cosets,
+        num_cols_per_coset,
+        cosets_per_launch,
+        columns_per_launch,
+        false,
+        stream,
+        initial_function,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn natural_monomials_to_bitrev_evals_2_pass_compact_with_initial(
+    inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
+    log_n: usize,
+    coset_index_base: usize,
+    coset_factor_shift: u32,
+    num_cosets: usize,
+    num_cols_per_coset: usize,
+    cosets_per_launch: usize,
+    columns_per_launch: usize,
+    transposed_monomials: bool,
+    stream: &CudaStream,
+    initial_function: MonomialsToEvalsCompactFunction,
+) -> CudaResult<()> {
     assert!(
         (13..=20).contains(&log_n),
         "2-pass-compact natural->bitrev NTT only supports log_n in [13, 20]"
@@ -533,9 +770,6 @@ pub(crate) fn natural_monomials_to_bitrev_evals_2_pass_compact(
         num_ntts,
     );
     let log_cosets_in_tile = cosets_per_launch.trailing_zeros() as i32;
-    let initial_function = MonomialsToEvalsCompactFunction(
-        ab_natural_monomials_to_bitrev_evals_initial_8_stages_kernel,
-    );
     let log_k = log_n - 8;
     let last_function = match log_k {
         5 => NaturalToBitrevFinalFunction(
@@ -702,6 +936,181 @@ pub(crate) fn fused_writeback_single_coset_3_pass(
         0,
         stream,
     )
+}
+
+/// Multi-coset LDE using the coset-0 slab as transient monomial storage.
+/// Coset 0 is overwritten only after all other initials have consumed it.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn natural_fused_multi_coset_3_pass(
+    outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
+    log_n: usize,
+    num_cosets: usize,
+    coset_factor_shift: u32,
+    num_cols_per_coset: usize,
+    num_cols: usize,
+    cross_column_finest: Option<(PtrAndStride<BF>, MutPtrAndStride<BF>)>,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    let n = 1 << log_n;
+    assert_eq!(outputs_matrix.rows(), n);
+    assert!(num_cosets.is_power_of_two() && num_cosets >= 2);
+    shared::assert_ntt_16b_aligned(outputs_matrix, outputs_matrix);
+    let stride = outputs_matrix.stride();
+    let offset = outputs_matrix.offset();
+    let shift_arg = shared::checked_i32(coset_factor_shift as usize, "coset_factor_shift");
+    let ncpc_arg = shared::checked_i32(num_cols_per_coset, "num_cols_per_coset");
+    let outputs_slice_const = unsafe {
+        DeviceSlice::from_raw_parts(
+            outputs_matrix.slice().as_ptr(),
+            outputs_matrix.slice().len(),
+        )
+    };
+    let outputs_slice_mut = outputs_matrix.slice_mut();
+
+    let chunk_const = |coset: usize| {
+        let slice = &outputs_slice_const[coset * num_cols_per_coset * stride..];
+        DeviceMatrixChunk::new(slice, stride, offset, n).as_ptr_and_stride()
+    };
+
+    let bf_vals_per_block = 1 << 13; // 8192
+    let blocks = n.get_chunks_count(bf_vals_per_block);
+    let grid_dim: Dim3 = (blocks as u32 * num_cols as u32).into();
+    let config = CudaLaunchConfig::basic(grid_dim, 256, stream);
+
+    // (1) fused boundary -> coset 1, streamed; monomials materialize in place
+    // in coset 0. Chunked mut views are constructed per launch from the raw
+    // mut slice to keep the borrows sequential.
+    {
+        let c0_mut = {
+            let slice = unsafe {
+                DeviceSlice::from_raw_parts_mut(outputs_slice_mut.as_mut_ptr(), num_cols * stride)
+            };
+            DeviceMatrixChunkMut::new(slice, stride, offset, n).as_mut_ptr_and_stride()
+        };
+        let c1_mut = {
+            let start = num_cols_per_coset * stride;
+            let slice = unsafe {
+                DeviceSlice::from_raw_parts_mut(
+                    outputs_slice_mut.as_mut_ptr().add(start),
+                    num_cols * stride,
+                )
+            };
+            DeviceMatrixChunkMut::new(slice, stride, offset, n).as_mut_ptr_and_stride()
+        };
+        if log_n == 21 && num_cosets == 2 && coset_factor_shift == 5 && num_cols == 1 {
+            let args = LdeFusedWritebackFixedArguments::new(c0_mut, c1_mut);
+            LdeFusedWritebackFixedFunction(
+                ab_natural_lde_fused_boundary_writeback_out_cs_log_n_21_c1_kernel,
+            )
+            .launch(&config, &args)?;
+        } else if log_n == 22 && num_cosets == 2 && coset_factor_shift == 4 && num_cols == 1 {
+            let args = LdeFusedWritebackFixedArguments::new(c0_mut, c1_mut);
+            LdeFusedWritebackFixedFunction(
+                ab_natural_lde_fused_boundary_writeback_out_cs_log_n_22_c1_kernel,
+            )
+            .launch(&config, &args)?;
+        } else if log_n == 23 && num_cosets == 2 && coset_factor_shift == 3 && num_cols == 1 {
+            let args = LdeFusedWritebackFixedArguments::new(c0_mut, c1_mut);
+            LdeFusedWritebackFixedFunction(
+                ab_natural_lde_fused_boundary_writeback_out_cs_log_n_23_c1_kernel,
+            )
+            .launch(&config, &args)?;
+        } else if log_n == 24 && num_cosets == 2 && coset_factor_shift == 2 && num_cols == 1 {
+            let args = LdeFusedWritebackFixedArguments::new(c0_mut, c1_mut);
+            LdeFusedWritebackFixedFunction(
+                ab_natural_lde_fused_boundary_writeback_out_cs_log_n_24_c1_kernel,
+            )
+            .launch(&config, &args)?;
+        } else {
+            let args = LdeFusedWritebackArguments::new(
+                c0_mut,
+                c1_mut,
+                log_n as i32,
+                1,
+                shift_arg,
+                ncpc_arg,
+                0,
+            );
+            LdeFusedWritebackFunction(ab_natural_lde_fused_boundary_writeback_out_cs_kernel)
+                .launch(&config, &args)?;
+        }
+    }
+
+    // (2) cosets 2..K-1 over the L2-hot monomials, (3) coset 0 in place LAST.
+    let initial_function = MonomialsToEvalsCompactFunction(
+        ab_natural_monomials_to_bitrev_evals_initial_8_stages_kernel,
+    );
+    let mut launch_initial = |coset: usize| -> CudaResult<()> {
+        let out_mut = {
+            let start = coset * num_cols_per_coset * stride;
+            let slice = unsafe {
+                DeviceSlice::from_raw_parts_mut(
+                    outputs_slice_mut.as_mut_ptr().add(start),
+                    num_cols * stride,
+                )
+            };
+            DeviceMatrixChunkMut::new(slice, stride, offset, n).as_mut_ptr_and_stride()
+        };
+        let args = MonomialsToEvalsCompactArguments::new(
+            chunk_const(0),
+            out_mut,
+            false,
+            log_n as i32,
+            shared::checked_i32(coset, "coset"),
+            shift_arg,
+            ncpc_arg,
+            0,
+        );
+        initial_function.launch(&config, &args)
+    };
+    for coset in 2..num_cosets {
+        launch_initial(coset)?;
+    }
+    launch_initial(0)?;
+
+    // (4) per-coset middle+final tails, coset 0 FIRST: its initial output is
+    // L2-hot and the whole coset-0 tail then runs at the 64 MB footprint;
+    // later cosets re-read their streamed initial output afterwards.
+    let mut launch_tail = |coset: usize,
+                           prefetch: Option<*const BF>,
+                           cross_column: Option<(PtrAndStride<BF>, MutPtrAndStride<BF>)>|
+     -> CudaResult<()> {
+        let start = coset * num_cols_per_coset * stride;
+        let chunk_mut = {
+            let slice = unsafe {
+                DeviceSlice::from_raw_parts_mut(
+                    outputs_slice_mut.as_mut_ptr().add(start),
+                    num_cols * stride,
+                )
+            };
+            DeviceMatrixChunkMut::new(slice, stride, offset, n).as_mut_ptr_and_stride()
+        };
+        launch_natural_to_bitrev_tail(
+            chunk_const(coset),
+            chunk_mut,
+            log_n,
+            num_cols,
+            num_cols_per_coset,
+            0,
+            prefetch,
+            cross_column,
+            stream,
+        )
+    };
+    // Each terminal pass prefetches the next coset's initial-output slab at
+    // the end of each block. The next launch consumes it immediately, while
+    // the LAST coset's terminal instead performs the next column's hypercube
+    // finest pass when one exists.
+    for coset in 0..num_cosets {
+        let last = coset == num_cosets - 1;
+        let prefetch = (!last && num_cols == 1).then(|| chunk_const(coset + 1).ptr);
+        launch_tail(
+            coset,
+            prefetch,
+            if last { cross_column_finest } else { None },
+        )?;
+    }
+    Ok(())
 }
 
 pub(crate) fn monomials_to_evals_compact_1_pass(

--- a/gpu/ntt/src/ntt/forward.rs
+++ b/gpu/ntt/src/ntt/forward.rs
@@ -14,7 +14,7 @@ use gpu_core::primitives::device_structures::{
 use gpu_core::primitives::field::BaseField;
 use gpu_core::primitives::utils::GetChunksCount;
 
-use std::mem::{MaybeUninit, size_of};
+use std::mem::{size_of, MaybeUninit};
 
 type BF = BaseField;
 

--- a/gpu/ntt/src/ntt/forward.rs
+++ b/gpu/ntt/src/ntt/forward.rs
@@ -1,12 +1,13 @@
 #![allow(non_snake_case)]
 
 use era_cudart::execution::{CudaLaunchConfig, Dim3, KernelFunction};
-use era_cudart::result::{CudaResult, CudaResultWrap};
+use era_cudart::result::CudaResult;
 use era_cudart::slice::DeviceSlice;
 use era_cudart::stream::CudaStream;
 
 use super::kernels::*;
 use super::shared;
+use gpu_core::primitives::context::DeviceProperties;
 use gpu_core::primitives::device_structures::{
     DeviceMatrixChunk, DeviceMatrixChunkImpl, DeviceMatrixChunkMut, DeviceMatrixChunkMutImpl,
     MutPtrAndStride, PtrAndStride,
@@ -14,23 +15,99 @@ use gpu_core::primitives::device_structures::{
 use gpu_core::primitives::field::BaseField;
 use gpu_core::primitives::utils::GetChunksCount;
 
+use std::ffi::{c_char, c_void};
 use std::mem::{size_of, MaybeUninit};
+use std::sync::OnceLock;
 
 type BF = BaseField;
+
+type CuTensorMapEncodeTiled = unsafe extern "C" fn(
+    tensor_map: *mut NaturalFinalOutputTensorMap,
+    tensor_data_type: i32,
+    tensor_rank: u32,
+    global_address: *mut c_void,
+    global_dims: *const u64,
+    global_strides: *const u64,
+    box_dims: *const u32,
+    element_strides: *const u32,
+    interleave: i32,
+    swizzle: i32,
+    l2_promotion: i32,
+    oob_fill: i32,
+) -> i32;
+
+::era_cudart_sys::cuda_fn_and_stub! {
+    fn cudaGetDriverEntryPointByVersion(
+        symbol: *const c_char,
+        function: *mut *mut c_void,
+        cuda_version: u32,
+        flags: u64,
+        query_result: *mut i32,
+    ) -> ::era_cudart_sys::CudaError;
+}
+
+static NATURAL_FINAL_TENSOR_MAP_ENCODER: OnceLock<CudaResult<CuTensorMapEncodeTiled>> =
+    OnceLock::new();
+
+fn natural_final_tensor_map_encoder() -> CudaResult<CuTensorMapEncodeTiled> {
+    *NATURAL_FINAL_TENSOR_MAP_ENCODER.get_or_init(|| {
+        let mut raw_function = std::ptr::null_mut();
+        let mut query_result = -1;
+        let status = unsafe {
+            cudaGetDriverEntryPointByVersion(
+                c"cuTensorMapEncodeTiled".as_ptr(),
+                &mut raw_function,
+                12_000,
+                0,
+                &mut query_result,
+            )
+        };
+        if status != era_cudart_sys::CudaError::Success {
+            return Err(status);
+        }
+        if raw_function.is_null() || query_result != 0 {
+            return Err(era_cudart_sys::CudaError::ErrorNotSupported);
+        }
+        // SAFETY: cudart reported a successful lookup of the exact CUDA
+        // driver symbol at the ABI version used by this signature.
+        Ok(unsafe { std::mem::transmute::<*mut c_void, CuTensorMapEncodeTiled>(raw_function) })
+    })
+}
 
 fn encode_natural_final_output_tensor_map(
     output: MutPtrAndStride<BF>,
     n: usize,
 ) -> CudaResult<NaturalFinalOutputTensorMap> {
-    let tensor_map = MaybeUninit::<NaturalFinalOutputTensorMap>::uninit();
-    unsafe {
-        ab_encode_natural_final_output_tensor_map(
-            tensor_map.as_ptr() as *mut NaturalFinalOutputTensorMap,
-            output.ptr,
-            n as u64,
-        )
-        .wrap_maybe_uninit(tensor_map)
+    if output.ptr as usize & 127 != 0 || n < 1024 || n & 1023 != 0 {
+        return Err(era_cudart_sys::CudaError::ErrorInvalidValue);
     }
+    let encoder = natural_final_tensor_map_encoder()?;
+    let mut tensor_map = MaybeUninit::<NaturalFinalOutputTensorMap>::uninit();
+    debug_assert_eq!(tensor_map.as_ptr() as usize & 127, 0);
+    let global_dims = [32_u64, (n / 32) as u64];
+    let global_strides = [(32 * size_of::<BF>()) as u64];
+    let box_dims = [32_u32, 32];
+    let element_strides = [1_u32, 1];
+    let result = unsafe {
+        encoder(
+            tensor_map.as_mut_ptr(),
+            2, // CU_TENSOR_MAP_DATA_TYPE_UINT32
+            2,
+            output.ptr.cast(),
+            global_dims.as_ptr(),
+            global_strides.as_ptr(),
+            box_dims.as_ptr(),
+            element_strides.as_ptr(),
+            0, // CU_TENSOR_MAP_INTERLEAVE_NONE
+            3, // CU_TENSOR_MAP_SWIZZLE_128B
+            0, // CU_TENSOR_MAP_L2_PROMOTION_NONE
+            0, // CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE
+        )
+    };
+    if result != 0 {
+        return Err(era_cudart_sys::CudaError::ErrorInvalidValue);
+    }
+    Ok(unsafe { tensor_map.assume_init() })
 }
 
 /// The two forward noninitial passes for one (column-chunk, coset-tile). The
@@ -215,6 +292,7 @@ fn launch_natural_to_bitrev_tail(
     log_cosets_in_tile: i32,
     prefetch_src: Option<*const BF>,
     cross_column_finest: Option<(PtrAndStride<BF>, MutPtrAndStride<BF>)>,
+    device_properties: &DeviceProperties,
     stream: &CudaStream,
 ) -> CudaResult<()> {
     let n = 1usize << log_n;
@@ -336,6 +414,7 @@ fn launch_natural_to_bitrev_tail(
         if matches!(log_n, 21..=24)
             && log_cosets_in_tile == 0
             && (output_matrix_mut.ptr as usize & 127) == 0
+            && shared::supports_tma_pdl(device_properties.compute_capability_major)
         {
             let output_tensor_map = encode_natural_final_output_tensor_map(output_matrix_mut, n)?;
             let args = NaturalToBitrevFinalPrefetchTmaArguments::new(
@@ -387,6 +466,7 @@ fn launch_natural_to_bitrev_tail(
         && ntts_in_launch == 1
         && log_cosets_in_tile == 0
         && (output_matrix_mut.ptr as usize & 127) == 0
+        && shared::supports_tma_pdl(device_properties.compute_capability_major)
     {
         let output_tensor_map = encode_natural_final_output_tensor_map(output_matrix_mut, n)?;
         let args = NaturalToBitrevFinalTmaArguments::new(
@@ -433,6 +513,7 @@ pub(crate) fn natural_monomials_to_bitrev_evals_3_pass(
     cosets_per_launch: usize,
     columns_per_launch: usize,
     transposed_monomials: bool,
+    device_properties: &DeviceProperties,
     stream: &CudaStream,
 ) -> CudaResult<()> {
     let n = 1 << log_n;
@@ -516,6 +597,7 @@ pub(crate) fn natural_monomials_to_bitrev_evals_3_pass(
                 log_cosets_in_tile,
                 None,
                 None,
+                device_properties,
                 stream,
             )?;
             coset_tile_start += cosets_in_tile;
@@ -949,6 +1031,7 @@ pub(crate) fn natural_fused_multi_coset_3_pass(
     num_cols_per_coset: usize,
     num_cols: usize,
     cross_column_finest: Option<(PtrAndStride<BF>, MutPtrAndStride<BF>)>,
+    device_properties: &DeviceProperties,
     stream: &CudaStream,
 ) -> CudaResult<()> {
     let n = 1 << log_n;
@@ -1094,6 +1177,7 @@ pub(crate) fn natural_fused_multi_coset_3_pass(
             0,
             prefetch,
             cross_column,
+            device_properties,
             stream,
         )
     };

--- a/gpu/ntt/src/ntt/hypercube.rs
+++ b/gpu/ntt/src/ntt/hypercube.rs
@@ -1,13 +1,14 @@
 #![allow(non_snake_case)]
 
 use era_cudart::cuda_kernel;
-use era_cudart::execution::{CudaLaunchConfig, Dim3, KernelFunction};
+use era_cudart::execution::{CudaLaunchAttribute, CudaLaunchConfig, Dim3, KernelFunction};
 use era_cudart::result::CudaResult;
 use era_cudart::slice::DeviceSlice;
 use era_cudart::stream::CudaStream;
 
+use super::hypercube_evals_to_monomial_coeffs;
 use super::shared;
-use super::{hypercube_evals_to_monomial_coeffs, MIN_LOG_N_FOR_MULTISTAGE_KERNELS};
+use super::strategy::{TWO_PASS_COMPACT_MAX_LOG_N, TWO_PASS_COMPACT_MIN_LOG_N};
 
 use gpu_core::primitives::context::DeviceProperties;
 use gpu_core::primitives::device_structures::{
@@ -20,6 +21,9 @@ use gpu_core::primitives::utils::GetChunksCount;
 use std::mem::size_of;
 
 type BF = BaseField;
+
+const _: () = assert!(TWO_PASS_COMPACT_MIN_LOG_N == 13);
+const _: () = assert!(TWO_PASS_COMPACT_MAX_LOG_N == 20);
 
 cuda_kernel!(
     StridedTilesStages,
@@ -35,7 +39,9 @@ strided_tiles_stages!(ab_hypercube_evals_to_monomials_first_9_stages_kernel);
 strided_tiles_stages!(ab_hypercube_evals_to_monomials_first_10_stages_kernel);
 
 // 3-pass evals to monomials
-strided_tiles_stages!(ab_hypercube_evals_to_monomials_nonfinal_8_stages_kernel);
+strided_tiles_stages!(ab_hypercube_evals_to_monomials_8_stages_kernel);
+strided_tiles_stages!(ab_hypercube_evals_to_monomials_8_stages_1_role_kernel);
+strided_tiles_stages!(ab_hypercube_evals_to_monomials_8_stages_pdl_kernel);
 
 cuda_kernel!(
     EvalsToMonomialsFinal,
@@ -50,10 +56,124 @@ cuda_kernel!(
 hypercube_evals_to_monomials_final!(ab_hypercube_evals_to_monomials_last_14_stages_kernel);
 
 // 3-pass evals to monomials
+hypercube_evals_to_monomials_final!(ab_hypercube_evals_to_monomials_final_4_stages_kernel);
 hypercube_evals_to_monomials_final!(ab_hypercube_evals_to_monomials_final_5_stages_kernel);
 hypercube_evals_to_monomials_final!(ab_hypercube_evals_to_monomials_final_6_stages_kernel);
 hypercube_evals_to_monomials_final!(ab_hypercube_evals_to_monomials_final_7_stages_kernel);
-hypercube_evals_to_monomials_final!(ab_hypercube_evals_to_monomials_final_8_stages_kernel);
+hypercube_evals_to_monomials_final!(ab_hypercube_evals_to_monomials_finest_8_stages_kernel);
+
+cuda_kernel!(
+    HypercubeLastCompact,
+    hypercube_last_compact,
+    inputs_matrix: PtrAndStride<BF>,
+    outputs_matrix: MutPtrAndStride<BF>,
+);
+
+hypercube_last_compact!(ab_hypercube_evals_to_monomials_last_5_stages_compact_kernel);
+hypercube_last_compact!(ab_hypercube_evals_to_monomials_last_6_stages_compact_kernel);
+hypercube_last_compact!(ab_hypercube_evals_to_monomials_last_7_stages_compact_kernel);
+hypercube_last_compact!(ab_hypercube_evals_to_monomials_last_8_stages_compact_kernel);
+hypercube_last_compact!(ab_hypercube_evals_to_monomials_last_9_stages_compact_kernel);
+hypercube_last_compact!(ab_hypercube_evals_to_monomials_last_10_stages_compact_kernel);
+hypercube_last_compact!(ab_hypercube_evals_to_monomials_last_11_stages_compact_kernel);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HypercubeDispatch {
+    OneStagePerVariable {
+        stages: usize,
+    },
+    TwoPassCompact {
+        first_stages: usize,
+        last_stages: usize,
+    },
+    ThreePassCompact {
+        first_stages: usize,
+        middle_stages: usize,
+        last_stages: usize,
+    },
+    TwoPass,
+    ThreePass,
+}
+
+impl HypercubeDispatch {
+    #[cfg(test)]
+    fn kernel_launches_per_column(self) -> usize {
+        match self {
+            Self::OneStagePerVariable { stages } => stages,
+            Self::TwoPassCompact { .. } | Self::TwoPass => 2,
+            Self::ThreePassCompact { .. } | Self::ThreePass => 3,
+        }
+    }
+}
+
+fn select_hypercube_dispatch(
+    log_n: usize,
+    large_ntt_passes: super::NttPassCount,
+) -> HypercubeDispatch {
+    if log_n < TWO_PASS_COMPACT_MIN_LOG_N {
+        HypercubeDispatch::OneStagePerVariable { stages: log_n }
+    } else if log_n < TWO_PASS_COMPACT_MAX_LOG_N {
+        HypercubeDispatch::TwoPassCompact {
+            first_stages: 8,
+            last_stages: log_n - 8,
+        }
+    } else if log_n == TWO_PASS_COMPACT_MAX_LOG_N {
+        HypercubeDispatch::ThreePassCompact {
+            first_stages: 8,
+            middle_stages: 8,
+            last_stages: 4,
+        }
+    } else {
+        match large_ntt_passes {
+            super::NttPassCount::Two => HypercubeDispatch::TwoPass,
+            super::NttPassCount::Three => HypercubeDispatch::ThreePass,
+        }
+    }
+}
+
+#[cfg(test)]
+mod cpu_dispatch_tests {
+    use super::*;
+
+    #[test]
+    fn compact_range_never_uses_one_stage_per_variable() {
+        for log_n in TWO_PASS_COMPACT_MIN_LOG_N..=TWO_PASS_COMPACT_MAX_LOG_N {
+            for large_ntt_passes in [
+                super::super::NttPassCount::Two,
+                super::super::NttPassCount::Three,
+            ] {
+                let dispatch = select_hypercube_dispatch(log_n, large_ntt_passes);
+                let expected = if log_n == TWO_PASS_COMPACT_MAX_LOG_N {
+                    HypercubeDispatch::ThreePassCompact {
+                        first_stages: 8,
+                        middle_stages: 8,
+                        last_stages: 4,
+                    }
+                } else {
+                    HypercubeDispatch::TwoPassCompact {
+                        first_stages: 8,
+                        last_stages: log_n - 8,
+                    }
+                };
+                assert_eq!(
+                    dispatch, expected,
+                    "log_n={log_n}, large_ntt_passes={large_ntt_passes:?}",
+                );
+                let expected_launches = if log_n == TWO_PASS_COMPACT_MAX_LOG_N {
+                    3
+                } else {
+                    2
+                };
+                assert_eq!(
+                    dispatch.kernel_launches_per_column(),
+                    expected_launches,
+                    "log_n={log_n}"
+                );
+                assert!(dispatch.kernel_launches_per_column() < log_n);
+            }
+        }
+    }
+}
 
 /// The two hypercube nonfinal passes for one column (pass 1 reads the
 /// hypercube evals, pass 2 runs in place on the output).
@@ -65,9 +185,14 @@ fn launch_nonfinal_passes(
     stream: &CudaStream,
 ) -> CudaResult<()> {
     let n = 1usize << log_n;
-    let bf_vals_per_block = 1usize << 13; // 8192
     let mut start_stage = 0;
     for i in 0..2 {
+        let log_bf_vals_per_block = if log_n == 20 && start_stage == 8 {
+            12 // 4096: one exchange region and one tile role per thread
+        } else {
+            13 // 8192: two tile roles per thread
+        };
+        let bf_vals_per_block = 1usize << log_bf_vals_per_block;
         let num_exchg_regions = 1 << start_stage;
         let exchg_region_size = n >> start_stage;
         let blocks_per_exchg_region = exchg_region_size / bf_vals_per_block;
@@ -85,8 +210,12 @@ fn launch_nonfinal_passes(
         };
         let args =
             StridedTilesStagesArguments::new(input, output_matrix_mut, log_n as i32, start_stage);
-        StridedTilesStagesFunction(ab_hypercube_evals_to_monomials_nonfinal_8_stages_kernel)
-            .launch(&config, &args)?;
+        let function = if log_bf_vals_per_block == 12 {
+            StridedTilesStagesFunction(ab_hypercube_evals_to_monomials_8_stages_1_role_kernel)
+        } else {
+            StridedTilesStagesFunction(ab_hypercube_evals_to_monomials_8_stages_kernel)
+        };
+        function.launch(&config, &args)?;
         start_stage += 8;
     }
     Ok(())
@@ -145,6 +274,10 @@ pub(crate) fn hypercube_evals_to_monomials_3_pass(
             log_n as i32,
         );
         match log_n {
+            20 => {
+                EvalsToMonomialsFinalFunction(ab_hypercube_evals_to_monomials_final_4_stages_kernel)
+                    .launch(&config, &args)?
+            }
             21 => {
                 EvalsToMonomialsFinalFunction(ab_hypercube_evals_to_monomials_final_5_stages_kernel)
                     .launch(&config, &args)?
@@ -157,11 +290,11 @@ pub(crate) fn hypercube_evals_to_monomials_3_pass(
                 EvalsToMonomialsFinalFunction(ab_hypercube_evals_to_monomials_final_7_stages_kernel)
                     .launch(&config, &args)?
             }
-            24 => {
-                EvalsToMonomialsFinalFunction(ab_hypercube_evals_to_monomials_final_8_stages_kernel)
-                    .launch(&config, &args)?
-            }
-            _ => unreachable!("hypercube 3-pass kernels are only generated for log_n in 21..=24"),
+            24 => EvalsToMonomialsFinalFunction(
+                ab_hypercube_evals_to_monomials_finest_8_stages_kernel,
+            )
+            .launch(&config, &args)?,
+            _ => unreachable!("hypercube 3-pass kernels are only generated for log_n in 20..=24"),
         }
     }
     Ok(())
@@ -212,6 +345,133 @@ pub(crate) fn hypercube_evals_to_pre_tail_monomials_3_pass(
             log_n,
             stream,
         )?;
+    }
+    Ok(())
+}
+
+/// Fine->coarse pre-tail for the natural fused LDE boundary kernel: the
+/// finest-stage kernel FIRST (reading the hypercube evals out of place),
+/// then the middle 8 stages in place — the coarse-8 tail stays for the fused
+/// kernel. Valid reorder: the hypercube stages carry no twiddles and commute.
+pub(crate) fn hypercube_evals_to_pre_tail_monomials_lsb_3_pass(
+    inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
+    log_n: usize,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    hypercube_evals_to_monomials_lsb_fine_first(inputs_matrix, outputs_matrix, log_n, false, stream)
+}
+
+/// Continue the fine->coarse pre-tail after a preceding cross-column kernel
+/// has already written the finest-stage output into `outputs_matrix`.
+pub(crate) fn hypercube_evals_to_pre_tail_monomials_lsb_3_pass_after_finest(
+    inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
+    log_n: usize,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    hypercube_evals_to_monomials_lsb_fine_first(inputs_matrix, outputs_matrix, log_n, true, stream)
+}
+
+fn hypercube_evals_to_monomials_lsb_fine_first(
+    inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
+    log_n: usize,
+    finest_already_computed: bool,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    let n = 1 << log_n;
+    assert_eq!(inputs_matrix.rows(), n);
+    assert_eq!(outputs_matrix.rows(), n);
+    shared::assert_ntt_16b_aligned(inputs_matrix, outputs_matrix);
+    let num_ntts = outputs_matrix.cols();
+    assert_eq!(inputs_matrix.cols(), num_ntts);
+    let inputs_slice = inputs_matrix.slice();
+    let stride = outputs_matrix.stride();
+    let offset = outputs_matrix.offset();
+    let outputs_slice_const = unsafe {
+        DeviceSlice::from_raw_parts(
+            outputs_matrix.slice().as_ptr(),
+            outputs_matrix.slice().len(),
+        )
+    };
+    let outputs_slice_mut = outputs_matrix.slice_mut();
+    for col in 0..num_ntts {
+        let range = col * stride..(col + 1) * stride;
+        let input_slice = &inputs_slice[range.clone()];
+        let output_slice_const = &outputs_slice_const[range.clone()];
+        let output_slice_mut = &mut outputs_slice_mut[range.clone()];
+        let input_matrix = DeviceMatrixChunk::new(input_slice, stride, offset, n);
+        let output_matrix_const = DeviceMatrixChunk::new(output_slice_const, stride, offset, n);
+        let mut output_matrix_mut = DeviceMatrixChunkMut::new(output_slice_mut, stride, offset, n);
+        let input_matrix = input_matrix.as_ptr_and_stride();
+        let output_matrix_const = output_matrix_const.as_ptr_and_stride();
+        let output_matrix_mut = output_matrix_mut.as_mut_ptr_and_stride();
+        // Finest stages first, out of place from the hypercube evals. A
+        // previous column's fused terminal may already have produced this
+        // exact slab.
+        let threads = 256;
+        let bf_vals_per_block = 1 << 13; // 8192
+        let blocks = n.get_chunks_count(bf_vals_per_block);
+        if !finest_already_computed {
+            let config = CudaLaunchConfig::basic(blocks as u32, threads as u32, stream);
+            let args = EvalsToMonomialsFinalArguments::new(
+                input_matrix,
+                output_matrix_mut,
+                false,
+                log_n as i32,
+            );
+            match log_n {
+                21 => EvalsToMonomialsFinalFunction(
+                    ab_hypercube_evals_to_monomials_final_5_stages_kernel,
+                )
+                .launch(&config, &args)?,
+                22 => EvalsToMonomialsFinalFunction(
+                    ab_hypercube_evals_to_monomials_final_6_stages_kernel,
+                )
+                .launch(&config, &args)?,
+                23 => EvalsToMonomialsFinalFunction(
+                    ab_hypercube_evals_to_monomials_final_7_stages_kernel,
+                )
+                .launch(&config, &args)?,
+                24 => EvalsToMonomialsFinalFunction(
+                    ab_hypercube_evals_to_monomials_finest_8_stages_kernel,
+                )
+                .launch(&config, &args)?,
+                _ => {
+                    unreachable!("hypercube 3-pass kernels are only generated for log_n in 21..=24")
+                }
+            }
+        }
+        // Middle 8 stages in place.
+        let start_stage = 8;
+        let num_exchg_regions = 1usize << start_stage;
+        let exchg_region_size = n >> start_stage;
+        let blocks_per_exchg_region = exchg_region_size / bf_vals_per_block;
+        assert_eq!(
+            blocks_per_exchg_region * num_exchg_regions,
+            n / bf_vals_per_block
+        );
+        let mut grid_dim: Dim3 = (blocks_per_exchg_region as u32).into();
+        grid_dim.y = num_exchg_regions as u32;
+        let pdl_middle = finest_already_computed && matches!(log_n, 22..=24);
+        let pdl_attributes = [CudaLaunchAttribute::ProgrammaticStreamSerialization(true)];
+        let mut config = CudaLaunchConfig::basic(grid_dim, threads as u32, stream);
+        if pdl_middle {
+            config.attributes = &pdl_attributes;
+        }
+        let args = StridedTilesStagesArguments::new(
+            output_matrix_const,
+            output_matrix_mut,
+            log_n as i32,
+            start_stage as i32,
+        );
+        let middle = if pdl_middle {
+            ab_hypercube_evals_to_monomials_8_stages_pdl_kernel
+        } else {
+            ab_hypercube_evals_to_monomials_8_stages_kernel
+        };
+        StridedTilesStagesFunction(middle).launch(&config, &args)?;
     }
     Ok(())
 }
@@ -289,6 +549,102 @@ pub(crate) fn hypercube_evals_to_monomials_2_pass(
     Ok(())
 }
 
+/// Two-pass compact-range Mobius transform: the existing whole-domain
+/// nonfinal8 pass followed by a twiddle-free consecutive-chunk tail of
+/// `log_n - 8` stages. This path is natural-layout only.
+pub(crate) fn hypercube_evals_to_monomials_2_pass_compact(
+    inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
+    log_n: usize,
+    transposed_monomials: bool,
+    stream: &CudaStream,
+) -> CudaResult<()> {
+    assert!(
+        (TWO_PASS_COMPACT_MIN_LOG_N..TWO_PASS_COMPACT_MAX_LOG_N).contains(&log_n),
+        "two-pass compact hypercube path supports log_n in [{TWO_PASS_COMPACT_MIN_LOG_N}, {TWO_PASS_COMPACT_MAX_LOG_N})",
+    );
+    assert!(
+        !transposed_monomials,
+        "compact hypercube path does not support transposed monomials",
+    );
+    let n = 1usize << log_n;
+    assert_eq!(inputs_matrix.rows(), n);
+    assert_eq!(outputs_matrix.rows(), n);
+    assert_eq!(inputs_matrix.stride(), outputs_matrix.stride());
+    shared::assert_ntt_16b_aligned(inputs_matrix, outputs_matrix);
+    let num_ntts = outputs_matrix.cols();
+    assert_eq!(inputs_matrix.cols(), num_ntts);
+    let inputs_slice = inputs_matrix.slice();
+    let stride = outputs_matrix.stride();
+    let offset = outputs_matrix.offset();
+    let outputs_slice_const = unsafe {
+        DeviceSlice::from_raw_parts(
+            outputs_matrix.slice().as_ptr(),
+            outputs_matrix.slice().len(),
+        )
+    };
+    let outputs_slice_mut = outputs_matrix.slice_mut();
+    let log_k = log_n - 8;
+    let tail_function = match log_k {
+        5 => HypercubeLastCompactFunction(
+            ab_hypercube_evals_to_monomials_last_5_stages_compact_kernel,
+        ),
+        6 => HypercubeLastCompactFunction(
+            ab_hypercube_evals_to_monomials_last_6_stages_compact_kernel,
+        ),
+        7 => HypercubeLastCompactFunction(
+            ab_hypercube_evals_to_monomials_last_7_stages_compact_kernel,
+        ),
+        8 => HypercubeLastCompactFunction(
+            ab_hypercube_evals_to_monomials_last_8_stages_compact_kernel,
+        ),
+        9 => HypercubeLastCompactFunction(
+            ab_hypercube_evals_to_monomials_last_9_stages_compact_kernel,
+        ),
+        10 => HypercubeLastCompactFunction(
+            ab_hypercube_evals_to_monomials_last_10_stages_compact_kernel,
+        ),
+        11 => HypercubeLastCompactFunction(
+            ab_hypercube_evals_to_monomials_last_11_stages_compact_kernel,
+        ),
+        _ => unreachable!("log_k = log_n - 8 is in [5, 11]"),
+    };
+
+    // Work on one column at a time to preserve the existing L2 locality.
+    for col in 0..num_ntts {
+        let range = col * stride..(col + 1) * stride;
+        let input_slice = &inputs_slice[range.clone()];
+        let output_slice_const = &outputs_slice_const[range.clone()];
+        let output_slice_mut = &mut outputs_slice_mut[range];
+        let input_matrix =
+            DeviceMatrixChunk::new(input_slice, stride, offset, n).as_ptr_and_stride();
+        let output_matrix_const =
+            DeviceMatrixChunk::new(output_slice_const, stride, offset, n).as_ptr_and_stride();
+        let mut output_matrix_mut = DeviceMatrixChunkMut::new(output_slice_mut, stride, offset, n);
+        let output_matrix_mut = output_matrix_mut.as_mut_ptr_and_stride();
+
+        // At log_n=13/14 this is intentionally a skinny 1/2-block grid per
+        // column; it is still a fixed two-launch path instead of 13/14
+        // one-stage launches. Column folding can be added if these sizes
+        // become hot enough to justify changing the kernel ABI.
+        let first_blocks = n / (1usize << 13);
+        let first_config = CudaLaunchConfig::basic(first_blocks as u32, 256, stream);
+        let first_args =
+            StridedTilesStagesArguments::new(input_matrix, output_matrix_mut, log_n as i32, 0);
+        StridedTilesStagesFunction(ab_hypercube_evals_to_monomials_8_stages_kernel)
+            .launch(&first_config, &first_args)?;
+
+        let k_vals = 1usize << log_k;
+        let tail_blocks = n / k_vals;
+        debug_assert_eq!(tail_blocks, 1usize << 8);
+        let mut tail_config = CudaLaunchConfig::basic(tail_blocks as u32, 256, stream);
+        tail_config.dynamic_smem_bytes = k_vals * size_of::<BF>();
+        let tail_args = HypercubeLastCompactArguments::new(output_matrix_const, output_matrix_mut);
+        tail_function.launch(&tail_config, &tail_args)?;
+    }
+    Ok(())
+}
+
 /// Multilinear hypercube evaluations -> multilinear monomial coefficients, the
 /// multistage form of [`super::hypercube_evals_to_monomial_coeffs`] (which
 /// serves the sub-floor fallback below). Being a Mobius transform it preserves
@@ -302,41 +658,71 @@ pub fn hypercube_evals_to_monomials(
     stream: &CudaStream,
     device_properties: &DeviceProperties,
 ) -> CudaResult<()> {
-    if log_n < MIN_LOG_N_FOR_MULTISTAGE_KERNELS {
-        // Fallback (uses 1 stage at a time kernels)
-        assert!(
-            !transposed_monomials,
-            "fallback path does not support transposed monomials",
-        );
-        let cols = inputs_matrix.cols();
-        let rows = inputs_matrix.rows();
-        assert_eq!(cols, outputs_matrix.cols());
-        assert_eq!(rows, outputs_matrix.rows());
-        let inputs_stride = inputs_matrix.stride();
-        let outputs_stride = outputs_matrix.stride();
-        let inputs_offset = inputs_matrix.offset();
-        let outputs_offset = outputs_matrix.offset();
-        let inputs_slice = &(inputs_matrix.slice())[inputs_offset..];
-        let outputs_slice = &mut (outputs_matrix.slice_mut())[outputs_offset..];
-        for col in 0..cols {
-            hypercube_evals_to_monomial_coeffs(
-                &inputs_slice[col * inputs_stride..col * inputs_stride + rows],
-                &mut outputs_slice[col * outputs_stride..col * outputs_stride + rows],
-                log_n,
-                stream,
-            )?;
+    let dispatch =
+        select_hypercube_dispatch(log_n, super::ntt_pass_selection(log_n, device_properties));
+    match dispatch {
+        HypercubeDispatch::OneStagePerVariable { stages } => {
+            debug_assert_eq!(stages, log_n);
+            assert!(
+                !transposed_monomials,
+                "fallback path does not support transposed monomials",
+            );
+            let cols = inputs_matrix.cols();
+            let rows = inputs_matrix.rows();
+            assert_eq!(cols, outputs_matrix.cols());
+            assert_eq!(rows, outputs_matrix.rows());
+            let inputs_stride = inputs_matrix.stride();
+            let outputs_stride = outputs_matrix.stride();
+            let inputs_offset = inputs_matrix.offset();
+            let outputs_offset = outputs_matrix.offset();
+            let inputs_slice = &(inputs_matrix.slice())[inputs_offset..];
+            let outputs_slice = &mut (outputs_matrix.slice_mut())[outputs_offset..];
+            for col in 0..cols {
+                hypercube_evals_to_monomial_coeffs(
+                    &inputs_slice[col * inputs_stride..col * inputs_stride + rows],
+                    &mut outputs_slice[col * outputs_stride..col * outputs_stride + rows],
+                    log_n,
+                    stream,
+                )?;
+            }
         }
-        return Ok(());
-    }
-    match super::ntt_pass_selection(log_n, device_properties) {
-        super::NttPassCount::Two => hypercube_evals_to_monomials_2_pass(
+        HypercubeDispatch::TwoPassCompact {
+            first_stages,
+            last_stages,
+        } => {
+            debug_assert_eq!(first_stages, 8);
+            debug_assert_eq!(first_stages + last_stages, log_n);
+            hypercube_evals_to_monomials_2_pass_compact(
+                inputs_matrix,
+                outputs_matrix,
+                log_n,
+                transposed_monomials,
+                stream,
+            )?
+        }
+        HypercubeDispatch::ThreePassCompact {
+            first_stages,
+            middle_stages,
+            last_stages,
+        } => {
+            debug_assert_eq!((first_stages, middle_stages, last_stages), (8, 8, 4));
+            debug_assert_eq!(first_stages + middle_stages + last_stages, log_n);
+            hypercube_evals_to_monomials_3_pass(
+                inputs_matrix,
+                outputs_matrix,
+                log_n,
+                transposed_monomials,
+                stream,
+            )?
+        }
+        HypercubeDispatch::TwoPass => hypercube_evals_to_monomials_2_pass(
             inputs_matrix,
             outputs_matrix,
             log_n,
             transposed_monomials,
             stream,
         )?,
-        super::NttPassCount::Three => hypercube_evals_to_monomials_3_pass(
+        HypercubeDispatch::ThreePass => hypercube_evals_to_monomials_3_pass(
             inputs_matrix,
             outputs_matrix,
             log_n,

--- a/gpu/ntt/src/ntt/hypercube.rs
+++ b/gpu/ntt/src/ntt/hypercube.rs
@@ -357,9 +357,17 @@ pub(crate) fn hypercube_evals_to_pre_tail_monomials_lsb_3_pass(
     inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
     outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
     log_n: usize,
+    device_properties: &DeviceProperties,
     stream: &CudaStream,
 ) -> CudaResult<()> {
-    hypercube_evals_to_monomials_lsb_fine_first(inputs_matrix, outputs_matrix, log_n, false, stream)
+    hypercube_evals_to_monomials_lsb_fine_first(
+        inputs_matrix,
+        outputs_matrix,
+        log_n,
+        false,
+        device_properties,
+        stream,
+    )
 }
 
 /// Continue the fine->coarse pre-tail after a preceding cross-column kernel
@@ -368,9 +376,17 @@ pub(crate) fn hypercube_evals_to_pre_tail_monomials_lsb_3_pass_after_finest(
     inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
     outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
     log_n: usize,
+    device_properties: &DeviceProperties,
     stream: &CudaStream,
 ) -> CudaResult<()> {
-    hypercube_evals_to_monomials_lsb_fine_first(inputs_matrix, outputs_matrix, log_n, true, stream)
+    hypercube_evals_to_monomials_lsb_fine_first(
+        inputs_matrix,
+        outputs_matrix,
+        log_n,
+        true,
+        device_properties,
+        stream,
+    )
 }
 
 fn hypercube_evals_to_monomials_lsb_fine_first(
@@ -378,6 +394,7 @@ fn hypercube_evals_to_monomials_lsb_fine_first(
     outputs_matrix: &mut (impl DeviceMatrixChunkMutImpl<BF> + ?Sized),
     log_n: usize,
     finest_already_computed: bool,
+    device_properties: &DeviceProperties,
     stream: &CudaStream,
 ) -> CudaResult<()> {
     let n = 1 << log_n;
@@ -454,7 +471,9 @@ fn hypercube_evals_to_monomials_lsb_fine_first(
         );
         let mut grid_dim: Dim3 = (blocks_per_exchg_region as u32).into();
         grid_dim.y = num_exchg_regions as u32;
-        let pdl_middle = finest_already_computed && matches!(log_n, 22..=24);
+        let pdl_middle = finest_already_computed
+            && matches!(log_n, 22..=24)
+            && shared::supports_tma_pdl(device_properties.compute_capability_major);
         let pdl_attributes = [CudaLaunchAttribute::ProgrammaticStreamSerialization(true)];
         let mut config = CudaLaunchConfig::basic(grid_dim, threads as u32, stream);
         if pdl_middle {

--- a/gpu/ntt/src/ntt/kernels.rs
+++ b/gpu/ntt/src/ntt/kernels.rs
@@ -11,14 +11,8 @@ type BF = BaseField;
 pub(super) struct NaturalFinalOutputTensorMap {
     opaque: [u64; 16],
 }
-
-::era_cudart_sys::cuda_fn_and_stub! {
-    pub(super) fn ab_encode_natural_final_output_tensor_map(
-        tensor_map: *mut NaturalFinalOutputTensorMap,
-        output: *mut BF,
-        n: u64,
-    ) -> ::era_cudart_sys::CudaError;
-}
+const _: () = assert!(std::mem::size_of::<NaturalFinalOutputTensorMap>() == 128);
+const _: () = assert!(std::mem::align_of::<NaturalFinalOutputTensorMap>() == 128);
 
 cuda_kernel_signature_and_arguments!(
     pub(super) StridedTilesStages,

--- a/gpu/ntt/src/ntt/kernels.rs
+++ b/gpu/ntt/src/ntt/kernels.rs
@@ -6,6 +6,20 @@ use gpu_core::primitives::field::BaseField;
 
 type BF = BaseField;
 
+#[repr(C, align(128))]
+#[derive(Clone, Copy)]
+pub(super) struct NaturalFinalOutputTensorMap {
+    opaque: [u64; 16],
+}
+
+::era_cudart_sys::cuda_fn_and_stub! {
+    pub(super) fn ab_encode_natural_final_output_tensor_map(
+        tensor_map: *mut NaturalFinalOutputTensorMap,
+        output: *mut BF,
+        n: u64,
+    ) -> ::era_cudart_sys::CudaError;
+}
+
 cuda_kernel_signature_and_arguments!(
     pub(super) StridedTilesStages,
     inputs_matrix: PtrAndStride<BF>,
@@ -54,6 +68,59 @@ strided_tiles_stages!(ab_monomials_to_evals_last_10_stages_kernel);
 strided_tiles_stages!(ab_monomials_to_evals_noninitial_8_stages_kernel);
 
 strided_tiles_stages!(ab_natural_monomials_to_bitrev_evals_middle_8_stages_kernel);
+
+cuda_kernel_signature_and_arguments!(
+    pub(super) NaturalMiddleFixed,
+    inputs_matrix: PtrAndStride<BF>,
+    outputs_matrix: MutPtrAndStride<BF>,
+);
+pub(super) struct NaturalMiddleFixedFunction(pub(super) NaturalMiddleFixedSignature);
+impl era_cudart::execution::KernelFunction for NaturalMiddleFixedFunction {
+    type Signature = NaturalMiddleFixedSignature;
+    fn as_ptr(&self) -> *const std::os::raw::c_void {
+        self.0 as *const std::os::raw::c_void
+    }
+}
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_monomials_to_bitrev_evals_middle_8_stages_log_n_24_packed_twiddles_kernel(
+        inputs_matrix: PtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+    )
+);
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_monomials_to_bitrev_evals_middle_8_stages_log_n_23_packed_twiddles_kernel(
+        inputs_matrix: PtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+    )
+);
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_monomials_to_bitrev_evals_middle_8_stages_log_n_22_packed_twiddles_kernel(
+        inputs_matrix: PtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+    )
+);
+cuda_kernel_signature_and_arguments!(
+    pub(super) NaturalMiddleLogN21TwoCosets,
+    inputs_matrix: PtrAndStride<BF>,
+    outputs_matrix: MutPtrAndStride<BF>,
+    num_cols_per_coset: i32,
+);
+pub(super) struct NaturalMiddleLogN21TwoCosetsFunction(
+    pub(super) NaturalMiddleLogN21TwoCosetsSignature,
+);
+impl era_cudart::execution::KernelFunction for NaturalMiddleLogN21TwoCosetsFunction {
+    type Signature = NaturalMiddleLogN21TwoCosetsSignature;
+    fn as_ptr(&self) -> *const std::os::raw::c_void {
+        self.0 as *const std::os::raw::c_void
+    }
+}
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_monomials_to_bitrev_evals_middle_8_stages_log_n_21_two_cosets_packed_twiddles_kernel(
+        inputs_matrix: PtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+        num_cols_per_coset: i32,
+    )
+);
 // evict-first variant for the LAST noninitial pass (hybrid LDE path)
 strided_tiles_stages!(ab_monomials_to_evals_noninitial_8_stages_evict_kernel);
 
@@ -133,6 +200,46 @@ lde_fused_writeback!(ab_lde_fused_boundary_writeback_6_stages_kernel);
 lde_fused_writeback!(ab_lde_fused_boundary_writeback_7_stages_kernel);
 lde_fused_writeback!(ab_lde_fused_boundary_writeback_8_stages_kernel);
 
+// Natural-order path: hypercube coarse tail + transient monomial writeback +
+// coset scale + DIT initial. The output is streamed because its tail is later.
+lde_fused_writeback!(ab_natural_lde_fused_boundary_writeback_out_cs_kernel);
+
+cuda_kernel_signature_and_arguments!(
+    pub(super) LdeFusedWritebackFixed,
+    scratch_matrix: MutPtrAndStride<BF>,
+    outputs_matrix: MutPtrAndStride<BF>,
+);
+pub(super) struct LdeFusedWritebackFixedFunction(pub(super) LdeFusedWritebackFixedSignature);
+impl era_cudart::execution::KernelFunction for LdeFusedWritebackFixedFunction {
+    type Signature = LdeFusedWritebackFixedSignature;
+    fn as_ptr(&self) -> *const std::os::raw::c_void {
+        self.0 as *const std::os::raw::c_void
+    }
+}
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_lde_fused_boundary_writeback_out_cs_log_n_24_c1_kernel(
+        scratch_matrix: MutPtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+    )
+);
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_lde_fused_boundary_writeback_out_cs_log_n_23_c1_kernel(
+        scratch_matrix: MutPtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+    )
+);
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_lde_fused_boundary_writeback_out_cs_log_n_22_c1_kernel(
+        scratch_matrix: MutPtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+    )
+);
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_lde_fused_boundary_writeback_out_cs_log_n_21_c1_kernel(
+        scratch_matrix: MutPtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+    )
+);
 cuda_kernel_signature_and_arguments!(
     pub(super) MonomialsToEvalsInitial,
     inputs_matrix: PtrAndStride<BF>,
@@ -249,6 +356,9 @@ monomials_to_evals_compact!(ab_monomials_to_evals_initial_8_stages_kernel);
 // Shares the multi-coset MonomialsToEvalsCompact signature (shared input
 // column, per-coset output slab, coset pre-scale).
 monomials_to_evals_compact!(ab_natural_monomials_to_bitrev_evals_initial_8_stages_kernel);
+monomials_to_evals_compact!(
+    ab_natural_monomials_to_bitrev_evals_initial_8_stages_from_hypercube_final_4_kernel
+);
 
 // Same MonomialsToEvalsCompact signature as the three-pass initial pass.
 monomials_to_evals_compact!(ab_natural_monomials_to_bitrev_evals_first_9_stages_kernel);
@@ -321,6 +431,190 @@ impl era_cudart::execution::KernelFunction for NaturalToBitrevFinalFunction {
         self.0 as *const std::os::raw::c_void
     }
 }
+
+cuda_kernel_signature_and_arguments!(
+    pub(super) NaturalToBitrevFinalTma,
+    inputs_matrix: PtrAndStride<BF>,
+    outputs_matrix: MutPtrAndStride<BF>,
+    log_n: i32,
+    output_tensor_map: NaturalFinalOutputTensorMap,
+);
+pub(super) struct NaturalToBitrevFinalTmaFunction(pub(super) NaturalToBitrevFinalTmaSignature);
+impl era_cudart::execution::KernelFunction for NaturalToBitrevFinalTmaFunction {
+    type Signature = NaturalToBitrevFinalTmaSignature;
+    fn as_ptr(&self) -> *const std::os::raw::c_void {
+        self.0 as *const std::os::raw::c_void
+    }
+}
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_monomials_to_bitrev_evals_final_8_stages_evict_tma_kernel(
+        inputs_matrix: PtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+        log_n: i32,
+        output_tensor_map: NaturalFinalOutputTensorMap,
+    )
+);
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_monomials_to_bitrev_evals_final_7_stages_evict_tma_kernel(
+        inputs_matrix: PtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+        log_n: i32,
+        output_tensor_map: NaturalFinalOutputTensorMap,
+    )
+);
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_monomials_to_bitrev_evals_final_6_stages_evict_tma_kernel(
+        inputs_matrix: PtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+        log_n: i32,
+        output_tensor_map: NaturalFinalOutputTensorMap,
+    )
+);
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_monomials_to_bitrev_evals_final_5_stages_evict_tma_kernel(
+        inputs_matrix: PtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+        log_n: i32,
+        output_tensor_map: NaturalFinalOutputTensorMap,
+    )
+);
+cuda_kernel_signature_and_arguments!(
+    pub(super) NaturalToBitrevFinalPrefetch,
+    inputs_matrix: PtrAndStride<BF>,
+    outputs_matrix: MutPtrAndStride<BF>,
+    log_n: i32,
+    num_cols_per_coset: i32,
+    log_cosets_in_tile: i32,
+    prefetch_src: *const BF,
+);
+pub(super) struct NaturalToBitrevFinalPrefetchFunction(
+    pub(super) NaturalToBitrevFinalPrefetchSignature,
+);
+impl era_cudart::execution::KernelFunction for NaturalToBitrevFinalPrefetchFunction {
+    type Signature = NaturalToBitrevFinalPrefetchSignature;
+    fn as_ptr(&self) -> *const std::os::raw::c_void {
+        self.0 as *const std::os::raw::c_void
+    }
+}
+
+cuda_kernel_signature_and_arguments!(
+    pub(super) NaturalToBitrevFinalPrefetchTma,
+    inputs_matrix: PtrAndStride<BF>,
+    outputs_matrix: MutPtrAndStride<BF>,
+    log_n: i32,
+    prefetch_src: *const BF,
+    output_tensor_map: NaturalFinalOutputTensorMap,
+);
+pub(super) struct NaturalToBitrevFinalPrefetchTmaFunction(
+    pub(super) NaturalToBitrevFinalPrefetchTmaSignature,
+);
+impl era_cudart::execution::KernelFunction for NaturalToBitrevFinalPrefetchTmaFunction {
+    type Signature = NaturalToBitrevFinalPrefetchTmaSignature;
+    fn as_ptr(&self) -> *const std::os::raw::c_void {
+        self.0 as *const std::os::raw::c_void
+    }
+}
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_monomials_to_bitrev_evals_final_7_stages_evict_prefetch_packed_smem_tma_kernel(
+        inputs_matrix: PtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+        log_n: i32,
+        prefetch_src: *const BF,
+        output_tensor_map: NaturalFinalOutputTensorMap,
+    )
+);
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_monomials_to_bitrev_evals_final_6_stages_evict_prefetch_packed_smem_tma_kernel(
+        inputs_matrix: PtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+        log_n: i32,
+        prefetch_src: *const BF,
+        output_tensor_map: NaturalFinalOutputTensorMap,
+    )
+);
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_monomials_to_bitrev_evals_final_5_stages_evict_prefetch_packed_smem_tma_kernel(
+        inputs_matrix: PtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+        log_n: i32,
+        prefetch_src: *const BF,
+        output_tensor_map: NaturalFinalOutputTensorMap,
+    )
+);
+::era_cudart::cuda_kernel_declaration!(
+    pub(super) ab_natural_monomials_to_bitrev_evals_final_8_stages_evict_prefetch_packed_smem_packed_num2_tma_kernel(
+        inputs_matrix: PtrAndStride<BF>,
+        outputs_matrix: MutPtrAndStride<BF>,
+        log_n: i32,
+        prefetch_src: *const BF,
+        output_tensor_map: NaturalFinalOutputTensorMap,
+    )
+);
+macro_rules! natural_to_bitrev_final_prefetch {
+    ($kernel_name:ident) => {
+        ::era_cudart::cuda_kernel_declaration!(pub(super) $kernel_name(
+    inputs_matrix: PtrAndStride<BF>,
+    outputs_matrix: MutPtrAndStride<BF>,
+    log_n: i32,
+    num_cols_per_coset: i32,
+    log_cosets_in_tile: i32,
+    prefetch_src: *const BF,
+        ));
+    };
+}
+natural_to_bitrev_final_prefetch!(
+    ab_natural_monomials_to_bitrev_evals_final_5_stages_evict_prefetch_kernel
+);
+natural_to_bitrev_final_prefetch!(
+    ab_natural_monomials_to_bitrev_evals_final_6_stages_evict_prefetch_kernel
+);
+natural_to_bitrev_final_prefetch!(
+    ab_natural_monomials_to_bitrev_evals_final_7_stages_evict_prefetch_kernel
+);
+natural_to_bitrev_final_prefetch!(
+    ab_natural_monomials_to_bitrev_evals_final_8_stages_evict_prefetch_kernel
+);
+
+cuda_kernel_signature_and_arguments!(
+    pub(super) NaturalToBitrevFinalCrossColumn,
+    inputs_matrix: PtrAndStride<BF>,
+    outputs_matrix: MutPtrAndStride<BF>,
+    next_hypercube_inputs_matrix: PtrAndStride<BF>,
+    next_pre_tail_outputs_matrix: MutPtrAndStride<BF>,
+    log_n: i32,
+);
+pub(super) struct NaturalToBitrevFinalCrossColumnFunction(
+    pub(super) NaturalToBitrevFinalCrossColumnSignature,
+);
+impl era_cudart::execution::KernelFunction for NaturalToBitrevFinalCrossColumnFunction {
+    type Signature = NaturalToBitrevFinalCrossColumnSignature;
+    fn as_ptr(&self) -> *const std::os::raw::c_void {
+        self.0 as *const std::os::raw::c_void
+    }
+}
+macro_rules! natural_to_bitrev_final_cross_column {
+    ($kernel_name:ident) => {
+        ::era_cudart::cuda_kernel_declaration!(pub(super) $kernel_name(
+    inputs_matrix: PtrAndStride<BF>,
+    outputs_matrix: MutPtrAndStride<BF>,
+    next_hypercube_inputs_matrix: PtrAndStride<BF>,
+    next_pre_tail_outputs_matrix: MutPtrAndStride<BF>,
+    log_n: i32,
+        ));
+    };
+}
+natural_to_bitrev_final_cross_column!(
+    ab_natural_monomials_to_bitrev_evals_final_5_stages_evict_delayed_prefetch_packed_smem_cross_column_kernel
+);
+natural_to_bitrev_final_cross_column!(
+    ab_natural_monomials_to_bitrev_evals_final_6_stages_evict_delayed_prefetch_packed_smem_cross_column_pdl_kernel
+);
+natural_to_bitrev_final_cross_column!(
+    ab_natural_monomials_to_bitrev_evals_final_7_stages_evict_delayed_prefetch_packed_smem_cross_column_pdl_kernel
+);
+natural_to_bitrev_final_cross_column!(
+    ab_natural_monomials_to_bitrev_evals_final_8_stages_evict_delayed_prefetch_packed_smem_cross_column_pdl_kernel
+);
 macro_rules! natural_to_bitrev_final {
     ($kernel_name:ident) => {
         ::era_cudart::cuda_kernel_declaration!(pub(super) $kernel_name(
@@ -350,3 +644,8 @@ natural_to_bitrev_final!(ab_natural_monomials_to_bitrev_evals_final_5_stages_ker
 natural_to_bitrev_final!(ab_natural_monomials_to_bitrev_evals_final_6_stages_kernel);
 natural_to_bitrev_final!(ab_natural_monomials_to_bitrev_evals_final_7_stages_kernel);
 natural_to_bitrev_final!(ab_natural_monomials_to_bitrev_evals_final_8_stages_kernel);
+// evict-first variants for the LDE's terminal pass
+natural_to_bitrev_final!(ab_natural_monomials_to_bitrev_evals_final_5_stages_evict_kernel);
+natural_to_bitrev_final!(ab_natural_monomials_to_bitrev_evals_final_6_stages_evict_kernel);
+natural_to_bitrev_final!(ab_natural_monomials_to_bitrev_evals_final_7_stages_evict_kernel);
+natural_to_bitrev_final!(ab_natural_monomials_to_bitrev_evals_final_8_stages_evict_kernel);

--- a/gpu/ntt/src/ntt/lde.rs
+++ b/gpu/ntt/src/ntt/lde.rs
@@ -10,17 +10,22 @@ use super::dit::monomials_to_evals_dit;
 use super::forward::{
     fused_writeback_single_coset_3_pass, monomials_to_evals_2_pass_compact_initial,
     monomials_to_evals_3_pass, monomials_to_evals_compact_1_pass, monomials_to_evals_smem_packed,
-    monomials_to_evals_subwarp, natural_monomials_to_bitrev_evals_2_pass,
-    natural_monomials_to_bitrev_evals_2_pass_compact, natural_monomials_to_bitrev_evals_3_pass,
+    monomials_to_evals_subwarp, natural_fused_multi_coset_3_pass,
+    natural_monomials_to_bitrev_evals_2_pass, natural_monomials_to_bitrev_evals_2_pass_compact,
+    natural_monomials_to_bitrev_evals_2_pass_compact_from_hypercube_final4,
+    natural_monomials_to_bitrev_evals_3_pass,
 };
-use super::hypercube::hypercube_evals_to_pre_tail_monomials_3_pass;
+use super::hypercube::{
+    hypercube_evals_to_pre_tail_monomials_3_pass, hypercube_evals_to_pre_tail_monomials_lsb_3_pass,
+    hypercube_evals_to_pre_tail_monomials_lsb_3_pass_after_finest,
+};
 use super::kernels::*;
 use super::shared;
 
 use crate::ntt_twiddles::OMEGA_LOG_ORDER;
 use gpu_core::primitives::context::DeviceProperties;
 use gpu_core::primitives::device_structures::{
-    DeviceMatrixChunkImpl, DeviceMatrixChunkMutImpl, DeviceMatrixMut,
+    DeviceMatrixChunkImpl, DeviceMatrixChunkMutImpl, DeviceMatrixMut, MutPtrAndStride, PtrAndStride,
 };
 use gpu_core::primitives::field::BaseField;
 
@@ -245,6 +250,72 @@ pub fn bitreversed_monomials_to_natural_evals_multi_coset(
 
 pub const MAX_LOG_N_FOR_SINGLE_KERNEL_LDE: usize = 13;
 
+/// Commitment-only log_n=20 boundary fusion for the LSB codeword.
+#[allow(clippy::too_many_arguments)]
+pub fn hypercube_to_bitreversed_multi_coset_evals_fused_log_n_20(
+    inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    coeff_scratch: &mut DeviceSlice<BF>,
+    outputs: &mut DeviceSlice<BF>,
+    log_lde_factor: usize,
+    num_cols_per_coset_stride: usize,
+    stream: &CudaStream,
+    device_properties: &DeviceProperties,
+) -> CudaResult<()> {
+    const LOG_N: usize = 20;
+    assert!(
+        LOG_N + log_lde_factor <= OMEGA_LOG_ORDER as usize,
+        "log_n ({LOG_N}) + log_lde_factor ({log_lde_factor}) > OMEGA_LOG_ORDER ({OMEGA_LOG_ORDER})",
+    );
+    let trace_len = 1usize << LOG_N;
+    let num_cosets = 1usize << log_lde_factor;
+    let num_cols = inputs_matrix.cols();
+    assert!(num_cols_per_coset_stride >= num_cols);
+    let scratch_len = num_cols * trace_len;
+    assert!(coeff_scratch.len() >= scratch_len);
+    let max_col_offset_exclusive = (num_cosets - 1) * num_cols_per_coset_stride + num_cols;
+    assert!(outputs.len() >= max_col_offset_exclusive * trace_len);
+
+    let strategy = super::select_ntt_strategy(
+        super::NttDirection::NaturalToBitrev,
+        LOG_N,
+        num_cols,
+        num_cosets,
+        device_properties,
+    )
+    .unwrap_or_else(|e| unreachable!("natural-to-bitrev strategy unavailable: {e:?}"));
+    debug_assert!(matches!(
+        strategy.passes.last().map(|pass| pass.kernel),
+        Some(super::NttKernelKind::NaturalToBitrevLastCompact { .. })
+    ));
+
+    let mut scratch_matrix = DeviceMatrixMut::new(&mut coeff_scratch[0..scratch_len], trace_len);
+    hypercube_evals_to_pre_tail_monomials_3_pass(
+        inputs_matrix,
+        &mut scratch_matrix,
+        LOG_N,
+        stream,
+    )?;
+
+    let scratch_const = unsafe { DeviceSlice::from_raw_parts(coeff_scratch.as_ptr(), scratch_len) };
+    let monomials =
+        gpu_core::primitives::device_structures::DeviceMatrix::new(scratch_const, trace_len);
+    let mut outputs_matrix = DeviceMatrixMut::new(outputs, trace_len);
+    let coset_factor_shift = (OMEGA_LOG_ORDER as usize - LOG_N - log_lde_factor) as u32;
+    natural_monomials_to_bitrev_evals_2_pass_compact_from_hypercube_final4(
+        &monomials,
+        &mut outputs_matrix,
+        LOG_N,
+        0,
+        coset_factor_shift,
+        num_cosets,
+        num_cols_per_coset_stride,
+        strategy.cosets_per_launch,
+        strategy.columns_per_launch,
+        stream,
+    )?;
+    Ok(())
+}
+
 /// Fused-boundary LDE for the trace-holder hypercube path: the standalone
 /// hypercube final pass disappears into the first coset's fused launch, which
 /// also materializes the monomials in place for the remaining cosets. Returns
@@ -344,6 +415,105 @@ pub fn hypercube_to_multi_coset_evals_fused(
         )?;
         coset += tile;
     }
+    Ok(true)
+}
+
+/// Fused-boundary LDE for the natural->bitrev commit path: the standalone
+/// hypercube final pass disappears into the first coset's fused launch, which
+/// also materializes the natural monomials in place for the remaining cosets.
+/// Returns `Ok(false)` without scheduling anything when ineligible (outside
+/// the natural->bitrev 3-pass regime); callers fall back to the unfused
+/// sequence.
+#[allow(clippy::too_many_arguments)]
+pub fn hypercube_to_multi_coset_bitrev_evals_fused(
+    inputs_matrix: &(impl DeviceMatrixChunkImpl<BF> + ?Sized),
+    outputs: &mut DeviceSlice<BF>,
+    log_n: usize,
+    log_lde_factor: usize,
+    num_cols_per_coset_stride: usize,
+    finest_already_computed: bool,
+    next_column_hypercube: Option<*const BF>,
+    stream: &CudaStream,
+    device_properties: &DeviceProperties,
+) -> CudaResult<bool> {
+    if !super::log_size_supports_natural_to_bitrev_lde(log_n) {
+        return Ok(false);
+    }
+    let trace_len = 1usize << log_n;
+    let num_cosets = 1usize << log_lde_factor;
+    let num_cols = inputs_matrix.cols();
+    let strategy = super::select_ntt_strategy(
+        super::NttDirection::NaturalToBitrev,
+        log_n,
+        num_cols,
+        num_cosets,
+        device_properties,
+    )
+    .unwrap_or_else(|e| unreachable!("natural->bitrev strategy unavailable: {e:?}"));
+    if !matches!(
+        strategy.passes.last().unwrap().kernel,
+        super::NttKernelKind::NaturalToBitrevFinal { .. }
+    ) {
+        return Ok(false);
+    }
+    assert!(
+        log_n + log_lde_factor <= OMEGA_LOG_ORDER as usize,
+        "log_n ({log_n}) + log_lde_factor ({log_lde_factor}) > OMEGA_LOG_ORDER ({OMEGA_LOG_ORDER})",
+    );
+    assert!(num_cols_per_coset_stride >= num_cols);
+    if !matches!(num_cosets, 2 | 4 | 8) {
+        return Ok(false);
+    }
+    let max_col_offset_exclusive = (num_cosets - 1) * num_cols_per_coset_stride + num_cols;
+    assert!(outputs.len() >= max_col_offset_exclusive * trace_len);
+    let _ = &strategy;
+
+    // The pre-tail runs IN the coset-0 slab: the monomials only ever exist
+    // transiently there, completed by the fused boundary and overwritten by
+    // coset 0's own initial-stage output.
+    {
+        let coset0_chunk = &mut outputs[0..num_cols * trace_len];
+        let mut coset0_matrix = DeviceMatrixMut::new(coset0_chunk, trace_len);
+        if finest_already_computed {
+            hypercube_evals_to_pre_tail_monomials_lsb_3_pass_after_finest(
+                inputs_matrix,
+                &mut coset0_matrix,
+                log_n,
+                stream,
+            )?;
+        } else {
+            hypercube_evals_to_pre_tail_monomials_lsb_3_pass(
+                inputs_matrix,
+                &mut coset0_matrix,
+                log_n,
+                stream,
+            )?;
+        }
+    }
+
+    let coset_factor_shift = (OMEGA_LOG_ORDER as usize - log_n - log_lde_factor) as u32;
+    let cross_column_finest = next_column_hypercube.map(|next_hypercube_ptr| {
+        assert!(outputs.len() >= 2 * trace_len);
+        let next_pre_tail_ptr = unsafe { outputs.as_mut_ptr().add(trace_len) };
+        (
+            PtrAndStride::new(next_hypercube_ptr, trace_len),
+            MutPtrAndStride::new(next_pre_tail_ptr, trace_len),
+        )
+    });
+    let mut outputs_matrix = DeviceMatrixMut::new(
+        &mut outputs[0..max_col_offset_exclusive * trace_len],
+        trace_len,
+    );
+    natural_fused_multi_coset_3_pass(
+        &mut outputs_matrix,
+        log_n,
+        num_cosets,
+        coset_factor_shift,
+        num_cols_per_coset_stride,
+        num_cols,
+        cross_column_finest,
+        stream,
+    )?;
     Ok(true)
 }
 
@@ -509,10 +679,6 @@ fn dispatch_forward_multi_coset(
                 log_instances_per_block,
                 ..
             } => {
-                // Precondition guard restored after the dead-param removal: this
-                // kernel only ever runs at log_n < 21, so transposed monomials
-                // (log_n >= 21) are unreachable by construction — panic loudly if
-                // a future strategy/caller change ever routes one here.
                 assert!(
                     !transposed_monomials,
                     "subwarp forward NTT kernel does not support transposed monomials",
@@ -574,10 +740,6 @@ fn dispatch_forward_multi_coset(
             super::NttKernelKind::MonomialsToEvalsFirstCompact { .. }
         )
     {
-        // Precondition guard restored after the dead-param removal: the 2-pass
-        // compact-initial kernel only ever runs at log_n < 21, so transposed
-        // monomials (log_n >= 21) are unreachable by construction — panic loudly
-        // if a future strategy/caller change ever routes one here.
         assert!(
             !transposed_monomials,
             "2-pass compact-initial forward NTT kernel does not support transposed monomials",

--- a/gpu/ntt/src/ntt/lde.rs
+++ b/gpu/ntt/src/ntt/lde.rs
@@ -479,6 +479,7 @@ pub fn hypercube_to_multi_coset_bitrev_evals_fused(
                 inputs_matrix,
                 &mut coset0_matrix,
                 log_n,
+                device_properties,
                 stream,
             )?;
         } else {
@@ -486,6 +487,7 @@ pub fn hypercube_to_multi_coset_bitrev_evals_fused(
                 inputs_matrix,
                 &mut coset0_matrix,
                 log_n,
+                device_properties,
                 stream,
             )?;
         }
@@ -512,6 +514,7 @@ pub fn hypercube_to_multi_coset_bitrev_evals_fused(
         num_cols_per_coset_stride,
         num_cols,
         cross_column_finest,
+        device_properties,
         stream,
     )?;
     Ok(true)
@@ -936,6 +939,7 @@ pub fn natural_monomials_to_bitreversed_evals_coset_range(
                 strategy.cosets_per_launch,
                 strategy.columns_per_launch,
                 transposed_monomials,
+                device_properties,
                 stream,
             )
         }

--- a/gpu/ntt/src/ntt/mod.rs
+++ b/gpu/ntt/src/ntt/mod.rs
@@ -14,7 +14,7 @@ use gpu_core::primitives::device_structures::{
 };
 use gpu_core::primitives::field::{BF, E4};
 use gpu_core::primitives::utils::{
-    get_grid_block_dims_for_threads_count, GetChunksCount, WARP_SIZE,
+    GetChunksCount, WARP_SIZE, get_grid_block_dims_for_threads_count,
 };
 
 /// Number of passes for the multi-stage NTT kernels at a given `log_n`.
@@ -55,11 +55,13 @@ pub(crate) use forward::{monomials_to_evals_2_pass_smem, monomials_to_evals_3_pa
 #[cfg(test)]
 pub(crate) use inverse::{evals_to_monomials_2_pass, evals_to_monomials_3_pass};
 pub use lde::{
-    bitreversed_monomials_to_natural_evals_multi_coset, hypercube_to_multi_coset_evals_fused,
+    MAX_LOG_N_FOR_SINGLE_KERNEL_LDE, bitreversed_monomials_to_natural_evals_multi_coset,
+    hypercube_to_bitreversed_multi_coset_evals_fused_log_n_20,
+    hypercube_to_multi_coset_bitrev_evals_fused, hypercube_to_multi_coset_evals_fused,
     lde_with_coset_range, natural_monomials_to_bitreversed_evals_coset_range,
-    natural_monomials_to_bitreversed_evals_multi_coset, MAX_LOG_N_FOR_SINGLE_KERNEL_LDE,
+    natural_monomials_to_bitreversed_evals_multi_coset,
 };
-pub(crate) use strategy::{select_ntt_strategy, NttDirection, NttKernelKind, NttStrategy};
+pub(crate) use strategy::{NttDirection, NttKernelKind, NttStrategy, select_ntt_strategy};
 
 mod hypercube;
 pub use hypercube::hypercube_evals_to_monomials;

--- a/gpu/ntt/src/ntt/mod.rs
+++ b/gpu/ntt/src/ntt/mod.rs
@@ -14,7 +14,7 @@ use gpu_core::primitives::device_structures::{
 };
 use gpu_core::primitives::field::{BF, E4};
 use gpu_core::primitives::utils::{
-    GetChunksCount, WARP_SIZE, get_grid_block_dims_for_threads_count,
+    get_grid_block_dims_for_threads_count, GetChunksCount, WARP_SIZE,
 };
 
 /// Number of passes for the multi-stage NTT kernels at a given `log_n`.
@@ -55,13 +55,13 @@ pub(crate) use forward::{monomials_to_evals_2_pass_smem, monomials_to_evals_3_pa
 #[cfg(test)]
 pub(crate) use inverse::{evals_to_monomials_2_pass, evals_to_monomials_3_pass};
 pub use lde::{
-    MAX_LOG_N_FOR_SINGLE_KERNEL_LDE, bitreversed_monomials_to_natural_evals_multi_coset,
+    bitreversed_monomials_to_natural_evals_multi_coset,
     hypercube_to_bitreversed_multi_coset_evals_fused_log_n_20,
     hypercube_to_multi_coset_bitrev_evals_fused, hypercube_to_multi_coset_evals_fused,
     lde_with_coset_range, natural_monomials_to_bitreversed_evals_coset_range,
-    natural_monomials_to_bitreversed_evals_multi_coset,
+    natural_monomials_to_bitreversed_evals_multi_coset, MAX_LOG_N_FOR_SINGLE_KERNEL_LDE,
 };
-pub(crate) use strategy::{NttDirection, NttKernelKind, NttStrategy, select_ntt_strategy};
+pub(crate) use strategy::{select_ntt_strategy, NttDirection, NttKernelKind, NttStrategy};
 
 mod hypercube;
 pub use hypercube::hypercube_evals_to_monomials;

--- a/gpu/ntt/src/ntt/shared.rs
+++ b/gpu/ntt/src/ntt/shared.rs
@@ -16,6 +16,12 @@ use std::mem::size_of;
 
 type BF = BaseField;
 
+/// TMA and programmatic dependent launch were introduced with Hopper.
+/// Ampere kernels must use the ordinary scalar-egress and same-stream paths.
+pub(super) const fn supports_tma_pdl(compute_capability_major: usize) -> bool {
+    compute_capability_major >= 9
+}
+
 /// Assert both NTT operands satisfy the 16-byte alignment the multi-stage
 /// kernels require: base pointer, row stride (`stride * sizeof(BF)`) and offset
 /// (`offset * sizeof(BF)`) of inputs and outputs must all be 16-byte aligned,
@@ -107,4 +113,16 @@ pub(super) fn checked_u32(v: usize, what: &str) -> u32 {
         "{what} ({v}) exceeds u32::MAX for its kernel-argument cast",
     );
     v as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::supports_tma_pdl;
+
+    #[test]
+    fn tma_pdl_requires_compute_capability_9() {
+        assert!(!supports_tma_pdl(8));
+        assert!(supports_tma_pdl(9));
+        assert!(supports_tma_pdl(12));
+    }
 }

--- a/gpu/ntt/src/ntt/tests/lde_writeback_hybrid.rs
+++ b/gpu/ntt/src/ntt/tests/lde_writeback_hybrid.rs
@@ -3,7 +3,7 @@
 //! scratch (the fused kernel's in-place side output) versus the unfused
 //! hypercube-final + multi-coset-initial sequence.
 
-use era_cudart::memory::{DeviceAllocation, memory_copy_async};
+use era_cudart::memory::{memory_copy_async, DeviceAllocation};
 
 use super::super::{
     bitreversed_monomials_to_natural_evals_multi_coset, hypercube_evals_to_monomials,

--- a/gpu/ntt/src/ntt/tests/lde_writeback_hybrid.rs
+++ b/gpu/ntt/src/ntt/tests/lde_writeback_hybrid.rs
@@ -3,11 +3,12 @@
 //! scratch (the fused kernel's in-place side output) versus the unfused
 //! hypercube-final + multi-coset-initial sequence.
 
-use era_cudart::memory::{memory_copy_async, DeviceAllocation};
+use era_cudart::memory::{DeviceAllocation, memory_copy_async};
 
 use super::super::{
     bitreversed_monomials_to_natural_evals_multi_coset, hypercube_evals_to_monomials,
-    hypercube_to_multi_coset_evals_fused,
+    hypercube_to_bitreversed_multi_coset_evals_fused_log_n_20,
+    hypercube_to_multi_coset_evals_fused, natural_monomials_to_bitreversed_evals_multi_coset,
 };
 use super::make_context;
 use gpu_core::primitives::device_structures::DeviceMatrixChunk;
@@ -96,5 +97,73 @@ fn check_case(log_n: usize, log_lde_factor: usize) {
 fn test_lde_writeback_hybrid_matches_unfused() {
     for (log_n, log_lde_factor) in [(21, 1), (22, 1), (23, 1), (24, 1), (22, 2), (24, 0)] {
         check_case(log_n, log_lde_factor);
+    }
+}
+
+#[test]
+fn test_log_n_20_hypercube_final4_natural_initial8_fusion_matches_unfused() {
+    let ctx = make_context();
+    let stream = ctx.get_exec_stream();
+    let log_n = 20usize;
+    let log_lde_factor = 1usize;
+    let n = 1usize << log_n;
+    let num_cosets = 1usize << log_lde_factor;
+    let input = (0..n)
+        .map(|idx| BF::new(71 + (idx as u32).wrapping_mul(2246822519)))
+        .collect::<Vec<_>>();
+    let mut d_in = DeviceAllocation::<BF>::alloc(n).unwrap();
+    let mut d_scratch_old = DeviceAllocation::<BF>::alloc(n).unwrap();
+    let mut d_scratch_new = DeviceAllocation::<BF>::alloc(n).unwrap();
+    let mut d_out_old = DeviceAllocation::<BF>::alloc(num_cosets * n).unwrap();
+    let mut d_out_new = DeviceAllocation::<BF>::alloc(num_cosets * n).unwrap();
+    memory_copy_async(&mut d_in, &input[..], stream).unwrap();
+
+    hypercube_evals_to_monomials(
+        &d_in[..],
+        &mut d_scratch_old[..],
+        log_n,
+        false,
+        stream,
+        ctx.get_device_properties(),
+    )
+    .unwrap();
+    let monomials = DeviceMatrixChunk::new(&d_scratch_old[..], n, 0, n);
+    natural_monomials_to_bitreversed_evals_multi_coset(
+        &monomials,
+        &mut d_out_old[..],
+        log_n,
+        log_lde_factor,
+        1,
+        false,
+        ctx.device_context(),
+        None,
+        stream,
+        ctx.get_device_properties(),
+    )
+    .unwrap();
+
+    hypercube_to_bitreversed_multi_coset_evals_fused_log_n_20(
+        &d_in[..],
+        &mut d_scratch_new[..],
+        &mut d_out_new[..],
+        log_lde_factor,
+        1,
+        stream,
+        ctx.get_device_properties(),
+    )
+    .unwrap();
+
+    let mut h_out_old = vec![BF::new(0); num_cosets * n];
+    let mut h_out_new = vec![BF::new(0); num_cosets * n];
+    memory_copy_async(&mut h_out_old[..], &d_out_old, stream).unwrap();
+    memory_copy_async(&mut h_out_new[..], &d_out_new, stream).unwrap();
+    stream.synchronize().unwrap();
+    if let Some((row, (old, new))) = h_out_old
+        .iter()
+        .zip(h_out_new.iter())
+        .enumerate()
+        .find(|(_, (old, new))| old != new)
+    {
+        panic!("first fused-boundary mismatch at row {row}: old={old:?}, new={new:?}");
     }
 }

--- a/gpu/ntt/src/ntt/tests/mod.rs
+++ b/gpu/ntt/src/ntt/tests/mod.rs
@@ -1,12 +1,12 @@
 use std::alloc::Global;
 
-use era_cudart::memory::{memory_copy_async, DeviceAllocation};
+use era_cudart::memory::{DeviceAllocation, memory_copy_async};
 use era_cudart::result::CudaResult;
 use era_cudart::stream::CudaStream;
 use worker::Worker;
 
 use super::{
-    hypercube_coeffs_to_evals, hypercube_evals_to_monomial_coeffs,
+    hypercube_coeffs_to_evals, hypercube_evals_to_monomial_coeffs, hypercube_evals_to_monomials,
     natural_evals_to_bitreversed_coeffs,
 };
 use crate::ntt_twiddles::DeviceContext;
@@ -117,6 +117,48 @@ fn hypercube_evals_to_monomial_coeffs_matches_cpu() {
         memory_copy_async(&mut actual, &dst, stream).unwrap();
         stream.synchronize().unwrap();
         assert_eq!(actual, expected, "log_n={}", log_n);
+    }
+}
+
+#[test]
+#[cfg(not(no_cuda))]
+fn hypercube_evals_to_monomials_two_pass_compact_range_matches_cpu() {
+    let context = make_context();
+    let stream = context.get_exec_stream();
+    for log_n in 13usize..=20 {
+        let n = 1usize << log_n;
+        let evals = (0..n)
+            .map(|idx| BF::new((17 + idx * 13) as u32))
+            .collect::<Vec<_>>();
+        let mut expected = evals.clone();
+        multivariate_hypercube_evals_into_coeffs(&mut expected, log_n as u32);
+
+        let mut src = context.alloc(n).unwrap();
+        let mut dst = context.alloc(n).unwrap();
+        memory_copy_async(&mut src, &evals, stream).unwrap();
+        hypercube_evals_to_monomials(
+            &src[..],
+            &mut dst[..],
+            log_n,
+            false,
+            stream,
+            context.get_device_properties(),
+        )
+        .unwrap();
+
+        let mut actual = vec![BF::ZERO; n];
+        memory_copy_async(&mut actual, &dst, stream).unwrap();
+        stream.synchronize().unwrap();
+        if let Some((row, (actual, expected))) = actual
+            .iter()
+            .zip(expected.iter())
+            .enumerate()
+            .find(|(_, (actual, expected))| actual != expected)
+        {
+            panic!(
+                "log_n={log_n} first mismatch at row {row}: actual={actual:?}, expected={expected:?}"
+            );
+        }
     }
 }
 
@@ -1016,7 +1058,8 @@ mod host_oracle {
                 let base = coset_offset * cols_size + col * stride;
                 for k in 0..n {
                     assert_eq!(
-                        outputs_host[base + k], expected[k],
+                        outputs_host[base + k],
+                        expected[k],
                         "log_n={log_n}, log_lde_factor={log_lde_factor}, num_cosets={num_cosets}, coset_index_base={coset_index_base}, coset_offset={coset_offset}, col={col}, k={k}, seed={seed:#x}"
                     );
                 }
@@ -1591,8 +1634,8 @@ fn run_subwarp_vs_host_parity(
     num_cosets: usize,
     num_cols: usize,
 ) {
-    use super::forward::monomials_to_evals_subwarp;
     use super::OMEGA_LOG_ORDER;
+    use super::forward::monomials_to_evals_subwarp;
     use fft::precompute_twiddles_for_fft;
     use gpu_core::primitives::device_structures::{DeviceMatrixChunk, DeviceMatrixChunkMut};
     use std::alloc::Global;
@@ -1661,7 +1704,8 @@ fn run_subwarp_vs_host_parity(
             let base = coset_index * cols_size + col * stride;
             for k in 0..n {
                 assert_eq!(
-                    candidate_host[base + k], expected[k],
+                    candidate_host[base + k],
+                    expected[k],
                     "log_n={log_n}, log_ipb={log_instances_per_block}, num_cosets={num_cosets}, num_cols={num_cols}, coset={coset_index}, col={col}, k={k}"
                 );
             }
@@ -1768,14 +1812,15 @@ mod natural_to_bitrev {
         natural_monomials_to_bitrev_evals_3_pass,
     };
     use super::super::{
+        bitreversed_monomials_to_natural_evals_multi_coset,
         natural_monomials_to_bitreversed_evals_coset_range,
         natural_monomials_to_bitreversed_evals_multi_coset,
     };
     use super::helpers::transpose_monomials;
-    use super::{make_context, NttTestContext};
+    use super::{NttTestContext, make_context};
     use crate::ntt_twiddles::OMEGA_LOG_ORDER;
     use crate::upstream::{
-        bitreverse_enumeration_inplace, distribute_powers_serial, domain_generator_for_size, Field,
+        Field, bitreverse_enumeration_inplace, distribute_powers_serial, domain_generator_for_size,
     };
     use era_cudart::memory::memory_copy_async;
     use era_cudart::stream::CudaStream;
@@ -2129,6 +2174,90 @@ mod natural_to_bitrev {
             (shape(21, 2, 2, 2, 1, 1, true), 0xc2),
         ] {
             oracle_c_cpu_naive(shape, seed);
+        }
+    }
+
+    /// The fused natural boundary (hypercube coarse tail + monomial writeback
+    /// + coset scale + DIT initial in one launch, over the fine->coarse
+    /// pre-tail) must reproduce the unfused sequence bit-exactly: the
+    /// multi-coset LDE output AND the materialized natural monomials.
+    #[test]
+    fn natural_fused_boundary_matches_unfused() {
+        use super::super::{
+            hypercube_evals_to_monomials, hypercube_to_multi_coset_bitrev_evals_fused,
+        };
+        for (sh, seed) in [
+            (shape(21, 1, 2, 0, 1, 1, false), 0xf1),
+            (shape(21, 2, 4, 0, 2, 3, false), 0xf2),
+        ] {
+            let context = make_context();
+            let stream = context.get_exec_stream();
+            let n = sh.n();
+            let logical = random_columns(&sh, seed);
+            let inputs_host = layout_columns(&logical, false);
+            let mut inputs_device = context.alloc(inputs_host.len()).unwrap();
+            memory_copy_async(&mut inputs_device, &inputs_host, stream).unwrap();
+
+            // Unfused reference: full hypercube iNTT, then the natural LDE.
+            let mut ref_monomials_device = context.alloc(sh.num_cols * n).unwrap();
+            let mut ref_outputs_device = context.alloc(sh.output_len()).unwrap();
+            {
+                let inputs_matrix = DeviceMatrixChunk::new(&inputs_device[..], n, 0, n);
+                let mut monomials_matrix =
+                    DeviceMatrixChunkMut::new(&mut ref_monomials_device[..], n, 0, n);
+                hypercube_evals_to_monomials(
+                    &inputs_matrix,
+                    &mut monomials_matrix,
+                    sh.log_n,
+                    false,
+                    stream,
+                    context.get_device_properties(),
+                )
+                .unwrap();
+                let monomials_matrix = DeviceMatrixChunk::new(&ref_monomials_device[..], n, 0, n);
+                natural_monomials_to_bitreversed_evals_multi_coset(
+                    &monomials_matrix,
+                    &mut ref_outputs_device[..],
+                    sh.log_n,
+                    sh.log_lde_factor,
+                    sh.stride_cols,
+                    false,
+                    context.device_context(),
+                    None,
+                    stream,
+                    context.get_device_properties(),
+                )
+                .unwrap();
+            }
+
+            // Fused arm (monomials are transient in the coset-0 slab; no scratch).
+            let mut fused_outputs_device = context.alloc(sh.output_len()).unwrap();
+            let fused = {
+                let inputs_matrix = DeviceMatrixChunk::new(&inputs_device[..], n, 0, n);
+                hypercube_to_multi_coset_bitrev_evals_fused(
+                    &inputs_matrix,
+                    &mut fused_outputs_device[..],
+                    sh.log_n,
+                    sh.log_lde_factor,
+                    sh.stride_cols,
+                    false,
+                    None,
+                    stream,
+                    context.get_device_properties(),
+                )
+                .unwrap()
+            };
+            assert!(
+                fused,
+                "shape {sh:?} must be eligible for the fused boundary"
+            );
+
+            let mut ref_outputs = vec![BF::ZERO; sh.output_len()];
+            let mut fused_outputs = vec![BF::ZERO; sh.output_len()];
+            memory_copy_async(&mut ref_outputs, &ref_outputs_device, stream).unwrap();
+            memory_copy_async(&mut fused_outputs, &fused_outputs_device, stream).unwrap();
+            stream.synchronize().unwrap();
+            compare_slices(&fused_outputs, &ref_outputs, "multi-coset LDE output");
         }
     }
 

--- a/gpu/ntt/src/ntt/tests/mod.rs
+++ b/gpu/ntt/src/ntt/tests/mod.rs
@@ -2265,7 +2265,12 @@ mod natural_to_bitrev {
         shape: Shape,
         seed: u64,
         what: &str,
-        launch: impl FnOnce(&DeviceMatrixChunk<BF>, &mut DeviceMatrixChunkMut<BF>, &CudaStream),
+        launch: impl FnOnce(
+            &DeviceMatrixChunk<BF>,
+            &mut DeviceMatrixChunkMut<BF>,
+            &DeviceProperties,
+            &CudaStream,
+        ),
     ) {
         let context = make_context();
         let stream = context.get_exec_stream();
@@ -2278,7 +2283,12 @@ mod natural_to_bitrev {
         {
             let inputs_matrix = DeviceMatrixChunk::new(&inputs_device[..], n, 0, n);
             let mut outputs_matrix = DeviceMatrixChunkMut::new(&mut outputs_device[..], n, 0, n);
-            launch(&inputs_matrix, &mut outputs_matrix, stream);
+            launch(
+                &inputs_matrix,
+                &mut outputs_matrix,
+                context.get_device_properties(),
+                stream,
+            );
         }
         let mut outputs = vec![BF::ZERO; shape.output_len()];
         memory_copy_async(&mut outputs, &outputs_device, stream).unwrap();
@@ -2298,7 +2308,7 @@ mod natural_to_bitrev {
             shape,
             0xc3,
             "forced launch tiling",
-            |inputs_matrix, outputs_matrix, stream| {
+            |inputs_matrix, outputs_matrix, device_properties, stream| {
                 natural_monomials_to_bitrev_evals_3_pass(
                     inputs_matrix,
                     outputs_matrix,
@@ -2310,6 +2320,7 @@ mod natural_to_bitrev {
                     1, // cosets_per_launch
                     1, // columns_per_launch
                     shape.transposed,
+                    device_properties,
                     stream,
                 )
                 .unwrap();
@@ -2584,7 +2595,7 @@ mod natural_to_bitrev {
             shape,
             0xd8,
             "two-pass-compact forced launch tiling",
-            |inputs_matrix, outputs_matrix, stream| {
+            |inputs_matrix, outputs_matrix, _device_properties, stream| {
                 natural_monomials_to_bitrev_evals_2_pass_compact(
                     inputs_matrix,
                     outputs_matrix,

--- a/gpu/ntt/src/ntt/tests/mod.rs
+++ b/gpu/ntt/src/ntt/tests/mod.rs
@@ -1,6 +1,6 @@
 use std::alloc::Global;
 
-use era_cudart::memory::{DeviceAllocation, memory_copy_async};
+use era_cudart::memory::{memory_copy_async, DeviceAllocation};
 use era_cudart::result::CudaResult;
 use era_cudart::stream::CudaStream;
 use worker::Worker;
@@ -1634,8 +1634,8 @@ fn run_subwarp_vs_host_parity(
     num_cosets: usize,
     num_cols: usize,
 ) {
-    use super::OMEGA_LOG_ORDER;
     use super::forward::monomials_to_evals_subwarp;
+    use super::OMEGA_LOG_ORDER;
     use fft::precompute_twiddles_for_fft;
     use gpu_core::primitives::device_structures::{DeviceMatrixChunk, DeviceMatrixChunkMut};
     use std::alloc::Global;
@@ -1817,10 +1817,10 @@ mod natural_to_bitrev {
         natural_monomials_to_bitreversed_evals_multi_coset,
     };
     use super::helpers::transpose_monomials;
-    use super::{NttTestContext, make_context};
+    use super::{make_context, NttTestContext};
     use crate::ntt_twiddles::OMEGA_LOG_ORDER;
     use crate::upstream::{
-        Field, bitreverse_enumeration_inplace, distribute_powers_serial, domain_generator_for_size,
+        bitreverse_enumeration_inplace, distribute_powers_serial, domain_generator_for_size, Field,
     };
     use era_cudart::memory::memory_copy_async;
     use era_cudart::stream::CudaStream;

--- a/gpu/trace/src/trace/holder/mod.rs
+++ b/gpu/trace/src/trace/holder/mod.rs
@@ -27,8 +27,10 @@ use gpu_hash::blake2s::{
 };
 use gpu_ntt::ntt::{
     bitreversed_monomials_to_natural_evals_multi_coset, hypercube_evals_to_monomials,
-    log_size_supports_natural_to_bitrev_lde, log_size_supports_transposed_monomials,
-    natural_monomials_to_bitreversed_evals_multi_coset, MIN_LOG_N_FOR_NATURAL_TO_BITREV_LDE,
+    hypercube_to_bitreversed_multi_coset_evals_fused_log_n_20,
+    hypercube_to_multi_coset_bitrev_evals_fused, log_size_supports_natural_to_bitrev_lde,
+    log_size_supports_transposed_monomials, natural_monomials_to_bitreversed_evals_multi_coset,
+    MIN_LOG_N_FOR_NATURAL_TO_BITREV_LDE,
 };
 use gpu_ops::bit_reverse::bit_reverse_in_place;
 use gpu_prover_context::ProverContext;
@@ -392,6 +394,7 @@ impl TraceHolder<BF> {
         };
         let use_transposed_monomials =
             !natural_to_bitrev && log_size_supports_transposed_monomials(log_n);
+        let mut current_finest_already_computed = false;
         for column in 0..self.columns_count {
             let offset = column * domain_size;
             let source_column = &source[offset..offset + domain_size];
@@ -405,6 +408,47 @@ impl TraceHolder<BF> {
                     // columns_count to write each coset's slab in one launch,
                     // replacing the per-coset NTT loop.
                     let backing_from_col = &mut backing[offset..];
+                    if natural_to_bitrev && log_n == 20 {
+                        hypercube_to_bitreversed_multi_coset_evals_fused_log_n_20(
+                            source_column,
+                            &mut coeff_scratch[0..domain_size],
+                            backing_from_col,
+                            self.log_lde_factor as usize,
+                            self.columns_count,
+                            stream,
+                            context.get_device_properties(),
+                        )?;
+                        current_finest_already_computed = false;
+                        continue;
+                    }
+                    // Natural arm: fused boundary first — the hypercube coarse
+                    // tail, monomial writeback, coset scale, and the first
+                    // coset's DIT initial stages run as one launch.
+                    let fused = if natural_to_bitrev {
+                        // The last tail launch also performs the NEXT
+                        // column's hypercube finest pass. The next iteration
+                        // therefore starts at the in-place middle pass.
+                        let next_column_hypercube = (column + 1 < self.columns_count)
+                            .then(|| source[offset + domain_size..].as_ptr());
+                        hypercube_to_multi_coset_bitrev_evals_fused(
+                            source_column,
+                            backing_from_col,
+                            log_n,
+                            self.log_lde_factor as usize,
+                            self.columns_count,
+                            current_finest_already_computed,
+                            next_column_hypercube,
+                            stream,
+                            context.get_device_properties(),
+                        )?
+                    } else {
+                        false
+                    };
+                    if fused {
+                        current_finest_already_computed = column + 1 < self.columns_count;
+                        continue;
+                    }
+                    current_finest_already_computed = false;
                     hypercube_evals_to_monomials(
                         source_column,
                         &mut coeff_scratch[0..domain_size],


### PR DESCRIPTION
## What ❔

Optimize the LSB commitment LDE without changing proof bytes.

- Keep monomials transiently in the coset-0 output slab, eliminating the separate monomial scratch allocation.
- Fuse the boundary and cross-column handoffs, preserve cache residency between passes, and prefetch the next coset tail.
- Replace the `log_n=20` single-stage hypercube fallback with a compact multistage path; retain specialized three-pass kernels for `log_n=21..=24`.
- Use TMA and programmatic dependent launch on compute capability 9.0+, with scalar egress and ordinary same-stream launches on 8.x. Architecture-specific instructions introduced by these fast paths are emitted only for supported targets.
- Remove experimental kernels, runtime toggles, and timing-only launchers.

On an RTX PRO 6000 Blackwell, A-B-B-A measurements against the previous MSB-ordered commitment NTT measured 67.3 µs/column lower commitment NTT time.

## Why ❔

The commitment LDE was paying for register spills, cold pass handoffs, redundant global-memory traffic, intermediate storage, and excess kernel launches. This change reduces those costs while preserving bit-exact output and supporting CUDA compute capability 8.0 and newer.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
