### PR TITLE
ci(gpu): build for Blackwell and use high-VRAM runners

### DIFF
--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -58,12 +58,12 @@ jobs:
         shell: bash
         run: |
           mkdir artifacts
-          # Build for A100 (sm_80), L4 (sm_89), and H100 (sm_90).
-          CUDAARCHS="80;89;90" \
+          # Build for A100 (sm_80), L4 (sm_89), H100 (sm_90), and RTX PRO 6000 Blackwell (sm_120).
+          CUDAARCHS="80;89;90;120" \
           cargo +$RUST_TOOLCHAIN build -p cli --features gpu --release --target x86_64-unknown-linux-gnu
           cp target/x86_64-unknown-linux-gnu/release/cli artifacts/cli
 
-          CUDAARCHS="80;89;90" \
+          CUDAARCHS="80;89;90;120" \
           cargo +$RUST_TOOLCHAIN test -p gpu_circuit_prover --release --target x86_64-unknown-linux-gnu --no-run
           test_binary="$(find target/x86_64-unknown-linux-gnu/release -type f -executable -name 'gpu_circuit_prover-*' -print -quit)"
           test -n "$test_binary"
@@ -77,7 +77,7 @@ jobs:
           if-no-files-found: error
 
   zksync-airbender-test:
-    runs-on: [ matterlabs-ci-gpu-runner ]
+    runs-on: [ matterlabs-ci-gpu-runner-highvram ]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What ❔

Add CUDA architecture `120` to the CLI and GPU test builds. Run GPU tests on `matterlabs-ci-gpu-runner-highvram`.

## Why ❔

Support RTX PRO 6000 Blackwell runners and ensure at least 40 GB VRAM for GPU tests.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
