### PR TITLE
fix(gpu): only clear the ROM tail when reusing a memory holder

### DIFF
--- a/gpu/execution_prover/src/workers/simulation_runner.rs
+++ b/gpu/execution_prover/src/workers/simulation_runner.rs
@@ -281,9 +281,15 @@ impl<ND: NonDeterminismCSRSource + Send + 'static, T: TracingType + 'static>
             }
         };
         let binary_image_len = binary_image.len();
-        // NOTE: during continuous reuse timestamps are zeroed during inits and teardowns collection
+        assert!(binary_image_len <= ROM_WORD_SIZE);
+        // NOTE: on reuse the holder is already clean outside the ROM region: every RAM word
+        // the JIT writes is timestamped, and `collect_inits_and_teardowns` zeroes both the
+        // value and the timestamp of every timestamped word (the abort path resets the whole
+        // buffer). The binary image is the exception: it is copied in without timestamps, so
+        // ROM words the program never loads survive collection. Only the ROM tail beyond the
+        // current image needs an explicit clear, in case the previous image was longer.
         memory_holder.memory_mut()[..binary_image_len].copy_from_slice(&binary_image);
-        memory_holder.memory_mut()[binary_image_len..].fill(0);
+        memory_holder.memory_mut()[binary_image_len..ROM_WORD_SIZE].fill(0);
         let mut trace = self
             .free_trace_chunks_receiver
             .recv()


### PR DESCRIPTION
## What ❔

Follow-up to #428: when reusing a cached `MemoryHolder`, clear only `[binary_image_len..ROM_WORD_SIZE]` instead of the whole RAM.

## Why ❔

The whole-RAM memset runs before every batch (1 GiB at `Medium`, 4 GiB at `Full`) and is redundant. Every RAM word the JIT writes is timestamped, and `collect_inits_and_teardowns` zeroes both value and timestamp of every timestamped word (the abort path resets the whole buffer). The only untimestamped writes are the binary image copy, so only the ROM tail beyond the current image can hold stale data.

## Is this a breaking change?
- [ ] Yes
- [x] No